### PR TITLE
Authorize cross domain requests to all subdomain of host using wildcard

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -3,10 +3,17 @@ import Session from './session';
 import LocalStorage from './stores/local-storage';
 import Ephemeral from './stores/ephemeral';
 
+var wildcardToken = "WILDCARD_TOKEN";
+
 function extractLocationOrigin(location) {
-  if (location.indexOf("*") > -1){
+  if (location === "*"){
       return location;
   }
+
+  if (location.indexOf("*") > -1) {
+    location = location.replace("*", wildcardToken);
+  }
+
   if (Ember.typeOf(location) === 'string') {
     var link = document.createElement('a');
     link.href = location;
@@ -26,8 +33,8 @@ function extractLocationOrigin(location) {
 
 function matchDomain(urlOrigin){
   return function(domain) {
-    if (domain.indexOf('*') > -1) {
-      var domainRegex = new RegExp(domain.replace("*" , ".+"));
+    if (domain.indexOf(wildcardToken) > -1) {
+      var domainRegex = new RegExp(domain.replace(wildcardToken , ".+"));
       return urlOrigin.match(domainRegex);
     }
 

--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -10,9 +10,7 @@ function extractLocationOrigin(location) {
       return location;
   }
 
-  if (location.indexOf('*') > -1) {
-    location = location.replace('*', wildcardToken);
-  }
+  location = location.replace('*', wildcardToken);
 
   if (Ember.typeOf(location) === 'string') {
     var link = document.createElement('a');

--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -6,12 +6,12 @@ import Ephemeral from './stores/ephemeral';
 var wildcardToken = "WILDCARD_TOKEN";
 
 function extractLocationOrigin(location) {
-  if (location === "*"){
+  if (location === '*'){
       return location;
   }
 
-  if (location.indexOf("*") > -1) {
-    location = location.replace("*", wildcardToken);
+  if (location.indexOf('*') > -1) {
+    location = location.replace('*', wildcardToken);
   }
 
   if (Ember.typeOf(location) === 'string') {
@@ -34,7 +34,7 @@ function extractLocationOrigin(location) {
 function matchDomain(urlOrigin){
   return function(domain) {
     if (domain.indexOf(wildcardToken) > -1) {
-      var domainRegex = new RegExp(domain.replace(wildcardToken , ".+"));
+      var domainRegex = new RegExp(domain.replace(wildcardToken , '.+'));
       return urlOrigin.match(domainRegex);
     }
 

--- a/packages/ember-simple-auth/tests/simple-auth/setup-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/setup-test.js
@@ -202,6 +202,10 @@ describe('setup', function() {
         Ember.$.get('http://test2.sub.test-domain.com:1234/path/query=string');
 
         expect(this.authorizer.authorize).to.have.been.callCount(5);
+
+        Ember.$.get('http://test2.sub.test-domain.com:1235/path/query=string');
+
+        expect(this.authorizer.authorize).to.not.have.been.callCount(6);
       });
 
       afterEach(function() {

--- a/packages/ember-simple-auth/tests/simple-auth/setup-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/setup-test.js
@@ -168,6 +168,22 @@ describe('setup', function() {
         expect(this.authorizer.authorize).to.have.been.calledThrice;
       });
 
+      it('authorizes requests going to a foreign origin if the hosts on whitelist allow subdomain to origin', function() {
+        Configuration.crossOriginWhitelist = ['http://*.other-domain.com'];
+        setup(this.container, this.application);
+        Ember.$.get('http://test.other-domain.com/path/query=string');
+
+        expect(this.authorizer.authorize).to.have.been.calledOnce;
+
+        Ember.$.get('http://another-test.other-domain.com/path/query=string');
+
+        expect(this.authorizer.authorize).to.have.been.calledTwice;
+
+        Ember.$.get('http://test2.other-domain.com/path/query=string');
+
+        expect(this.authorizer.authorize).to.have.been.calledThrice;
+      });
+
       afterEach(function() {
         this.authorizer.isDestroyed = false;
       });

--- a/packages/ember-simple-auth/tests/simple-auth/setup-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/setup-test.js
@@ -169,7 +169,7 @@ describe('setup', function() {
       });
 
       it('authorizes requests going to a foreign origin if the hosts on whitelist allow subdomain to origin', function() {
-        Configuration.crossOriginWhitelist = ['http://*.other-domain.com'];
+        Configuration.crossOriginWhitelist = ['http://*.other-domain.com', 'http://*.sub.test-domain.com:1234'];
         setup(this.container, this.application);
         Ember.$.get('http://test.other-domain.com/path/query=string');
 
@@ -182,6 +182,26 @@ describe('setup', function() {
         Ember.$.get('http://test2.other-domain.com/path/query=string');
 
         expect(this.authorizer.authorize).to.have.been.calledThrice;
+
+        Ember.$.get('http://test2.other-domain.com:80/path/query=string');
+
+        expect(this.authorizer.authorize).to.have.been.callCount(4);
+
+        Ember.$.get('http://another-port.other-domain.com:1234/path/query=string');
+
+        expect(this.authorizer.authorize).to.not.have.been.callCount(5);
+
+        Ember.$.get('http://test2.sub.test-domain.com/path/query=string');
+
+        expect(this.authorizer.authorize).to.not.have.been.callCount(5);
+
+        Ember.$.get('http://wrong.test2.test-domain.com:1234/path/query=string');
+
+        expect(this.authorizer.authorize).to.not.have.been.callCount(5);
+
+        Ember.$.get('http://test2.sub.test-domain.com:1234/path/query=string');
+
+        expect(this.authorizer.authorize).to.have.been.callCount(5);
       });
 
       afterEach(function() {


### PR DESCRIPTION
Add a easy to developers enable request for all subdomain, like

```
ENV['simple-auth'] = {
  crossOriginWhitelist: ['http://*.other.domain']
}
````

That is important for multitenancy application, in many cases the server get the correct client data by subdomain, today using simple-auth is necessary put a [*] on crossOriginWhitelist and check url on authorizer 