### PR TITLE
Fix issue with authenticated account example

### DIFF
--- a/examples/4-authenticated-account.html
+++ b/examples/4-authenticated-account.html
@@ -109,7 +109,7 @@
               if (!Ember.isEmpty(accountId)) {
                 return container.lookup('store:main').find('account', accountId);
               }
-            }.property('accountId')
+            }.property('account_id')
           });
           // register the custom authenticator so the session can find it
           container.register('authenticator:custom', App.CustomAuthenticator);


### PR DESCRIPTION
Fixes a typo in the authenticated account example.

`accountId` -> `account_id`
