### PR TITLE
HTTP Authorization header instead of custom header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ with their credentials and that - given the credentials are valid - responds
 with a secret token that the client then uses to identify the user in
 subsequent requests.
 
-The secret token is usually sent in a custom header. Ember.SimpleAuth
-uses ```X-AUTHENTICATION-TOKEN``` and automatically injects this header into
-all AJAX requests.
+The secret token is usually sent as a header. Ember.SimpleAuth uses the
+`Authorization` header and automatically injects this header into all AJAX
+requests.
 
 ## Usage
 

--- a/packages/ember-simple-auth/lib/core.js
+++ b/packages/ember-simple-auth/lib/core.js
@@ -15,7 +15,7 @@ Ember.SimpleAuth.setup = function(app, options) {
 
   Ember.$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
     if (!jqXHR.crossDomain && !Ember.isEmpty(session.get('authToken'))) {
-      jqXHR.setRequestHeader('X-AUTHENTICATION-TOKEN',  session.get('authToken'));
+      jqXHR.setRequestHeader('Authorization', 'Token token="' + session.get('authToken') + '"');
     }
   });
 };

--- a/packages/ember-simple-auth/tests/core_test.js
+++ b/packages/ember-simple-auth/tests/core_test.js
@@ -89,10 +89,10 @@ test('registers an AJAX prefilter that adds the authToken for non-crossdomain re
   Ember.SimpleAuth.setup(ContainerMock.create());
 
   registeredAjaxPrefilter({}, {}, xhrMock);
-  equal(xhrMock.requestHeaders['X-AUTHENTICATION-TOKEN'], token, 'Ember.SimpleAuth registers an AJAX prefilter that adds the authToken for non-crossdomain requests.');
+  equal(xhrMock.requestHeaders['Authorization'], 'Token token="' + token + '"', 'Ember.SimpleAuth registers an AJAX prefilter that adds the authToken for non-crossdomain requests.');
 
   xhrMock = XhrMock.create();
   xhrMock.crossDomain = true;
   registeredAjaxPrefilter({}, {}, xhrMock);
-  equal(xhrMock.requestHeaders['X-AUTHENTICATION-TOKEN'], undefined, 'Ember.SimpleAuth registers an AJAX prefilter that does not add the authToken for crossdomain requests.');
+  equal(xhrMock.requestHeaders['Authorization'], undefined, 'Ember.SimpleAuth registers an AJAX prefilter that does not add the authToken for crossdomain requests.');
 });


### PR DESCRIPTION
Is there any reason you're using a `X-AUTHENTICATION-TOKEN` custom header instead of the standard HTTP `Authorization` header usually used for token (and basic, etc.) auth?

This also works well with Rails' [`ActionController::HttpAuthentication::Token`](http://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) server-side which uses the Authorization header.
