### PR TITLE
Prevent loop if  matches current route

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/mixins/unauthenticated-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/unauthenticated-route-mixin.js
@@ -32,8 +32,6 @@ export default Ember.Mixin.create({
     be aborted and a redirect will be triggered to the
     [`Configuration.isAuthenticatedRoute`](#SimpleAuth-Configuration-isAuthenticatedRoute).
 
-    This method also checks for a circular transition.
-
     @method beforeModel
     @param {Transition} transition The transition that lead to this route
   */

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/authenticated-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/authenticated-route-mixin-test.js
@@ -1,6 +1,5 @@
 import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 import Session from 'simple-auth/session';
-import Configuration from 'simple-auth/configuration';
 import EphemeralStore from 'simple-auth/stores/ephemeral';
 
 describe('AuthenticatedRouteMixin', function() {
@@ -12,7 +11,6 @@ describe('AuthenticatedRouteMixin', function() {
       this.route      = Ember.Route.extend(AuthenticatedRouteMixin).create({ session: this.session });
       sinon.spy(this.transition, 'abort');
       sinon.spy(this.transition, 'send');
-      sinon.spy(this.route, 'transitionTo');
     });
 
     describe('if the session is authenticated', function() {
@@ -44,19 +42,6 @@ describe('AuthenticatedRouteMixin', function() {
         this.route.beforeModel(this.transition);
 
         expect(this.transition.send).to.have.been.calledWith('authenticateSession');
-      });
-
-      it('errors if current route matches authenticationRoute', function() {
-        this.route.routeName = Configuration.authenticationRoute;
-
-        try {
-            this.route.beforeModel(this.transition);
-        }
-        catch(err) {
-            // Code generates an Exception, we should catch this.
-        }
-
-        expect(this.route.transitionTo).to.not.have.been.called;
       });
     });
   });

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/unauthenticated-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/unauthenticated-route-mixin-test.js
@@ -31,19 +31,6 @@ describe('UnauthenticatedRouteMixin', function() {
 
         expect(this.route.transitionTo).to.have.been.calledWith(Configuration.isAuthenticatedRoute);
       });
-
-      it('errors if current route matches isAuthenticatedRoute', function() {
-        this.route.routeName = Configuration.isAuthenticatedRoute;
-
-        try {
-            this.route.beforeModel(this.transition);
-        }
-        catch(err) {
-            // Code generates an Exception, we should catch this.
-        }
-
-        expect(this.route.transitionTo).to.not.have.been.called;
-      });
     });
 
     describe('if the session is not authenticated', function() {


### PR DESCRIPTION
Adds check for circular transition loop if `UnauthenticatedRouteMixin` has been included in the `isAuthenticatedRoute`.  

Resolves issue https://github.com/simplabs/ember-simple-auth/issues/293
