### PR TITLE
updated ajaxPrefilter to accept all ajaxTransport

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -66,7 +66,7 @@ export default function(container, application) {
     if (!!authorizer) {
       authorizer.set('session', session);
       if (!didSetupAjaxHooks) {
-        Ember.$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+        Ember.$.ajaxPrefilter('+*', function(options, originalOptions, jqXHR) {
           if (!authorizer.isDestroyed && shouldAuthorizeRequest(options)) {
             jqXHR.__simple_auth_authorized__ = true;
             authorizer.authorize(jqXHR, options);


### PR DESCRIPTION
To simple-auth works with libs like flxhr (https://github.com/b9chris/flxhr-jquery-packed/blob/master/src/jquery.flxhr.src.js#L65) I added +\* to ajaxPrefilter
