### PR TITLE
Fix typo

### DIFF
--- a/examples/1-simple.html
+++ b/examples/1-simple.html
@@ -81,10 +81,10 @@
     </script>
 
     <script type="text/javascript">
-      // enable token revokation
+      // enable token revocation
       window.ENV = window.ENV || {};
       window.ENV['simple-auth-oauth2'] = {
-        serverTokenRevokationEndpoint: '/revoke',
+        serverTokenRevocationEndpoint: '/revoke',
       };
       App = Ember.Application.create({});
 

--- a/examples/3-token-refresh.html
+++ b/examples/3-token-refresh.html
@@ -90,11 +90,11 @@
     </script>
 
     <script type="text/javascript">
-      // configure the endpoint for the OAuth 2.0 authenticator and enable token revokation
+      // configure the endpoint for the OAuth 2.0 authenticator and enable token revocation
       window.ENV = window.ENV || {};
       window.ENV['simple-auth-oauth2'] = {
         serverTokenEndpoint: '/v2/token',
-        serverTokenRevokationEndpoint: '/revoke',
+        serverTokenRevocationEndpoint: '/revoke',
       };
 
       App = Ember.Application.create({});

--- a/examples/middleware.js
+++ b/examples/middleware.js
@@ -22,7 +22,7 @@ module.exports = function(request, response, next) {
       error(400, '{ "error": "unsupported_grant_type" }');
     }
 
-  // endpoint for token revokation
+  // endpoint for token revocation
   } else if (request.url === '/revoke' && request.method === 'POST') {
     if (request.body.token_type_hint === 'access_token' || request.body.token_type_hint === 'refresh_token') {
       success('');

--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
@@ -49,22 +49,22 @@ export default Base.extend({
 
   /**
     The endpoint on the server the authenticator uses to revoke tokens. Only
-    set this if the server actually supports token revokation.
+    set this if the server actually supports token revocation.
 
     This value can be configured via the global environment object:
 
     ```js
     window.ENV = window.ENV || {};
     window.ENV['simple-auth-oauth2'] = {
-      serverTokenRevokationEndpoint: '/some/custom/endpoint'
+      serverTokenRevocationEndpoint: '/some/custom/endpoint'
     }
     ```
 
-    @property serverTokenRevokationEndpoint
+    @property serverTokenRevocationEndpoint
     @type String
     @default null
   */
-  serverTokenRevokationEndpoint: null,
+  serverTokenRevocationEndpoint: null,
 
   /**
     Sets whether the authenticator automatically refreshes access tokens.
@@ -97,7 +97,7 @@ export default Base.extend({
   init: function() {
     var globalConfig                   = getGlobalConfig('simple-auth-oauth2');
     this.serverTokenEndpoint           = globalConfig.serverTokenEndpoint || this.serverTokenEndpoint;
-    this.serverTokenRevokationEndpoint = globalConfig.serverTokenRevokationEndpoint || this.serverTokenRevokationEndpoint;
+    this.serverTokenRevocationEndpoint = globalConfig.serverTokenRevocationEndpoint || this.serverTokenRevocationEndpoint;
     this.refreshAccessTokens           = globalConfig.refreshAccessTokens || this.refreshAccessTokens;
   },
 
@@ -194,11 +194,11 @@ export default Base.extend({
       resolve();
     }
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      if (!Ember.isEmpty(_this.serverTokenRevokationEndpoint)) {
+      if (!Ember.isEmpty(_this.serverTokenRevocationEndpoint)) {
         var requests = [];
         Ember.A(['access_token', 'refresh_token']).forEach(function(tokenType) {
           if (!Ember.isEmpty(data[tokenType])) {
-            requests.push(_this.makeRequest(_this.serverTokenRevokationEndpoint, {
+            requests.push(_this.makeRequest(_this.serverTokenRevocationEndpoint, {
               token_type_hint: tokenType, token: data[tokenType]
             }));
           }

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
@@ -15,8 +15,8 @@ describe('OAuth2', function() {
         expect(OAuth2.create().serverTokenEndpoint).to.eq('/token');
       });
 
-      it('defaults serverTokenRevokationEndpoint to null', function() {
-        expect(OAuth2.create().serverTokenRevokationEndpoint).to.be.null;
+      it('defaults serverTokenRevocationEndpoint to null', function() {
+        expect(OAuth2.create().serverTokenRevocationEndpoint).to.be.null;
       });
 
       it('defaults refreshAccessTokens to true', function() {
@@ -29,7 +29,7 @@ describe('OAuth2', function() {
         window.ENV = window.ENV || {};
         window.ENV['simple-auth-oauth2'] = {
           serverTokenEndpoint:           'serverTokenEndpoint',
-          serverTokenRevokationEndpoint: 'serverTokenRevokationEndpoint',
+          serverTokenRevocationEndpoint: 'serverTokenRevocationEndpoint',
           refreshAccessTokens:           false
         };
       });
@@ -38,8 +38,8 @@ describe('OAuth2', function() {
         expect(OAuth2.create().serverTokenEndpoint).to.eq('serverTokenEndpoint');
       });
 
-      it('uses the defined value for serverTokenRevokationEndpoint', function() {
-        expect(OAuth2.create().serverTokenRevokationEndpoint).to.eq('serverTokenRevokationEndpoint');
+      it('uses the defined value for serverTokenRevocationEndpoint', function() {
+        expect(OAuth2.create().serverTokenRevocationEndpoint).to.eq('serverTokenRevocationEndpoint');
       });
 
       it('uses the defined value for refreshAccessTokens', function() {
@@ -295,14 +295,14 @@ describe('OAuth2', function() {
       });
     }
 
-    describe('when token revokation is enabled', function() {
+    describe('when token revocation is enabled', function() {
       beforeEach(function() {
         this.authenticator = OAuth2.create({
-          serverTokenRevokationEndpoint: '/revoke'
+          serverTokenRevocationEndpoint: '/revoke'
         });
       });
 
-      it('sends an AJAX request to the revokation endpoint', function(done) {
+      it('sends an AJAX request to the revocation endpoint', function(done) {
         this.authenticator.invalidate({ access_token: 'access token!' });
 
         Ember.run.next(function() {
@@ -317,7 +317,7 @@ describe('OAuth2', function() {
         });
       });
 
-      describe('when the revokation request is successful', function() {
+      describe('when the revocation request is successful', function() {
         beforeEach(function() {
           this.server.respondWith('POST', '/revoke', [200, { 'Content-Type': 'application/json' }, '']);
         });
@@ -325,7 +325,7 @@ describe('OAuth2', function() {
         itSuccessfullyInvalidatesTheSession();
       });
 
-      describe('when the revokation request fails', function() {
+      describe('when the revocation request fails', function() {
         beforeEach(function() {
           this.server.respondWith('POST', '/revoke', [400, { 'Content-Type': 'application/json' },
           '{ "error": "unsupported_grant_type" }']);
@@ -352,7 +352,7 @@ describe('OAuth2', function() {
       });
     });
 
-    describe('when token revokation is not enabled', function() {
+    describe('when token revocation is not enabled', function() {
       itSuccessfullyInvalidatesTheSession();
     });
   });


### PR DESCRIPTION
- revokation -> revocation

As mentioned on #228 the new option name contains a spelling error and should be fixed. I'm aware that this breaks backwards compatibility, but I think it is better to fix this now rather than wait for much confusion in the future.
