### PR TITLE
Add support for OAuth scopes to OAuth2 authenticator

### DIFF
--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
@@ -119,11 +119,11 @@ export default Base.extend({
   },
 
   /**
-    Authenticates the session with the specified `credentials`; the credentials
+    Authenticates the session with the specified `options`; the options
     are send via a _"POST"_ request to the
     [`Authenticators.OAuth2#serverTokenEndpoint`](#SimpleAuth-Authenticators-OAuth2-serverTokenEndpoint)
     and if they are valid the server returns an access token in response (see
-    http://tools.ietf.org/html/rfc6749#section-4.3). __If the credentials are
+    http://tools.ietf.org/html/rfc6749#section-4.3). __If the options are
     valid and authentication succeeds, a promise that resolves with the
     server's response is returned__, otherwise a promise that rejects with the
     error is returned.
@@ -134,13 +134,20 @@ export default Base.extend({
     [`Authenticators.OAuth2#refreshAccessTokens`](#SimpleAuth-Authenticators-OAuth2-refreshAccessTokens)).
 
     @method authenticate
-    @param {Object} credentials The credentials to authenticate the session with
+    @param {Object} options
+    @param {String} options.identification The resource owner username
+    @param {String} options.password The resource owner password
+    @param {String|Array} [options.scope] The scope of the access request (see [RFC 6749, section 3.3](http://tools.ietf.org/html/rfc6749#section-3.3))
     @return {Ember.RSVP.Promise} A promise that resolves when an access token is successfully acquired from the server and rejects otherwise
   */
-  authenticate: function(credentials) {
+  authenticate: function(options) {
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      var data = { grant_type: 'password', username: credentials.identification, password: credentials.password };
+      var data = { grant_type: 'password', username: options.identification, password: options.password };
+      if (!Ember.isEmpty(options.scope)) {
+        var scopesString = Ember.makeArray(options.scope).join(' ');
+        Ember.merge(data, { scope: scopesString });
+      }
       _this.makeRequest(_this.serverTokenEndpoint, data).then(function(response) {
         Ember.run(function() {
           var expiresAt = _this.absolutizeExpirationTime(response.expires_in);

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
@@ -169,6 +169,24 @@ describe('OAuth2', function() {
       });
     });
 
+    it('sends a single OAuth scope to the token endpoint', function(done) {
+      this.authenticator.authenticate({ identification: 'username', password: 'password', scope: 'public' });
+
+      Ember.run.next(function() {
+        expect(Ember.$.ajax.getCall(0).args[0].data.scope).to.eql('public');
+        done();
+      });
+    });
+
+    it('sends multiple OAuth scopes to the token endpoint', function(done) {
+      this.authenticator.authenticate({ identification: 'username', password: 'password', scope: ['public', 'private'] });
+
+      Ember.run.next(function() {
+        expect(Ember.$.ajax.getCall(0).args[0].data.scope).to.eql('public private');
+        done();
+      });
+    });
+
     describe('when the authentication request is successful', function() {
       beforeEach(function() {
         this.server.respondWith('POST', '/token', [


### PR DESCRIPTION
This PR adds support for OAuth scopes as described in [Resource Owner Password Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.3.2).

To use scopes one will need to implement the `authenticate` action on their login controller (instead of using ember-simple-auth's login controller mixin):

``` js
import AuthenticationControllerMixin from 'simple-auth/mixins/authentication-controller-mixin';

export default Ember.Controller.extend(AuthenticationControllerMixin, {
  authenticator: 'simple-auth-authenticator:oauth2-password-grant'

  actions: {
    authenticate: function() {
      var data = this.getProperties('identification', 'password', 'scope'); // note the `scope` property
      this.set('password', null);
      return this._super(data);
    }
  }
});
```

closes #355 
