### PR TITLE
loggingIn session flag

### DIFF
--- a/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
@@ -62,9 +62,11 @@ Ember.SimpleAuth.LoginControllerMixin = Ember.Mixin.create({
         self.set('loggingIn', true);
         var requestOptions = this.tokenRequestOptions(data.identification, data.password);
         Ember.$.ajax(Ember.SimpleAuth.serverTokenEndpoint, requestOptions).then(function(response) {
+          self.set('loggingIn', false);
           self.get('session').setup(response);
           self.send('loginSucceeded');
         }, function(xhr, status, error) {
+          self.set('loggingIn', false);
           self.send('loginFailed', xhr, status, error);
         });
       }

--- a/packages/ember-simple-auth/lib/session.js
+++ b/packages/ember-simple-auth/lib/session.js
@@ -43,7 +43,6 @@ Ember.SimpleAuth.Session = Ember.Object.extend({
   setup: function(data) {
     data = data || {};
     this.setProperties({
-      loggingIn:       false,
       authToken:       data.access_token,
       refreshToken:    (data.refresh_token || this.get('refreshToken')),
       authTokenExpiry: (data.expires_in > 0 ? data.expires_in * 1000 : this.get('authTokenExpiry')) || 0


### PR DESCRIPTION
Here is a simple change that adds a `loggingIn` flag to the session object.

This allows to display a message when the authentication requests takes some time (I'm using a remote LDAP that is sometimes slow).

This way, the template can display a message when `session.loggingIn` is true.
