### PR TITLE
Lock store before clearing or persisting (Fix #97)

### DIFF
--- a/lib/ember-simple-auth/session.js
+++ b/lib/ember-simple-auth/session.js
@@ -79,10 +79,20 @@ var Session = Ember.ObjectProxy.extend(Ember.Evented, {
       this.container.lookup(authenticatorFactory).restore(restoredContent).then(function(content) {
         _this.setup(authenticatorFactory, content);
       }, function() {
-        _this.store.clear();
+        if (!this.store.isLocked()) {
+            Ember.Logger.debug('******** INIT: STORE IS NOT LOCKED: 1');
+            _this.store.clear();
+        } else {
+            Ember.Logger.debug('******** INIT: STORE IS LOCKED: 1');
+        }
       });
     } else {
-      this.store.clear();
+        if (!this.store.isLocked()) {
+            Ember.Logger.debug('******** INIT: STORE IS NOT LOCKED: 2');
+            this.store.clear();
+        } else {
+            Ember.Logger.debug('******** INIT: STORE IS LOCKED: 2');
+        }
     }
   },
 
@@ -159,10 +169,23 @@ var Session = Ember.ObjectProxy.extend(Ember.Evented, {
     });
     this.bindToAuthenticatorEvents();
     var data = Ember.$.extend({ authenticatorFactory: authenticatorFactory }, this.content);
-    this.store.clear();
-    this.store.persist(data);
+
+    if(!this.store.isLocked()) {
+      Ember.Logger.debug('******** SETUP: STORE IS NOT LOCKED');
+      Ember.Logger.debug('******** SETUP: LOCK');
+      this.store.lock();
+      Ember.Logger.debug('******** SETUP: CLEAR');
+      this.store.clear();
+      Ember.Logger.debug('******** SETUP: PERSIST');
+      this.store.persist(data);
+      Ember.Logger.debug('******** SETUP: UNLOCK');
+      this.store.unlock();
+    } else {
+      Ember.Logger.debug('******** SETUP: STORE IS LOCKED');
+    }
+
     if (trigger) {
-      this.trigger('ember-simple-auth:session-authentication-succeeded');
+        this.trigger('ember-simple-auth:session-authentication-succeeded');
     }
   },
 
@@ -177,7 +200,15 @@ var Session = Ember.ObjectProxy.extend(Ember.Evented, {
       authenticatorFactory: null,
       content:              {}
     });
-    this.store.clear();
+
+    if(!this.store.isLocked()) {
+        Ember.Logger.debug('******** CLEAR: CLEAR');
+        this.store.clear();
+    } else {
+        Ember.debug('******** CLEAR: LOCKED');
+    }
+
+    // TODO
     if (trigger) {
       this.trigger('ember-simple-auth:session-invalidation-succeeded');
     }

--- a/lib/ember-simple-auth/stores/base.js
+++ b/lib/ember-simple-auth/stores/base.js
@@ -51,6 +51,16 @@ var Base = Ember.Object.extend(Ember.Evented, {
     @method clear
   */
   clear: function() {
+  },
+
+  isLocked: function() {
+      return false;
+  },
+
+  lock: function() {
+  },
+
+  unlock: function() {
   }
 });
 

--- a/lib/ember-simple-auth/stores/local_storage.js
+++ b/lib/ember-simple-auth/stores/local_storage.js
@@ -47,6 +47,7 @@ var LocalStorage = Base.extend({
   persist: function(properties) {
     for (var property in properties) {
       var key = this.buildStorageKey(property);
+      Ember.Logger.debug('persist: ', key, properties[property]);
       localStorage.setItem(key, properties[property]);
     }
     this._lastProperties = JSON.stringify(this.restore());
@@ -112,16 +113,34 @@ var LocalStorage = Base.extend({
   bindToStorageEvents: function() {
     var _this = this;
     Ember.$(window).bind('storage', function(e) {
+      if(_this.isLocked()) {
+          Ember.Logger.debug('******** STORAGE EVENT: LOCKED');
+      }
+      Ember.Logger.debug('******** STORAGE EVENT: set', e.originalEvent.key, 'from', e.originalEvent.oldValue, 'to',  e.originalEvent.newValue);
+
       var properties        = _this.restore();
       var encodedProperties = JSON.stringify(properties);
       if (encodedProperties !== _this._lastProperties) {
         _this._lastProperties = encodedProperties;
         Ember.run.cancel(_this._triggerChangeEventTimeout);
         _this._triggerChangeEventTimeout = Ember.run.next(_this, function() {
+          Ember.Logger.debug('session updated!');
           this.trigger('ember-simple-auth:session-updated', properties);
         });
       }
     });
+  },
+
+  isLocked: function() {
+      return !!localStorage.getItem(this.buildStorageKey('is_locked'));
+  },
+
+  lock: function() {
+      localStorage.setItem(this.buildStorageKey('is_locked'), 'true');
+  },
+
+  unlock: function() {
+      localStorage.removeItem(this.buildStorageKey('is_locked'));
   }
 });
 


### PR DESCRIPTION
Hey,

although I can't reproduce #97 anymore, someone else on my team can until I apply this patch (sometimes at least).

This is work-in-progress, if we agree on the direction this goes, then I will of course remove debug spam, fix formatting/whitespaces, add documentation and tests.

I was especially unsure about triggering the events. Should we only trigger them if the store was not locked? Should we always trigger them? Is this too important as an edge case that is hardly reproducible anyways? At least my team member doesn't notice any borkage afterwards... 

I believe this improves the situation a lot anyway.

Looking forward to your suggestions!
