### PR TITLE
Use identificationAttributeName to send during auth

### DIFF
--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -58,6 +58,9 @@ import Configuration from './../configuration';
   /**
     The identification attribute name.
 
+    This is also the param that is sent to [serverTokenEndpoint]((#SimpleAuth-Configuration-Devise-serverTokenEndpoint)
+    during the authentication process.
+
     This value can be configured via
     [`SimpleAuth.Configuration.Devise#identificationAttributeName`](#SimpleAuth-Configuration-Devise-identificationAttributeName).
 
@@ -117,9 +120,10 @@ import Configuration from './../configuration';
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var data                 = {};
       data[_this.resourceName] = {
-        email:    credentials.identification,
         password: credentials.password
       };
+      data[_this.resourceName][_this.identificationAttributeName] = credentials.identification;
+
       _this.makeRequest(data).then(function(response) {
         Ember.run(function() {
           resolve(response);

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
@@ -91,7 +91,7 @@ describe('Devise', function() {
         expect(args).to.eql({
           url:      '/users/sign_in',
           type:     'POST',
-          data:     { user: { email: 'identification', password: 'password' } },
+          data:     { user: { user_email: 'identification', password: 'password' } },
           dataType: 'json',
         });
         done();


### PR DESCRIPTION
This is to support alternate identification attribute names that you may
use with Devise (such as `login`).