### PR TITLE
Fixes README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ var CustomAuthenticator = Ember.SimpleAuth.Authenticators.Base.extend({
 Ember.Application.initializer({
   name: 'authentication',
   initialize: function(container, application) {
-    container.register('app:authenticators:custom', CustomAuthenticator);
+    container.register('authenticators:custom', CustomAuthenticator);
     Ember.SimpleAuth.setup(container, application);
   }
 });
@@ -213,7 +213,7 @@ application:
 
 ```js
 App.LoginController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin, {
-  authenticatorFactory: 'app:authenticators:custom'
+  authenticatorFactory: 'authenticators:custom'
 });
 ```
 
@@ -225,7 +225,7 @@ to implement a custom solution:
 
 ```js
 App.LoginController = Ember.Controller.extend(Ember.SimpleAuth.AuthenticationControllerMixin, {
-  authenticatorFactory: 'app:authenticators:custom',
+  authenticatorFactory: 'authenticators:custom',
   actions: {
     authenticate: function() {
       var options = …// some options that the authenticator uses

--- a/lib/ember-simple-auth/authenticators/base.js
+++ b/lib/ember-simple-auth/authenticators/base.js
@@ -29,7 +29,7 @@ var global = (typeof window !== 'undefined') ? window : {},
   Ember.Application.initializer({
     name: 'authentication',
     initialize: function(container, application) {
-      container.register('app:authenticators:custom', CustomAuthenticator);
+      container.register('authenticators:custom', CustomAuthenticator);
       Ember.SimpleAuth.setup(container, application);
     }
   });

--- a/lib/ember-simple-auth/mixins/application_route_mixin.js
+++ b/lib/ember-simple-auth/mixins/application_route_mixin.js
@@ -72,7 +72,7 @@ var ApplicationRouteMixin = Ember.Mixin.create({
       App.ApplicationRoute = Ember.Route.extend(Ember.SimpleAuth.ApplicationRouteMixin, {
         actions: {
           authenticateSession: function() {
-            this.get('session').authenticate('app:authenticators:custom', {});
+            this.get('session').authenticate('authenticators:custom', {});
           }
         }
       });


### PR DESCRIPTION
If you're gonna try to register something with a name that has two colons in
it, Ember.js resolver will stop working properly.

[Current implementation](https://github.com/stefanpenner/ember-jj-abrams-resolver/blob/618dca2affd21e980f7efee83e3f5c7a170887bb/dist/ember-resolver.prod.js#L231) of resolver will ignore everything after second colon.
