### PR TITLE
Change link.origin with link.host for compatibility with firefox.

### DIFF
--- a/packages/ember-simple-auth/lib/core.js
+++ b/packages/ember-simple-auth/lib/core.js
@@ -67,8 +67,8 @@ Ember.SimpleAuth.setup = function(container, application, options) {
       Ember.SimpleAuth._links[url] = link;
       return link;
     }();
-    var linkUrl = link.protocol+'//'+link.hostname+':'+link.port;
-    var windowLocationUrl = window.location.protocol+'//'+window.location.hostname+':'+window.location.port;
+    var linkUrl = link.protocol+'//'+link.hostname+(link.port !== '' ? ':'+link.port : '');
+    var windowLocationUrl = window.location.protocol+'//'+window.location.hostname+(window.location.port !== '' ? ':'+window.location.port : '');
     return this.crossOriginWhitelist.indexOf(linkUrl) > -1 || linkUrl === windowLocationUrl;
   },
 


### PR DESCRIPTION
I found that link.origin crashed with firefox : 'undefined method'. 
I changed it for link.host and I needed to remove 'https://' from urls in tests. 
