### PR TITLE
Configurable cookieDomain option for ember-simple-auth-cookie-store

### DIFF
--- a/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/configuration.js
+++ b/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/configuration.js
@@ -2,6 +2,7 @@ import loadConfig from 'simple-auth/utils/load-config';
 
 var defaults = {
   cookieName:           'ember_simple_auth:session',
+  cookieDomain:         '',
   cookieExpirationTime: null
 };
 
@@ -22,6 +23,27 @@ var defaults = {
   @module simple-auth/configuration
 */
 export default {
+
+  /**
+    The domain to use for the cookie. E.g., "example.com", ".example.com" (includes all subdomains)
+    or "subdomain.example.com"; if not specified, defaults to the host portion of the
+    current document location (string or null).
+
+    This value can be configured via the global environment object:
+
+    ```js
+    window.ENV = window.ENV || {};
+    window.ENV['simple-auth-cookie-store'] = {
+      cookieDomain: '.example.com'
+    }
+    ```
+
+    @property cookieDomain
+    @type String
+    @default ''
+  */
+  cookieDomain: defaults.cookieDomain,
+
   /**
     The name of the cookie the store stores its data in.
 

--- a/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/stores/cookie.js
+++ b/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/stores/cookie.js
@@ -42,6 +42,27 @@ import Configuration from './../configuration';
   @extends Stores.Base
 */
 export default Base.extend({
+
+  /**
+    The domain to use for the cookie. E.g., "example.com", ".example.com" (includes all subdomains)
+    or "subdomain.example.com"; if not specified, defaults to the host portion of the
+    current document location (string or null).
+
+    This value can be configured via the global environment object:
+
+    ```js
+    window.ENV = window.ENV || {};
+    window.ENV['simple-auth-cookie-store'] = {
+      cookieDomain: '.example.com'
+    }
+    ```
+
+    @property cookieDomain
+    @type String
+    @default ''
+  */
+  cookieDomain: '',
+
   /**
     The name of the cookie the store stores its data in.
 
@@ -87,6 +108,7 @@ export default Base.extend({
   init: function() {
     this.cookieName           = Configuration.cookieName;
     this.cookieExpirationTime = Configuration.cookieExpirationTime;
+    this.cookieDomain         = Configuration.cookieDomain;
     this.syncData();
   },
 
@@ -99,7 +121,8 @@ export default Base.extend({
   persist: function(data) {
     data           = JSON.stringify(data || {});
     var expiration = !!this.cookieExpirationTime ? new Date().getTime() + this.cookieExpirationTime * 1000 : null;
-    this.write(data, expiration);
+    var domain     = this.cookieDomain;
+    this.write(data, expiration, domain);
     this._lastData = this.restore();
   },
 
@@ -127,7 +150,7 @@ export default Base.extend({
     @method clear
   */
   clear: function() {
-    this.write(null, 0);
+    this.write(null, 0, this.cookieDomain);
     this._lastData = null;
   },
 
@@ -144,11 +167,11 @@ export default Base.extend({
     @method write
     @private
   */
-  write: function(value, expiration) {
+  write: function(value, expiration, domain) {
     var path = '; path=/';
     var expires = Ember.isEmpty(expiration) ? '' : '; expires=' + new Date(expiration).toUTCString();
     var secure  = !!this._secureCookies ? ';secure' : '';
-    document.cookie = this.cookieName + '=' + encodeURIComponent(value) + path + expires + secure;
+    document.cookie = this.cookieName + '=' + encodeURIComponent(value) + domain + path + expires + secure;
   },
 
   /**

--- a/packages/ember-simple-auth-cookie-store/tests/simple-auth-cookie-store/configuration-test.js
+++ b/packages/ember-simple-auth-cookie-store/tests/simple-auth-cookie-store/configuration-test.js
@@ -5,6 +5,12 @@ describe('Configuration', function() {
     this.container = {};
   });
 
+  describe('cookieDomain', function() {
+    it('defaults to ""', function() {
+      expect(Configuration.cookieDomain).to.eql('');
+    });
+  });
+
   describe('cookieName', function() {
     it('defaults to "ember_simple_auth:session"', function() {
       expect(Configuration.cookieName).to.eql('ember_simple_auth:session');
@@ -18,6 +24,12 @@ describe('Configuration', function() {
   });
 
   describe('.load', function() {
+    it('sets cookieDomain correctly', function() {
+      Configuration.load(this.container, { cookieDomain: '.example.com' });
+
+      expect(Configuration.cookieDomain).to.eql('.example.com');
+    });
+
     it('sets cookieName correctly', function() {
       Configuration.load(this.container, { cookieName: 'cookieName' });
 

--- a/packages/ember-simple-auth-cookie-store/tests/simple-auth-cookie-store/stores/cookie-test.js
+++ b/packages/ember-simple-auth-cookie-store/tests/simple-auth-cookie-store/stores/cookie-test.js
@@ -14,6 +14,12 @@ describe('Stores.Cookie', function() {
   });
 
   describe('initilization', function() {
+    it('assigns cookieDomain from the configuration object', function() {
+      Configuration.cookieDomain = '.example.com';
+
+      expect(Cookie.create().cookieDomain).to.eq('.example.com');
+    });
+
     it('assigns cookieName from the configuration object', function() {
       Configuration.cookieName = 'cookieName';
 
@@ -52,7 +58,7 @@ describe('Stores.Cookie', function() {
     });
 
     it('is not triggered when the cookie has not actually changed', function(done) {
-      document.cookie = 'ember_simple_auth:session=%7B%22key%22%3A%22value%22%7D;path=/;';
+      document.cookie = 'ember_simple_auth:session=%7B%22key%22%3A%22value%22%7D;domain=;path=/;';
       this.store.syncData();
 
       Ember.run.next(this, function() {
@@ -62,7 +68,7 @@ describe('Stores.Cookie', function() {
     });
 
     it('is triggered when the cookie changed', function(done) {
-      document.cookie = 'ember_simple_auth:session=%7B%22key%22%3A%22other%20value%22%7D;path=/;';
+      document.cookie = 'ember_simple_auth:session=%7B%22key%22%3A%22other%20value%22%7D;domain=;path=/;';
       this.store.syncData();
 
       Ember.run.next(this, function() {


### PR DESCRIPTION
Hi! This need to share session with subdomains, or other manipulations with cookie domain value.
