### PR TITLE
Make user_token and user_email configurable

### DIFF
--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -58,26 +58,26 @@ export default Base.extend({
   tokenAttributeName: 'user_token',
 
   /**
-    The email attribute name
+    The identification attribute name
 
     This value can be configured via
-    [`SimpleAuth.Configuration.Devise#emailAttributeName`](#SimpleAuth-Configuration-Devise-emailAttributeName).
+    [`SimpleAuth.Configuration.Devise#identificationAttributeName`](#SimpleAuth-Configuration-Devise-identificationAttributeName).
 
-    @property emailAttributeName
+    @property identificationAttributeName
     @type String
     @default 'user_email'
   */
-  emailAttributeName: 'user_email',
+  identificationAttributeName: 'user_email',
 
   /**
     @method init
     @private
   */
   init: function() {
-    this.serverTokenEndpoint = Configuration.serverTokenEndpoint;
-    this.resourceName        = Configuration.resourceName;
-    this.tokenAttributeName  = Configuration.tokenAttributeName;
-    this.emailAttributeName  = Configuration.emailAttributeName;
+    this.serverTokenEndpoint          = Configuration.serverTokenEndpoint;
+    this.resourceName                 = Configuration.resourceName;
+    this.tokenAttributeName           = Configuration.tokenAttributeName;
+    this.identificationAttributeName  = Configuration.identificationAttributeName;
   },
 
   /**
@@ -94,7 +94,7 @@ export default Base.extend({
     var _this = this;
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      if (!Ember.isEmpty(_properties.get(_this.tokenAttributeName) && !Ember.isEmpty(_properties.get(_this.emailAttributeName)))) {
+      if (!Ember.isEmpty(_properties.get(_this.tokenAttributeName) && !Ember.isEmpty(_properties.get(_this.identificationAttributeName)))) {
         resolve(properties);
       } else {
         reject();

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
@@ -36,13 +36,13 @@ export default Base.extend({
     The email attribute name
 
     This value can be configured via
-    [`SimpleAuth.Configuration.Devise#emailAttributeName`](#SimpleAuth-Configuration-Devise-emailAttributeName).
+    [`SimpleAuth.Configuration.Devise#identificationAttributeName`](#SimpleAuth-Configuration-Devise-identificationAttributeName).
 
-    @property emailAttributeName
+    @property identificationAttributeName
     @type String
     @default 'user_email'
   */
-  emailAttributeName: 'user_email',
+  identificationAttributeName: 'user_email',
 
   /**
     Authorizes an XHR request by sending the `user_token` and `user_email`
@@ -62,13 +62,13 @@ export default Base.extend({
     @private
   */
   init: function() {
-    this.tokenAttributeName = Configuration.tokenAttributeName;
-    this.emailAttributeName = Configuration.emailAttributeName;
+    this.tokenAttributeName          = Configuration.tokenAttributeName;
+    this.identificationAttributeName = Configuration.identificationAttributeName;
   },
 
   authorize: function(jqXHR, requestOptions) {
     var userToken = this.get('session.' + this.tokenAttributeName);
-    var userEmail = this.get('session.' + this.emailAttributeName);
+    var userEmail = this.get('session.' + this.identificationAttributeName);
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(userToken) && !Ember.isEmpty(userEmail)) {
       if (!isSecureUrl(requestOptions.url)) {
         Ember.Logger.warn('Credentials are transmitted via an insecure connection - use HTTPS to keep them secure.');

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/configuration.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/configuration.js
@@ -1,10 +1,10 @@
 import loadConfig from 'simple-auth/utils/load-config';
 
 var defaults = {
-  serverTokenEndpoint: '/users/sign_in',
-  resourceName:        'user',
-  tokenAttributeName:  'user_token',
-  emailAttributeName:  'user_email'
+  serverTokenEndpoint:          '/users/sign_in',
+  resourceName:                 'user',
+  tokenAttributeName:           'user_token',
+  identificationAttributeName:  'user_email'
 };
 
 /**
@@ -62,13 +62,13 @@ export default {
   /**
     The email attribute name
 
-    @property emailAttributeName
+    @property identificationAttributeName
     @readOnly
     @static
     @type String
     @default 'user_email'
   */
-  emailAttributeName: defaults.emailAttributeName,
+  identificationAttributeName: defaults.identificationAttributeName,
 
   /**
     @method load

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
@@ -48,7 +48,7 @@ describe('Devise', function() {
     describe('when the data contains an custom token and email attribute', function() {
       beforeEach(function() {
         Configuration.tokenAttributeName = 'employee_token';
-        Configuration.emailAttributeName = 'employee_email';
+        Configuration.identificationAttributeName = 'employee_email';
         this.customAttributesAuthenticator = Devise.create();
         Configuration.load({}, {});
       });

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
@@ -43,7 +43,7 @@ describe('Devise', function() {
       describe('when the session contains a non empty custom token and email attributes', function() {
         beforeEach(function() {
           Configuration.tokenAttributeName = 'employee_token';
-          Configuration.emailAttributeName = 'employee_email';
+          Configuration.identificationAttributeName = 'employee_email';
 
           this.customAttributesAuthenticator = Devise.create();
           this.customAttributesAuthenticator.set('session', this.session);


### PR DESCRIPTION
Rather than forcing the API to return a response with `user_token` and `user_email` in order for the session to be persisted, you should be able to configure what properties to look for in the response. This adds `tokenAttributeName` and `emailAttributeName` that may be configured to reflect the API that Simple Auth is interacting with. Our API for instance returns a new session response like:

``` json
{
  "user": {
    "token": "someToken",
    "email": "hello@example.com"
  }
}
```

This would allow us to configure the `tokenAttributeName` to be `'user.token'` and the `emailAttributeName` to be `'user.email'`.
