### PR TITLE
Invoke send on route instead of transition object.

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -1,5 +1,7 @@
 import Configuration from './../configuration';
 
+var routeEntryComplete = false;
+
 /**
   The mixin for the application route; defines actions to authenticate the
   session as well as to invalidate it. These actions can be used in all
@@ -58,6 +60,15 @@ import Configuration from './../configuration';
 */
 export default Ember.Mixin.create({
   /**
+    @method activate
+    @private
+  */
+  activate: function () {
+    routeEntryComplete = true;
+    this._super();
+  },
+
+  /**
     @method beforeModel
     @private
   */
@@ -75,7 +86,8 @@ export default Ember.Mixin.create({
       ]).forEach(function(event) {
         _this.get(Configuration.sessionPropertyName).on(event, function(error) {
           Array.prototype.unshift.call(arguments, event);
-          transition.send.apply(transition, arguments);
+          var target = routeEntryComplete ? _this : transition;
+          target.send.apply(target, arguments);
         });
       });
     }

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
@@ -15,18 +15,37 @@ describe('ApplicationRouteMixin', function() {
     }).create({ session: this.session });
   });
 
-  describe('#beforeModel', function() {
+  describe('#beforeModel without active route', function () {
     beforeEach(function() {
       this.transition = { send: function() {}, isActive: false };
       sinon.spy(this.transition, 'send');
       this.route.beforeModel(this.transition);
     });
 
+    it("calls 'send' on the transition object if a route has not been entered yet", function (done) {
+      this.session.trigger('authorizationFailed');
+
+      Ember.run.next(this, function () {
+        expect(this.transition.send).to.have.been.calledWith('authorizationFailed');
+        done();
+      });
+    });
+  });
+
+  describe('#beforeModel', function() {
+    beforeEach(function() {
+      this.transition = { send: function() {}, isActive: false };
+      sinon.spy(this.route, 'send');
+      sinon.spy(this.transition, 'send');
+      this.route.beforeModel(this.transition);
+      this.route.activate();
+    });
+
     it("translates the session's 'sessionAuthenticationSucceeded' event into an action invocation", function(done) {
       this.session.trigger('sessionAuthenticationSucceeded');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledWith('sessionAuthenticationSucceeded');
+        expect(this.route.send).to.have.been.calledWith('sessionAuthenticationSucceeded');
         done();
       });
     });
@@ -35,7 +54,7 @@ describe('ApplicationRouteMixin', function() {
       this.session.trigger('sessionAuthenticationFailed', 'error');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledWith('sessionAuthenticationFailed', 'error');
+        expect(this.route.send).to.have.been.calledWith('sessionAuthenticationFailed', 'error');
         done();
       });
     });
@@ -44,7 +63,7 @@ describe('ApplicationRouteMixin', function() {
       this.session.trigger('sessionInvalidationSucceeded');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledWith('sessionInvalidationSucceeded');
+        expect(this.route.send).to.have.been.calledWith('sessionInvalidationSucceeded');
         done();
       });
     });
@@ -53,7 +72,7 @@ describe('ApplicationRouteMixin', function() {
       this.session.trigger('sessionInvalidationFailed', 'error');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledWith('sessionInvalidationFailed', 'error');
+        expect(this.route.send).to.have.been.calledWith('sessionInvalidationFailed', 'error');
         done();
       });
     });
@@ -62,7 +81,7 @@ describe('ApplicationRouteMixin', function() {
       this.session.trigger('authorizationFailed');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledWith('authorizationFailed');
+        expect(this.route.send).to.have.been.calledWith('authorizationFailed');
         done();
       });
     });
@@ -72,7 +91,7 @@ describe('ApplicationRouteMixin', function() {
       this.session.trigger('sessionAuthenticationSucceeded');
 
       Ember.run.next(this, function() {
-        expect(this.transition.send).to.have.been.calledOnce;
+        expect(this.route.send).to.have.been.calledOnce;
         done();
       });
     });


### PR DESCRIPTION
Currently a `Transition` object is being closed over the first time the `beforeModel` hook is called on the `ApplicationRouteMixin`.  If a different route overrides one of the action handlers (e.g., `authenticationFailed`), it may not be invoked because `transition.send()` will start looking for action handlers on the target of the transition object that is being held onto instead of the currently active route.

Changing this to call `send()` on the route object provides the expected behavior of starting the search on the active route.

I discovered this while looking into https://github.com/TryGhost/Ghost/pull/3492
