### PR TITLE
fix second login not redirected

### DIFF
--- a/packages/ember-simple-auth/lib/ember-simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/ember-simple-auth/session.js
@@ -245,9 +245,7 @@ var Session = Ember.ObjectProxy.extend(Ember.Evented, {
     var data = Ember.$.extend({ authenticatorFactory: authenticatorFactory }, this.content);
     this.store.replace(data);
     this.endPropertyChanges();
-    if (trigger) {
-      this.trigger('sessionAuthenticationSucceeded');
-    }
+    this.trigger('sessionAuthenticationSucceeded');
   },
 
   /**


### PR DESCRIPTION
If session is authenticated and we manual go to login page and login, sessionAuthenticationSucceeded event is not fired, so the page would not redirect.
