### PR TITLE
Update API doc links to ember-simple-auth.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ incorrectly to npm...
   `setup` method, these values are now defined on `window.ENV['simple-auth']`
   (and `window.ENV['simple-auth-oauth']` etc. for the extension libraries).
   See the
-  [API Docs for `Configuration`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Configuration)
+  [API Docs for `Configuration`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Configuration)
   for more information.
 * __[BREAKING]__ All underscores have been replaced with dashes in filenames.
   This only affects users that were using the AMD build.

--- a/packages/ember-simple-auth-cookie-store/README.md
+++ b/packages/ember-simple-auth-cookie-store/README.md
@@ -1,4 +1,4 @@
-__[The API docs for the cookie store are available here](http://ember-simple-auth.simplabs.com/ember-simple-auth-cookie-store-api-docs.html)__
+__[The API docs for the cookie store are available here](http://ember-simple-auth.com/ember-simple-auth-cookie-store-api-docs.html)__
 
 #  Ember Simple Auth Cookie Store
 

--- a/packages/ember-simple-auth-devise/README.md
+++ b/packages/ember-simple-auth-devise/README.md
@@ -1,4 +1,4 @@
-__[The API docs for Ember Simple Auth Devise are available here](http://ember-simple-auth.simplabs.com/ember-simple-auth-devise-api-docs.html)__
+__[The API docs for Ember Simple Auth Devise are available here](http://ember-simple-auth.com/ember-simple-auth-devise-api-docs.html)__
 
 # Ember Simple Auth Devise
 
@@ -126,7 +126,7 @@ delete it on session invalidation!
 ## The Authenticator
 
 In order to use the Devise authenticator (see the
-[API docs for `Authenticators.Devise`](http://ember-simple-auth.simplabs.com/ember-simple-auth-devise-api-docs.html#SimpleAuth-Authenticators-Devise))
+[API docs for `Authenticators.Devise`](http://ember-simple-auth.com/ember-simple-auth-devise-api-docs.html#SimpleAuth-Authenticators-Devise))
 the application needs to have a login route:
 
 ```js
@@ -152,7 +152,7 @@ The `authenticate` action that is triggered by submitting the form is provided
 by the `LoginControllerMixin` that the respective controller in the application
 can include (the controller can also implement its own action and use the
 session API directly; see the
-[API docs for `Session`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
+[API docs for `Session`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
 It then also needs to specify the Devise authenticator to be used:
 
 ```js
@@ -167,7 +167,7 @@ export default Ember.Controller.extend(LoginControllerMixin, {
 ## The Authorizer
 
 The authorizer (see the
-[API docs for `Authorizers.Devise`](http://ember-simple-auth.simplabs.com/ember-simple-auth-devise-api-docs.html#SimpleAuth-Authorizers-Devise))
+[API docs for `Authorizers.Devise`](http://ember-simple-auth.com/ember-simple-auth-devise-api-docs.html#SimpleAuth-Authorizers-Devise))
 authorizes requests by adding `user_token` and `user_email` properties from the
 session in the `Authorization` header:
 

--- a/packages/ember-simple-auth-oauth2/README.md
+++ b/packages/ember-simple-auth-oauth2/README.md
@@ -1,4 +1,4 @@
-__[The API docs for Ember Simple Auth OAuth 2.0 are available here](http://ember-simple-auth.simplabs.com/ember-simple-auth-oauth2-api-docs.html)__
+__[The API docs for Ember Simple Auth OAuth 2.0 are available here](http://ember-simple-auth.com/ember-simple-auth-oauth2-api-docs.html)__
 
 # Ember Simple Auth OAuth 2.0
 
@@ -12,7 +12,7 @@ connection uses HTTPS!__
 ## The Authenticator
 
 The authenticator (see the
-[API docs for `Authenticators.OAuth2`](http://ember-simple-auth.simplabs.com/ember-simple-auth-oauth2-api-docs.html#SimpleAuth-Authenticators-OAuth2))
+[API docs for `Authenticators.OAuth2`](http://ember-simple-auth.com/ember-simple-auth-oauth2-api-docs.html#SimpleAuth-Authenticators-OAuth2))
 is compliant with [RFC 6749 (OAuth 2.0)](http://tools.ietf.org/html/rfc6749),
 specifically the _"Resource Owner Password Credentials Grant Type"_. This grant
 type basically specifies that the client sends a set of credentials to a
@@ -72,7 +72,7 @@ The `authenticate` action that is triggered by submitting the form is provided
 by the `LoginControllerMixin` that the respective controller in the application
 can include (the controller can also implement its own action and use the
 session API directly; see the
-[API docs for `Session`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
+[API docs for `Session`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
 It then also needs to specify the OAuth 2.0 authenticator to be used:
 
 ```js
@@ -113,7 +113,7 @@ with this library:
 ## The Authorizer
 
 The authorizer (see the
-[API docs for `Authorizers.OAuth2`](http://ember-simple-auth.simplabs.com/ember-simple-auth-oauth2-api-docs.html#SimpleAuth-Authorizers-OAuth2))
+[API docs for `Authorizers.OAuth2`](http://ember-simple-auth.com/ember-simple-auth-oauth2-api-docs.html#SimpleAuth-Authorizers-OAuth2))
 is compliant with [RFC 6750 (OAuth 2.0 Bearer Tokens)](http://tools.ietf.org/html/rfc6750)
 and thus fits the OAuth 2.0 authenticator. It simply injects an `Authorization`
 header with the `access_token` that the authenticator acquired into all

--- a/packages/ember-simple-auth-torii/README.md
+++ b/packages/ember-simple-auth-torii/README.md
@@ -1,4 +1,4 @@
-__[The API docs for Ember Simple Auth Torii are available here](http://ember-simple-auth.simplabs.com/ember-simple-auth-torii-api-docs.html)__
+__[The API docs for Ember Simple Auth Torii are available here](http://ember-simple-auth.com/ember-simple-auth-torii-api-docs.html)__
 
 # Ember Simple Auth Torii
 
@@ -13,7 +13,7 @@ __Ember Simple Auth Torii requires Ember.js 1.6 or later!__
 ## The Authenticator
 
 In order to use the torii authenticator (see the
-[API docs for `Authenticators.Torii`](http://ember-simple-auth.simplabs.com/ember-simple-auth-torii-api-docs.html#SimpleAuth-Authenticators-Torii))
+[API docs for `Authenticators.Torii`](http://ember-simple-auth.com/ember-simple-auth-torii-api-docs.html#SimpleAuth-Authenticators-Torii))
 the application needs to configure one or more torii providers, e.g.:
 
 ```js

--- a/packages/ember-simple-auth/README.md
+++ b/packages/ember-simple-auth/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/simplabs/ember-simple-auth.svg?branch=master)](https://travis-ci.org/simplabs/ember-simple-auth)
 
-__[Ember Simple Auth's API docs are available here](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html)__
+__[Ember Simple Auth's API docs are available here](http://ember-simple-auth.com/ember-simple-auth-api-docs.html)__
 
 #  Ember Simple Auth
 
@@ -40,7 +40,7 @@ When Ember Simple Auth is included in an application (see the
 options for including it into all types of Ember applications), it registers an
 [initializer](http://emberjs.com/api/classes/Ember.Application.html#toc_initializers)
 named `'simple-auth'`. Once that initializer has run, the session (see the
-[API docs for `Session`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session))
+[API docs for `Session`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session))
 __will be available in all routes and controllers__ of the application.
 
 While not necessary, the easiest way to use the session is to include the
@@ -58,7 +58,7 @@ This adds some actions to the application route like `authenticateSession` and
 `invalidateSession` as well as callback actions that are triggered when the
 session's authentication state changes like `sessionAuthenticationSucceeded` or
 `sessionInvalidationSucceeded` (see the
-[API docs for `ApplicationRouteMixin`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-ApplicationRouteMixin)).
+[API docs for `ApplicationRouteMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-ApplicationRouteMixin)).
 Displaying e.g. login/logout buttons in the UI depending on the session's
 authentication state then is as easy as:
 
@@ -73,7 +73,7 @@ authentication state then is as easy as:
 To make a route in the application require the session to be authenticated,
 there is another mixin that Ember Simple Auth provides and that is included in
 the respective route (see the
-[API docs for `AuthenticatedRouteMixin`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-AuthenticatedRouteMixin)):
+[API docs for `AuthenticatedRouteMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-AuthenticatedRouteMixin)):
 
 ```js
 // app/routes/protected.js
@@ -92,7 +92,7 @@ session.__ An application can have several authenticators for different kinds
 of authentication mechanisms (e.g. the application's own backend server,
 external authentication providers like Facebook etc.) while the session is only
 authenticated with one authenticator at a time (see the
-[API docs for `Session#authenticate`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate)).
+[API docs for `Session#authenticate`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate)).
 The authenticator to use is chosen when authentication is triggered:
 
 ```js
@@ -112,7 +112,7 @@ Besides the option to use one of the predefined authenticators from the
 extension libraries, it is easy to implement custom authenticators as well. All
 that is necessary is to extend the base authenticator and implement three
 methods (see the
-[API docs for `Authenticators.Base`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Authenticators-Base)).
+[API docs for `Authenticators.Base`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Authenticators-Base)).
 
 __Custom authenticators have to be registered with Ember's dependency injection
 container__ so that the session can retrieve an instance, e.g.:
@@ -135,7 +135,7 @@ Ember.Application.initializer({
 
 To authenticate the session with a custom authenticator, simply pass the
 registered factory's name to the session's `authenticate` method (see the
-[API docs for `Session#authenticate`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate)):
+[API docs for `Session#authenticate`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate)):
 
 ```js
 this.get('session').authenticate('authenticator:custom', {});
@@ -153,10 +153,10 @@ export default Ember.Controller.extend(LoginControllerMixin, {
 ```
 
 Also see the
-[API docs for `Session#authenticate`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate),
-[`LoginControllerMixin`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-LoginControllerMixin)
+[API docs for `Session#authenticate`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate),
+[`LoginControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-LoginControllerMixin)
 and
-[`AuthenticationControllerMixin`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-AuthenticationControllerMixin).
+[`AuthenticationControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-AuthenticationControllerMixin).
 
 ### Authorizers
 
@@ -190,7 +190,7 @@ offers extension libraries that can be loaded in the application as needed:
 Besides the option to use one of the predefined authorizers from the extension
 libraries, it is easy to implement custom authorizers as well. All you have to
 do is to extend the base authorizer and implement one method (see the
-[API docs for `Authorizers.Base`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Authorizers-Base)).
+[API docs for `Authorizers.Base`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Authorizers-Base)).
 
 To use a custom authorizer, register it with Ember's container:
 
@@ -258,13 +258,13 @@ Ember Simple Auth comes with 2 bundled stores:
 ##### `localStorage` Store
 
 The `localStorage` store (see the
-[API docs for `Stores.LocalStorage`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-LocalStorage))
+[API docs for `Stores.LocalStorage`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-LocalStorage))
 stores its data in the browser's `localStorage`; __this is the default store__.
 
 ##### Ephemeral Store
 
 The ephemeral store (see the
-[API docs for `Stores.Ephemeral`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-Ephemeral))
+[API docs for `Stores.Ephemeral`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-Ephemeral))
 stores its data in memory and thus __is not actually persistent__. This store
 is mainly useful for testing. Also the ephemeral store cannot keep multiple
 tabs or windows in sync as tabs/windows cannot share memory.
@@ -277,7 +277,7 @@ A cookie based store is available in the extension library
 Implementing a custom store is as easy as implementing custom authenticators or
 authorizers. All you have to do is to extend the base store and implement three
 methods (see the
-[API docs for `Stores.Base`](http://ember-simple-auth.simplabs.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-Base)).
+[API docs for `Stores.Base`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-Base)).
 
 ## Testing
 


### PR DESCRIPTION
This makes the links in the READMEs work with the recent domain update.
