### PR TITLE
Checking for the correct data

### DIFF
--- a/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
@@ -54,7 +54,7 @@ Ember.SimpleAuth.LoginControllerMixin = Ember.Mixin.create({
     var postData = ['grant_type=password', 'username=' + identification, 'password=' + password];
     if (!Ember.isEmpty(client_id)) {
       postData.push('client_id=' + client_id);
-      if (!Ember.isEmpty(client_id)) {
+      if (!Ember.isEmpty(client_secret)) {
         postData.push('client_secret=' + client_secret);
       }
     }


### PR DESCRIPTION
Fixes #42

Checking to make sure `client_secret` is present before including it in
`postData` in the default implementation of
`Ember.SimpleAuth.LoginControllerMixin#tokenRequestOptions`.
