### PR TITLE
Remove check for Ember.testing because it is not initialized yet.

### DIFF
--- a/packages/ember-simple-auth-testing/wrap/browser.end
+++ b/packages/ember-simple-auth-testing/wrap/browser.end
@@ -5,8 +5,6 @@ define('simple-auth/configuration',  ['exports'], function(__exports__) {
   __exports__['default'] = global.SimpleAuth.Configuration;
 });
 
-if (global.Ember.testing) {
-  requireModule('simple-auth-testing/ember');
-  requireModule('simple-auth-testing/test-helpers');
-}
+requireModule('simple-auth-testing/ember');
+requireModule('simple-auth-testing/test-helpers');
 })((typeof global !== 'undefined') ? global : window);


### PR DESCRIPTION
Since the browser version runs immediately `Ember.testing` will not be initialized yet so we can't check for it.

This PR is https://github.com/simplabs/ember-simple-auth/pull/282 but rebased on `next` instead of `master`.
