### PR TITLE
In code example use quotes for the action parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This route displays the login form with fields for `identification` and
 `password`:
 
 ```html
-<form {{action authenticate on='submit'}}>
+<form {{action 'authenticate' on='submit'}}>
   <label for="identification">Login</label>
   {{input id='identification' placeholder='Enter Login' value=identification}}
   <label for="password">Password</label>

--- a/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
+++ b/packages/ember-simple-auth/lib/mixins/login_controller_mixin.js
@@ -16,7 +16,7 @@
   action, e.g.:
 
   ```handlebars
-  <form {{action login on='submit'}}>
+  <form {{action 'authenticate' on='submit'}}>
     <label for="identification">Login</label>
     {{input id='identification' placeholder='Enter Login' value=identification}}
     <label for="password">Password</label>


### PR DESCRIPTION
Otherwise there’s a deprecation warning suggesting use of quoted version.
