### PR TITLE
Add UnauthenticatedRouteMixin

### DIFF
--- a/examples/1-simple.html
+++ b/examples/1-simple.html
@@ -107,6 +107,9 @@
 
       // make this route protected
       App.ProtectedRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin);
+
+      // make the login route only available when not authenticated
+      App.LoginRoute = Ember.Route.extend(SimpleAuth.UnauthenticatedRouteMixin);
     </script>
   </body>
 </html>

--- a/packages/ember-simple-auth/lib/simple-auth/configuration.js
+++ b/packages/ember-simple-auth/lib/simple-auth/configuration.js
@@ -44,13 +44,13 @@ export default {
     The route to transition to if a route with UnauthenticatedRouteMixin is
     accessed after the session is authenticated.
 
-    @property alreadyAuthenticatedRoute
+    @property isAuthenticatedRoute
     @readOnly
     @static
     @type String
-    @default `routeAfterAuthentication`
+    @default 'index'
   */
-  alreadyAuthenticatedRoute: this.routeAfterAuthentication,
+  isAuthenticatedRoute: 'index',
 
   /**
     The name of the property that the session is injected with into routes and
@@ -117,14 +117,14 @@ export default {
     @private
   */
   load: function(container) {
-    var globalConfig               = getGlobalConfig('simple-auth');
-    this.authenticationRoute       = globalConfig.authenticationRoute || this.authenticationRoute;
-    this.routeAfterAuthentication  = globalConfig.routeAfterAuthentication || this.routeAfterAuthentication;
-    this.alreadyAuthenticatedRoute = globalConfig.alreadyAuthenticatedRoute || this.alreadyAuthenticatedRoute;
-    this.sessionPropertyName       = globalConfig.sessionPropertyName || this.sessionPropertyName;
-    this.authorizer                = globalConfig.authorizer || this.authorizer;
-    this.store                     = globalConfig.store || this.store;
-    this.crossOriginWhitelist      = globalConfig.crossOriginWhitelist || this.crossOriginWhitelist;
-    this.applicationRootUrl        = container.lookup('router:main').get('rootURL') || '/';
+    var globalConfig              = getGlobalConfig('simple-auth');
+    this.authenticationRoute      = globalConfig.authenticationRoute || this.authenticationRoute;
+    this.routeAfterAuthentication = globalConfig.routeAfterAuthentication || this.routeAfterAuthentication;
+    this.isAuthenticatedRoute     = globalConfig.isAuthenticatedRoute || this.isAuthenticatedRoute;
+    this.sessionPropertyName      = globalConfig.sessionPropertyName || this.sessionPropertyName;
+    this.authorizer               = globalConfig.authorizer || this.authorizer;
+    this.store                    = globalConfig.store || this.store;
+    this.crossOriginWhitelist     = globalConfig.crossOriginWhitelist || this.crossOriginWhitelist;
+    this.applicationRootUrl       = container.lookup('router:main').get('rootURL') || '/';
   }
 };

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/unauthenticated-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/unauthenticated-route-mixin.js
@@ -8,7 +8,7 @@ import Configuration from './../configuration';
   not authenticated. For example, you might want the login page to redirect to the
   index page if the session is authenticated. Including this mixin in a route
   automatically adds a hook that redirects to the
-  [`Configuration.alreadyAuthenticatedRoute`](#SimpleAuth-Configuration-alreadyAuthenticatedRoute),
+  [`Configuration.isAuthenticatedRoute`](#SimpleAuth-Configuration-isAuthenticatedRoute),
   which defaults to the
   [`Configuration.routeAfterAuthentication`](#SimpleAuth-Configuration-routeAfterAuthentication).
 
@@ -34,7 +34,7 @@ export default Ember.Mixin.create({
     This method implements the enforcement of the session being unauthenticated.
     If the session is authenticated, the current transition will be aborted
     and a redirect will be triggered to the
-    [`Configuration.alreadyAuthenticatedRoute`](#SimpleAuth-Configuration-alreadyAuthenticatedRoute).
+    [`Configuration.isAuthenticatedRoute`](#SimpleAuth-Configuration-isAuthenticatedRoute).
 
     @method beforeModel
     @param {Transition} transition The transition that lead to this route
@@ -42,7 +42,7 @@ export default Ember.Mixin.create({
   beforeModel: function(transition) {
     if (this.get(Configuration.sessionPropertyName).get('isAuthenticated')) {
       transition.abort();
-      this.transitionTo(Configuration.alreadyAuthenticatedRoute);
+      this.transitionTo(Configuration.isAuthenticatedRoute);
     }
   }
 });

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/unauthenticated-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/unauthenticated-route-mixin-test.js
@@ -26,10 +26,10 @@ describe('UnauthenticatedRouteMixin', function() {
         expect(this.transition.abort).to.have.been.called;
       });
 
-      it('transitions to alreadyAuthenticatedRoute', function() {
+      it('transitions to isAuthenticatedRoute', function() {
         this.route.beforeModel(this.transition);
 
-        expect(this.route.transitionTo).to.have.been.calledWith(Configuration.alreadyAuthenticatedRoute);
+        expect(this.route.transitionTo).to.have.been.calledWith(Configuration.isAuthenticatedRoute);
       });
     });
 
@@ -40,7 +40,7 @@ describe('UnauthenticatedRouteMixin', function() {
         expect(this.transition.abort).to.not.have.been.called;
       });
 
-      it('', function() {
+      it('does not call route transitionTo', function() {
         this.route.beforeModel(this.transition);
 
         expect(this.route.transitionTo).to.not.have.been.called;

--- a/packages/ember-simple-auth/wrap/browser.end
+++ b/packages/ember-simple-auth/wrap/browser.end
@@ -13,6 +13,7 @@ var ApplicationRouteMixin         = requireModule('simple-auth/mixins/applicatio
 var AuthenticatedRouteMixin       = requireModule('simple-auth/mixins/authenticated-route-mixin').default;
 var AuthenticationControllerMixin = requireModule('simple-auth/mixins/authentication-controller-mixin').default;
 var LoginControllerMixin          = requireModule('simple-auth/mixins/login-controller-mixin').default;
+var UnauthenticatedRouteMixin     = requireModule('simple-auth/mixins/unauthenticated-route-mixin').default;
 
 global.SimpleAuth = {
   Configuration: Configuration,
@@ -42,7 +43,8 @@ global.SimpleAuth = {
   ApplicationRouteMixin:         ApplicationRouteMixin,
   AuthenticatedRouteMixin:       AuthenticatedRouteMixin,
   AuthenticationControllerMixin: AuthenticationControllerMixin,
-  LoginControllerMixin:          LoginControllerMixin
+  LoginControllerMixin:          LoginControllerMixin,
+  UnauthenticatedRouteMixin:     UnauthenticatedRouteMixin
 };
 
 requireModule('simple-auth/ember');


### PR DESCRIPTION
This adds a mixin to redirect if the session is already authenticated.

I wasn't able to make sure this works in a real app because I'm using ember-cli-simple-auth, but all the tests pass.
