### PR TITLE
Change default devise tokenAttributeName to token

### DIFF
--- a/packages/ember-simple-auth-devise/README.md
+++ b/packages/ember-simple-auth-devise/README.md
@@ -64,7 +64,7 @@ class SessionsController < Devise::SessionsController
         self.resource = warden.authenticate!(auth_options)
         sign_in(resource_name, resource)
         data = {
-          user_token: self.resource.authentication_token,
+          token: self.resource.authentication_token,
           user_email: self.resource.email
         }
         render json: data, status: 201

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -52,9 +52,9 @@ export default Base.extend({
 
     @property tokenAttributeName
     @type String
-    @default 'user_token'
+    @default 'token'
   */
-  tokenAttributeName: 'user_token',
+  tokenAttributeName: 'token',
 
   /**
     The identification attribute name.
@@ -81,7 +81,7 @@ export default Base.extend({
 
   /**
     Restores the session from a set of session properties; __will return a
-    resolving promise when there's a non-empty `user_token` and a non-empty
+    resolving promise when there's a non-empty `token` and a non-empty
     `user_email` in the `properties`__ and a rejecting promise otherwise.
 
     @method restore

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
@@ -2,8 +2,7 @@ import Base from 'simple-auth/authorizers/base';
 import Configuration from './../configuration';
 
 /**
-  Authenticator that works with the Ruby gem
-  [Devise](https://github.com/plataformatec/devise) by sending the `user_token`
+  Authenticator that works with Rails by sending the `token`
   and `user_email` properties from the session in the `Authorization` header.
 
   __As token authentication is not actually part of devise anymore, the server
@@ -27,9 +26,9 @@ export default Base.extend({
 
     @property tokenAttributeName
     @type String
-    @default 'user_token'
+    @default 'token'
   */
-  tokenAttributeName: 'user_token',
+  tokenAttributeName: 'token',
 
   /**
     The identification attribute name.
@@ -44,7 +43,7 @@ export default Base.extend({
   identificationAttributeName: 'user_email',
 
   /**
-    Authorizes an XHR request by sending the `user_token` and `user_email`
+    Authorizes an XHR request by sending the `token` and `user_email`
     properties from the session in the `Authorization` header:
 
     ```

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/configuration.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/configuration.js
@@ -3,7 +3,7 @@ import loadConfig from 'simple-auth/utils/load-config';
 var defaults = {
   serverTokenEndpoint:         '/users/sign_in',
   resourceName:                'user',
-  tokenAttributeName:          'user_token',
+  tokenAttributeName:          'token',
   identificationAttributeName: 'user_email'
 };
 
@@ -54,7 +54,7 @@ export default {
     @readOnly
     @static
     @type String
-    @default 'user_token'
+    @default 'token'
   */
   tokenAttributeName: defaults.tokenAttributeName,
 

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
@@ -48,10 +48,10 @@ describe('Devise', function() {
       ]);
     });
 
-    context('when the data contains a user_token and user_email', function() {
+    context('when the data contains a token and user_email', function() {
       it('resolves with the correct data', function(done) {
-        this.authenticator.restore({ "user_token": 'secret token!', "user_email": "user@email.com" }).then(function(content){
-          expect(content).to.eql({ "user_token": "secret token!", "user_email": "user@email.com" });
+        this.authenticator.restore({ "token": 'secret token!', "user_email": "user@email.com" }).then(function(content){
+          expect(content).to.eql({ "token": "secret token!", "user_email": "user@email.com" });
           done();
         });
       });

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
@@ -45,16 +45,16 @@ describe('Devise', function() {
         this.authorizer.set('session.isAuthenticated', true);
       });
 
-      context('when the session contains a non empty user_token and user_email', function() {
+      context('when the session contains a non empty token and user_email', function() {
         beforeEach(function() {
-          this.authorizer.set('session.user_token', 'secret token!');
+          this.authorizer.set('session.token', 'secret token!');
           this.authorizer.set('session.user_email', 'user@email.com');
         });
 
-        it('adds the "user_token" and "user_email" query string fields to the request', function() {
+        it('adds the "token" and "user_email" query string fields to the request', function() {
           this.authorizer.authorize(this.request, {});
 
-          expect(this.request.setRequestHeader).to.have.been.calledWith('Authorization', 'Token user_token="secret token!", user_email="user@email.com"');
+          expect(this.request.setRequestHeader).to.have.been.calledWith('Authorization', 'Token token="secret token!", user_email="user@email.com"');
         });
       });
 
@@ -85,9 +85,9 @@ describe('Devise', function() {
         });
       });
 
-      context('when the session does not contain an user_token', function() {
+      context('when the session does not contain an token', function() {
         beforeEach(function() {
-          this.authorizer.set('session.user_token', null);
+          this.authorizer.set('session.token', null);
         });
 
         itDoesNotAuthorizeTheRequest();

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/configuration-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/configuration-test.js
@@ -18,8 +18,8 @@ describe('Configuration', function() {
   });
 
   describe('tokenAttributeName', function() {
-    it('defaults to "user_token"', function() {
-      expect(Configuration.tokenAttributeName).to.eql('user_token');
+    it('defaults to "token"', function() {
+      expect(Configuration.tokenAttributeName).to.eql('token');
     });
   });
 


### PR DESCRIPTION
Changes the default devise ```tokenAttributeName``` to ```token```.
Works out of the box with [the rails implementation of HTTP token authentication](https://github.com/rails/rails/blob/25b14b4d3238d5474c60826ee1b359537af987ef/actionpack/lib/action_controller/metal/http_authentication.rb#L400) and the  ```authenticate_with_http_token``` method from the current README.

See #387 for more details.