### PR TITLE
Allowed RSVP.Promise from Session.authenticate() to be passed down throu...

### DIFF
--- a/packages/ember-simple-auth/lib/ember-simple-auth/mixins/authentication_controller_mixin.js
+++ b/packages/ember-simple-auth/lib/ember-simple-auth/mixins/authentication_controller_mixin.js
@@ -31,10 +31,10 @@ var AuthenticationControllerMixin = Ember.Mixin.create({
       [Ember.SimpleAuth.Session#authenticate](#Ember-SimpleAuth-Session-authenticate)).
 
       @method actions.authenticate
-      @param {Object} options Any options the auhtenticator needs to authenticate the session
+      @param {Object} options Any options the authenticator needs to authenticate the session
     */
     authenticate: function(options) {
-      this.get(Configuration.sessionPropertyName).authenticate(this.get('authenticatorFactory'), options);
+      return this.get(Configuration.sessionPropertyName).authenticate(this.get('authenticatorFactory'), options);
     }
   }
 });


### PR DESCRIPTION
I was writing a custom Login Controller and I wanted to be able to act depending on whether the authentication was a success or failure. The `return` allows the `RSVP.Promise` from `authenticate` to be passed down.
