### PR TITLE
Also add 403

### DIFF
--- a/packages/ember-simple-auth/lib/mixins/application_route_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/application_route_mixin.js
@@ -151,7 +151,7 @@ Ember.SimpleAuth.ApplicationRouteMixin = Ember.Mixin.create({
 
     /**
       This action is invoked when an authorization error occurs (which is
-      __when a server responds with HTTP status 401__). This will invalidate
+      __when a server responds with HTTP status 401 or 403__). This will invalidate
       the session and transitions to the `routeAfterInvalidation` specified in
       [Ember.SimpleAuth.setup](#Ember-SimpleAuth-setup).
 
@@ -169,7 +169,7 @@ Ember.SimpleAuth.ApplicationRouteMixin = Ember.Mixin.create({
       @private
     */
     error: function(reason) {
-      if (reason.status === 401) {
+      if (reason.status === 401 || reason.status === 403) {
         this.send('authorizationFailed');
       }
     }


### PR DESCRIPTION
Hi,

I've added the new feature for 403 error too. My server returns 403 error when a user is unauthorized to perform an action. Actually, 403 is forbidden, but I've seen many cases where 403 and 401 are used interchangeably for this purpose.
