### PR TITLE
Prevent custom content being overwritten

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -305,7 +305,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     authenticator.off('sessionDataUpdated');
     authenticator.off('sessionDataInvalidated');
     authenticator.on('sessionDataUpdated', function(content) {
-      _this.set('content', {});
       _this.setup(_this.authenticator, content);
     });
     authenticator.on('sessionDataInvalidated', function(content) {

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -26,11 +26,11 @@ describe('Session', function() {
       });
 
       it('retains custom content on update', function(done) {
-        this.session.set('content', {existing: "property"});
+        this.session.set('content', { existing: 'property' });
         this.authenticator.trigger('sessionDataUpdated', { some: 'other property' });
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({ some: 'other property' });
+          expect(this.session.get('content')).to.eql({ existing: 'property', some: 'other property' });
           done();
         });
       });
@@ -152,14 +152,15 @@ describe('Session', function() {
           });
         });
 
-        it('sets its content to the data the authenticator resolves with', function(done) {
+        it('merges its content to the data the authenticator resolves with', function(done) {
           var _this = this;
+          this.session.set('content', { existing: 'property' });
 
           this.session.restore().then(function() {
             var properties = _this.store.restore();
             delete properties.authenticator;
 
-            expect(_this.session.get('content')).to.eql({ some: 'properties' });
+            expect(_this.session.get('content')).to.eql({ existing: 'property', some: 'properties' });
             done();
           });
         });
@@ -246,11 +247,12 @@ describe('Session', function() {
         });
       });
 
-      it('sets its content to the data the authenticator resolves with', function(done) {
+      it('merges its content to the data the authenticator resolves with', function(done) {
         var _this = this;
+        this.session.set('content', { existing: 'property' });
 
         this.session.authenticate('authenticator').then(function() {
-          expect(_this.session.get('content')).to.eql({ some: 'properties' });
+          expect(_this.session.get('content')).to.eql({ existing: 'property', some: 'properties' });
           done();
         });
       });
@@ -573,7 +575,7 @@ describe('Session', function() {
           });
         });
 
-        it('sets its content to the data the authenticator resolves with', function(done) {
+        it('merges its content to the data the authenticator resolves with', function(done) {
           this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
 
           Ember.run.next(this, function() {


### PR DESCRIPTION
Further to commit https://github.com/simplabs/ember-simple-auth/commit/d363fcca7e310ec0e60b950dfe0a897f15a13d7d I discovered that when the token refresh was triggering from an authenticator it was completely overwriting the session content with the refresh token return.
