### PR TITLE
Allow to use an alternative token request host

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Ember.SimpleAuth.setup(container, application, {
   routeAfterLogout: ...    // route to redirect the user to after logging out - defaults to 'index'
   loginRoute: ...          // route to redirect the user to when login is required - defaults to 'login'
   serverTokenEndpoint: ... // the server endpoint used to obtain the access token - defaults to '/token'
+  serverHost: ...          // absolute server host if the api is on another domain - defaults to '' (relative request)
   autoRefreshToken: ...    // enable/disable automatic token refreshing (if the server supports it) - defaults to true
 });
 ```

--- a/packages/ember-simple-auth/lib/core.js
+++ b/packages/ember-simple-auth/lib/core.js
@@ -5,6 +5,8 @@ Ember.SimpleAuth.setup = function(container, application, options) {
   this.routeAfterLogout    = options.routeAfterLogout || 'index';
   this.loginRoute          = options.loginRoute || 'login';
   this.serverTokenEndpoint = options.serverTokenEndpoint || '/token';
+  this.serverHost          = options.serverHost || '';
+  this.serverTokenURL      = this.serverHost + this.serverTokenEndpoint;
   this.autoRefreshToken    = Ember.isEmpty(options.autoRefreshToken) ? true : !!options.autoRefreshToken;
 
   var session = Ember.SimpleAuth.Session.create();

--- a/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
@@ -9,7 +9,7 @@ Ember.SimpleAuth.LoginControllerMixin = Ember.Mixin.create({
       var data = this.getProperties('identification', 'password');
       if (!Ember.isEmpty(data.identification) && !Ember.isEmpty(data.password)) {
         var requestOptions = this.tokenRequestOptions(data.identification, data.password);
-        Ember.$.ajax(Ember.SimpleAuth.serverTokenEndpoint, requestOptions).then(function(response) {
+        Ember.$.ajax(Ember.SimpleAuth.serverURL, requestOptions).then(function(response) {
           self.get('session').setup(response);
           self.send('loginSucceeded');
         }, function(xhr, status, error) {

--- a/packages/ember-simple-auth/lib/session.js
+++ b/packages/ember-simple-auth/lib/session.js
@@ -61,7 +61,7 @@ Ember.SimpleAuth.Session = Ember.Object.extend({
       if (!Ember.isEmpty(this.get('refreshToken')) && waitTime > 0) {
         this.set('refreshAuthTokenTimeout', Ember.run.later(this, function() {
           var self = this;
-          Ember.$.ajax(Ember.SimpleAuth.serverTokenEndpoint, {
+          Ember.$.ajax(Ember.SimpleAuth.serverURL, {
             type:        'POST',
             data:        'grant_type=refresh_token&refresh_token=' + this.get('refreshToken'),
             contentType: 'application/x-www-form-urlencoded'


### PR DESCRIPTION
Hi !

Here is a simple patch to allow the use of an alternative host if the API and the Ember app are on two different hosts, for example 'https://api.myapp.com/token'.

The idea is just to setup `serverHost` with 'https://api.myapp.com'.

The request is sent to `serverHost` + `serverTokenEndpoint`.

If `serverHost` is not set, it's an empty string by default and the request keep being relative to the current host.
