### PR TITLE
Add SessionStorage based store

### DIFF
--- a/packages/ember-simple-auth/README.md
+++ b/packages/ember-simple-auth/README.md
@@ -261,6 +261,11 @@ The `localStorage` store (see the
 [API docs for `Stores.LocalStorage`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Stores-LocalStorage))
 stores its data in the browser's `localStorage`; __this is the default store__.
 
+##### `sessionStorage` Store
+
+The `sessionStorage` store (see the
+stores its data in the browser's `sessionStorage`; This works much like localStorage except it does not persist after the browser session.
+
 ##### Ephemeral Store
 
 The ephemeral store (see the

--- a/packages/ember-simple-auth/lib/simple-auth/configuration.js
+++ b/packages/ember-simple-auth/lib/simple-auth/configuration.js
@@ -9,6 +9,7 @@ var defaults = {
   session:                     'simple-auth-session:main',
   store:                       'simple-auth-session-store:local-storage',
   localStorageKey:             'ember_simple_auth:session',
+  sessionStorageKey:           'ember_simple_auth:session',
   crossOriginWhitelist:        [],
   applicationRootUrl:          null
 };
@@ -125,6 +126,15 @@ export default {
     @default 'ember_simple_auth:session'
   */
   localStorageKey: defaults.localStorageKey,
+
+  /**
+    The key the store stores the data in.
+
+    @property key
+    @type String
+    @default 'ember_simple_auth:session'
+  */
+  sessionStorageKey: defaults.sessionStorageKey,
 
   /**
     Ember Simple Auth will never authorize requests going to a different origin

--- a/packages/ember-simple-auth/lib/simple-auth/stores/session-storage.js
+++ b/packages/ember-simple-auth/lib/simple-auth/stores/session-storage.js
@@ -1,0 +1,88 @@
+import Base from './base';
+import objectsAreEqual from '../utils/objects-are-equal';
+import Configuration from '../configuration';
+
+/**
+  Store that saves its data in the browser's `sessionStorage`.
+
+  _The factory for this store is registered as
+  `'simple-auth-session-store:session-storage'` in Ember's container._
+
+  This store behaves much like the localStorage store, except that it uses the sessionStorage object,
+  This means it will not persist beyond the life of the browser session
+
+  @class SessionStorage
+  @namespace SimpleAuth.Stores
+  @module simple-auth/stores/session-storage
+  @extends Stores.Base
+*/
+export default Base.extend({
+  /**
+    The key the store stores the data in.
+
+    @property key
+    @type String
+    @default 'ember_simple_auth:session'
+  */
+  key: 'ember_simple_auth:session',
+
+  /**
+    @method init
+    @private
+  */
+  init: function() {
+    this.key = Configuration.sessionStorageKey;
+
+    this.bindToStorageEvents();
+  },
+
+  /**
+    Persists the `data` in the `sessionStorage`.
+
+    @method persist
+    @param {Object} data The data to persist
+  */
+  persist: function(data) {
+    data = JSON.stringify(data || {});
+    sessionStorage.setItem(this.key, data);
+    this._lastData = this.restore();
+  },
+
+  /**
+    Restores all data currently saved in the `sessionStorage` identified by the
+    `keyPrefix` as one plain object.
+
+    @method restore
+    @return {Object} All data currently persisted in the `sessionStorage`
+  */
+  restore: function() {
+    var data = sessionStorage.getItem(this.key);
+    return JSON.parse(data) || {};
+  },
+
+  /**
+    Clears the store by deleting all `sessionStorage` keys prefixed with the
+    `keyPrefix`.
+
+    @method clear
+  */
+  clear: function() {
+    sessionStorage.removeItem(this.key);
+    this._lastData = {};
+  },
+
+  /**
+    @method bindToStorageEvents
+    @private
+  */
+  bindToStorageEvents: function() {
+    var _this = this;
+    Ember.$(window).bind('storage', function(e) {
+      var data = _this.restore();
+      if (!objectsAreEqual(data, _this._lastData)) {
+        _this._lastData = data;
+        _this.trigger('sessionDataUpdated', data);
+      }
+    });
+  }
+});

--- a/packages/ember-simple-auth/tests/simple-auth/stores/session-storage-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/stores/session-storage-test.js
@@ -1,0 +1,24 @@
+import SessionStorage from 'simple-auth/stores/session-storage';
+import Configuration from 'simple-auth/configuration';
+import itBehavesLikeAStore from './shared/store-behavior';
+
+describe('Stores.SessionStorage', function() {
+  beforeEach(function() {
+    this.store = SessionStorage.create();
+    this.store.clear();
+  });
+
+  itBehavesLikeAStore();
+
+  describe('initilization', function() {
+    it('defaults key to "ember_simple_auth:session"', function() {
+      expect(SessionStorage.create().key).to.eq('ember_simple_auth:session');
+    });
+
+    it('assigns sessionStorageKey from the configuration object', function() {
+      Configuration.sessionStorageKey = 'sessionStorageKey';
+
+      expect(SessionStorage.create().key).to.eq('sessionStorageKey');
+    });
+  });
+});


### PR DESCRIPTION
This implements a new store, the sessionStorage store, which may be better in some use cases than persisting auth tokens indefinitely in localStorage.
