### PR TITLE
Handle relative URLs in IE

### DIFF
--- a/packages/ember-simple-auth/lib/core.js
+++ b/packages/ember-simple-auth/lib/core.js
@@ -110,6 +110,10 @@ Ember.SimpleAuth = Ember.Namespace.create({
     var link = this._linkOrigins[url] || function() {
       var link = document.createElement('a');
       link.href = url;
+      //IE requires the following line when url is relative.
+      //First assignment of relative url to link.href results in absolute url on link.href but link.hostname and other properties are not set
+      //Second assignment of absolute url to link.href results in link.hostname and other properties being set as expected
+      link.href = link.href;
       return (this._linkOrigins[url] = link);
     }.apply(this);
     var linkOrigin = extractLocationOrigin(link);


### PR DESCRIPTION
IE requires reassignment of HTMLAnchorElement href property to properly
handle relative URLs
First assignment of relative url to link.href results in absolute url on
link.href but link.hostname and other properties are not set
Second assignment of absolute url to link.href results in link.hostname
and other properties being set as expected
