### PR TITLE
do not silently fail when identification or password is missing

### DIFF
--- a/lib/ember-simple-auth/mixins/login_controller_mixin.js
+++ b/lib/ember-simple-auth/mixins/login_controller_mixin.js
@@ -56,10 +56,8 @@ var LoginControllerMixin = Ember.Mixin.create(AuthenticationControllerMixin, {
     */
     authenticate: function() {
       var data = this.getProperties('identification', 'password');
-      if (!Ember.isEmpty(data.identification) && !Ember.isEmpty(data.password)) {
-        this.set('password', null);
-        this._super(data);
-      }
+      this.set('password', null);
+      this._super(data);
     }
   }
 });

--- a/test/tests/mixins/login_controller_mixin_test.js
+++ b/test/tests/mixins/login_controller_mixin_test.js
@@ -40,13 +40,5 @@ describe('LoginControllerMixin', function() {
       });
     });
 
-    describe('when both identification and password are set on the controller', function() {
-      it('does not authenticate the session', function() {
-        sinon.spy(this.session, 'authenticate');
-        this.controller._actions.authenticate.apply(this.controller);
-
-        expect(this.session.authenticate).to.not.have.been.called;
-      });
-    });
   });
 });


### PR DESCRIPTION
When a user does not input an identification or password LoginControllerMixin silently fail with no visible clue for the user, and to the user that is probably experienced as the app being unresponsive. This pull request removes this functionality since it is effectively an insufficient validation, and the Ember Simple Auth users can either rely on server side validations and/or cheap validations on the controller/model.
