### PR TITLE
Custom authToken key name support

### DIFF
--- a/packages/ember-simple-auth/lib/core.js
+++ b/packages/ember-simple-auth/lib/core.js
@@ -38,6 +38,7 @@ Ember.SimpleAuth.setup = function(container, application, options) {
   this.loginRoute          = options.loginRoute || 'login';
   this.serverTokenEndpoint = options.serverTokenEndpoint || '/token';
   this.autoRefreshToken    = Ember.isEmpty(options.autoRefreshToken) ? true : !!options.autoRefreshToken;
+  this.authTokenKey        = options.authTokenKey || 'access_token';
 
   var session = Ember.SimpleAuth.Session.create();
   application.register('simple_auth:session', session, { instantiate: false, singleton: true });

--- a/packages/ember-simple-auth/lib/session.js
+++ b/packages/ember-simple-auth/lib/session.js
@@ -40,7 +40,7 @@ Ember.SimpleAuth.Session = Ember.Object.extend({
   setup: function(data) {
     data = data || {};
     this.setProperties({
-      authToken:       data.access_token,
+      authToken:       data[Ember.SimpleAuth.authTokenKey],
       refreshToken:    (data.refresh_token || this.get('refreshToken')),
       authTokenExpiry: (data.expires_in > 0 ? data.expires_in * 1000 : this.get('authTokenExpiry')) || 0
     });

--- a/packages/ember-simple-auth/tests/core_test.js
+++ b/packages/ember-simple-auth/tests/core_test.js
@@ -108,6 +108,11 @@ test('saves the login route when specified for setup', function() {
   equal(Ember.SimpleAuth.loginRoute, 'somewhere', 'Ember.SimpleAuth saves loginRoute when specified for setup.');
 });
 
+test('saves the authToken response key name when specified for setup', function() {
+  Ember.SimpleAuth.setup(containerMock, applicationMock, { authTokenKey: 'auth_token' });
+  equal(Ember.SimpleAuth.authTokenKey, 'auth_token', 'Ember.SimpleAuth saves authTokenKey when specified for setup.');
+});
+
 test('injects a session object in models, views, controllers and routes during setup', function() {
   Ember.SimpleAuth.setup(containerMock, applicationMock);
 

--- a/packages/ember-simple-auth/tests/session_test.js
+++ b/packages/ember-simple-auth/tests/session_test.js
@@ -110,6 +110,15 @@ test('assigns its properties correctly during setup', function() {
   equal(session.get('authToken'), undefined, 'Ember.SimpleAuth.Session assigns authToken as undefined during setup when the supplied session is null.');
   equal(session.get('refreshToken'), undefined, 'Ember.SimpleAuth.Session assigns refreshToken as undefined during setup when the supplied session is null.');
   equal(session.get('authTokenExpiry'), 0, 'Ember.SimpleAuth.Session assigns authTokenExpiry as 0 during setup when the supplied session is null.');
+
+  session.destroy();
+  Ember.SimpleAuth.authTokenKey = 'auth_token';
+  session = Ember.SimpleAuth.Session.create();
+  session.setup({ auth_token: authToken });
+
+  equal(session.get('authToken'), authToken, 'Ember.SimpleAuth.Session assigns the value of a custom token key to authToken.');
+
+  session.destroy();
 });
 
 test('clears its properties during destruction', function() {


### PR DESCRIPTION
This pull request makes it possible to set a custom a key name for
authTokens inside authenication responses.

The current hardcoded value (`access_token`) is great for OAuth
authorized APIs, but makes it hard to use SimpleAuth for authentication
with existing, non-Oauth API designs.

Changing an existing API requires more effort, hence the pull request.
It would be nice if you'd accept this, but I understand if you want to
keep it as is :)
