### PR TITLE
allow bubbling of errors

### DIFF
--- a/packages/ember-simple-auth/lib/mixins/application_route_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/application_route_mixin.js
@@ -172,6 +172,7 @@ Ember.SimpleAuth.ApplicationRouteMixin = Ember.Mixin.create({
       if (reason.status === 401) {
         this.send('authorizationFailed');
       }
+      return true;
     }
   }
 });


### PR DESCRIPTION
Ember.SimpleAuth.ApplicationRouteMixin was swallowing the error event before.
