### PR TITLE
Make email and password undefined if string is empty, null, etc...

### DIFF
--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -107,8 +107,8 @@ export default Base.extend({
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var data                 = {};
       data[_this.resourceName] = {
-        email:    credentials.identification,
-        password: credentials.password
+        email:    credentials.identification ?  credentials.identification : undefined,
+        password: credentials.password ?        credentials.password       : undefined
       };
       _this.makeRequest(data).then(function(response) {
         Ember.run(function() {


### PR DESCRIPTION
Let me know if this needs testing (passing existing tests)... just a simple ternary operator

I needed to pinpoint exactly where the user is entering the wrong information and before this change, the request came into the server with empty strings after an initial login attempt. This ensures the email and password stays undefined when the string is empty.
