### PR TITLE
Update application route mixin - support deep links if not authenticated

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -66,6 +66,8 @@ export default Ember.Mixin.create({
   */
   beforeModel: function(transition) {
     this._super(transition);
+    if (this.get('_authEventListenersAssigned')) return;
+    this.set('_authEventListenersAssigned', true);
     var _this = this;
     Ember.A([
       'sessionAuthenticationSucceeded',

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
@@ -77,6 +77,21 @@ describe('ApplicationRouteMixin', function() {
           done();
         });
       });
+
+      describe('and "beforeModel" was triggered multiple times due to an aborted initial transition', function() {
+        it('the action is only invoked on the transition once', function(done) {
+          this.route.beforeModel(this.transition);
+
+          this.transition.isActive = true;
+          this.session.trigger('sessionAuthenticationSucceeded');
+
+          Ember.run.next(this, function() {
+            expect(this.transition.send).to.have.been.calledWith('sessionAuthenticationSucceeded');
+            expect(this.transition.send).to.have.been.calledOnce;
+            done();
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Closes simplabs/ember-simple-auth#256

A user arriving at an application via a deep link to a page that requires authentication was not redirected to that page after login.

It's not an elegant fix, but I couldn't think of a better solution so went with the most obvious.
