### PR TITLE
Store data in unauthenticated session

### DIFF
--- a/examples/1-simple.html
+++ b/examples/1-simple.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/10-devise.html
+++ b/examples/10-devise.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/11-amd.html
+++ b/examples/11-amd.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../vendor/loader.js"></script>

--- a/examples/12-torii.html
+++ b/examples/12-torii.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/beta/ember.js"></script>
     <script src="../vendor/loader.js"></script>

--- a/examples/2-errors.html
+++ b/examples/2-errors.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/3-token-refresh.html
+++ b/examples/3-token-refresh.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/4-authenticated-account.html
+++ b/examples/4-authenticated-account.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="http://builds.emberjs.com/beta/ember-data.js"></script>

--- a/examples/5-ember-data.html
+++ b/examples/5-ember-data.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="http://builds.emberjs.com/beta/ember-data.js"></script>

--- a/examples/6-custom-server.html
+++ b/examples/6-custom-server.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="http://builds.emberjs.com/beta/ember-data.js"></script>

--- a/examples/7-multiple-external-providers.html
+++ b/examples/7-multiple-external-providers.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="http://connect.facebook.net/en_US/all.js"></script>

--- a/examples/8-cookie-store.html
+++ b/examples/8-cookie-store.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/9-custom.html
+++ b/examples/9-custom.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <title>Ember Simple Auth - examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-    <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+    <script src="http://code.jquery.com/jquery-2.1.3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script src="http://builds.emberjs.com/release/ember.js"></script>
     <script src="../tmp/ember-simple-auth.js"></script>

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -82,13 +82,17 @@ export default Base.extend({
   /**
     Restores the session from a set of session properties; __will return a
     resolving promise when there's a non-empty `token` and a non-empty
-    `user_email` in the `properties`__ and a rejecting promise otherwise.
+    `user_email` in the `data`__ (or whatever has been configured for
+    [`SimpleAuth.Configuration.Devise#tokenAttributeName`](#SimpleAuth-Configuration-Devise-tokenAttributeName)
+    and
+    [`SimpleAuth.Configuration.Devise#identificationAttributeName`](#SimpleAuth-Configuration-Devise-identificationAttributeName))
+    and a rejecting promise otherwise.
 
     @method restore
-    @param {Object} properties The properties to restore the session from
+    @param {Object} data The current session data
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being authenticated
   */
-  restore: function(properties) {
+  restore: function(data) {
     var _this            = this;
     var propertiesObject = Ember.Object.create(properties);
     return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -142,6 +146,18 @@ export default Base.extend({
   */
   invalidate: function() {
     return Ember.RSVP.resolve();
+  },
+
+  /**
+    @method stripAuthenticatedData
+    @private
+  */
+  stripAuthenticatedData: function(data) {
+    delete data.access_token;
+    delete data.refresh_token;
+    delete data.expires_in;
+    delete data.expires_at;
+    return data;
   },
 
   /**

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -93,13 +93,13 @@ export default Base.extend({
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being authenticated
   */
   restore: function(data) {
-    var _this            = this;
-    var propertiesObject = Ember.Object.create(properties);
+    var _this      = this;
+    var dataObject = Ember.Object.create(data);
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      if (!Ember.isEmpty(propertiesObject.get(_this.tokenAttributeName)) && !Ember.isEmpty(propertiesObject.get(_this.identificationAttributeName))) {
-        resolve(properties);
+      if (!Ember.isEmpty(dataObject.get(_this.tokenAttributeName)) && !Ember.isEmpty(dataObject.get(_this.identificationAttributeName))) {
+        resolve(data);
       } else {
-        reject();
+        reject(_this.stripAuthenticatedData(data));
       }
     });
   },
@@ -139,13 +139,15 @@ export default Base.extend({
   },
 
   /**
-    Does nothing
+    Deletes the `token` and `user_email` properties from the session and
+    returns a resolving promise.
 
     @method invalidate
+    @param {Object} data The data of the session to be invalidated
     @return {Ember.RSVP.Promise} A resolving promise
   */
-  invalidate: function() {
-    return Ember.RSVP.resolve();
+  invalidate: function(data) {
+    return Ember.RSVP.resolve(this.stripAuthenticatedData(data || {}));
   },
 
   /**
@@ -153,10 +155,10 @@ export default Base.extend({
     @private
   */
   stripAuthenticatedData: function(data) {
-    delete data.access_token;
-    delete data.refresh_token;
-    delete data.expires_in;
-    delete data.expires_at;
+    Ember.A([this.tokenAttributeName, this.identificationAttributeName]).forEach(function(propertyName) {
+      var rootProperty = propertyName.split('.')[0];
+      delete data[rootProperty];
+    });
     return data;
   },
 

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
@@ -57,17 +57,51 @@ describe('Devise', function() {
       });
     });
 
-    context('when the data contains a custom token and email attribute', function() {
+    context('when the data does not contain a token and user_email', function() {
+      it('returns a rejecting promise', function(done) {
+        this.authenticator.restore().then(null, function(content){
+          expect(true).to.be.true;
+          done();
+        });
+      });
+
+      it('strips sensitivate data from the session data', function(done) {
+        this.authenticator.restore({ token: 'secret token!', some: 'property' }).then(null, function(data) {
+          expect(data).to.eql({ some: 'property' });
+          done();
+        });
+      });
+    });
+
+    context('custom token and identification attributes have been configured', function() {
       beforeEach(function() {
         Configuration.tokenAttributeName          = 'employee.token';
         Configuration.identificationAttributeName = 'employee.email';
         this.authenticator                        = Devise.create();
       });
 
-      it('resolves with the correct data', function(done) {
-        this.authenticator.restore({ employee: { token: 'secret token!', email: 'user@email.com' } }).then(function(content){
-          expect(content).to.eql({ employee: { token: 'secret token!', email: 'user@email.com' } });
-          done();
+      context('when the data contains values for token and identification', function() {
+        it('resolves with the correct data', function(done) {
+          this.authenticator.restore({ employee: { token: 'secret token!', email: 'user@email.com' } }).then(function(content){
+            expect(content).to.eql({ employee: { token: 'secret token!', email: 'user@email.com' } });
+            done();
+          });
+        });
+      });
+
+      context('when the data does not contain values for token and identifitication', function() {
+        it('returns a rejecting promise', function(done) {
+          this.authenticator.restore().then(null, function(content){
+            expect(true).to.be.true;
+            done();
+          });
+        });
+
+        it('strips sensitivate data from the session data', function(done) {
+          this.authenticator.restore({ employee: { token: 'secret token!' }, some: 'property' }).then(null, function(data) {
+            expect(data).to.eql({ some: 'property' });
+            done();
+          });
         });
       });
 
@@ -142,6 +176,13 @@ describe('Devise', function() {
     it('returns a resolving promise', function(done) {
       this.authenticator.invalidate().then(function() {
         expect(true).to.be.true;
+        done();
+      });
+    });
+
+    it('strips sensitivate data from the session data', function(done) {
+      this.authenticator.invalidate({ token: 'secret token!', some: 'property' }).then(function(data) {
+        expect(data).to.eql({ some: 'property' });
         done();
       });
     });

--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
@@ -92,7 +92,7 @@ export default Base.extend({
     [`Authenticators.OAuth2#refreshAccessTokens`](#SimpleAuth-Authenticators-OAuth2-refreshAccessTokens)).
 
     @method restore
-    @param {Object} data The data to restore the session from
+    @param {Object} data The current sesion data
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being authenticated
   */
   restore: function(data) {
@@ -173,8 +173,9 @@ export default Base.extend({
   },
 
   /**
-    Cancels any outstanding automatic token refreshes and returns a resolving
-    promise.
+    Cancels any outstanding automatic token refreshes, deletes the
+    `access_token`, `refresh_token`, `expires_in` and `expires_at` properties
+    from the session and returns a resolving promise.
 
     @method invalidate
     @param {Object} data The data of the session to be invalidated
@@ -231,6 +232,10 @@ export default Base.extend({
     });
   },
 
+  /**
+    @method stripAuthenticatedData
+    @private
+  */
   stripAuthenticatedData: function(data) {
     delete data.access_token;
     delete data.refresh_token;

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
@@ -71,6 +71,13 @@ describe('OAuth2', function() {
                 done();
               });
             });
+
+            it('strips sensitivate data from the session data', function(done) {
+              this.authenticator.restore({ access_token: 'access_token', expires_at: 1, some: 'property' }).then(null, function(data) {
+                expect(data).to.eql({ some: 'property' });
+                done();
+              });
+            });
           });
         });
 
@@ -82,6 +89,13 @@ describe('OAuth2', function() {
           it('returns a rejecting promise', function(done) {
             this.authenticator.restore({ access_token: 'secret token!', expires_at: 1 }).then(null, function() {
               expect(true).to.be.true;
+              done();
+            });
+          });
+
+          it('strips sensitivate data from the session data', function(done) {
+            this.authenticator.restore({ access_token: 'access_token', expires_at: 1, some: 'property' }).then(null, function(data) {
+              expect(data).to.eql({ some: 'property' });
               done();
             });
           });
@@ -103,6 +117,13 @@ describe('OAuth2', function() {
         it('returns a rejecting promise', function(done) {
           this.authenticator.restore().then(null, function() {
             expect(true).to.be.true;
+            done();
+          });
+        });
+
+        it('strips sensitivate data from the session data', function(done) {
+          this.authenticator.restore({ refresh_token: 'access_token', some: 'property' }).then(null, function(data) {
+            expect(data).to.eql({ some: 'property' });
             done();
           });
         });
@@ -290,6 +311,13 @@ describe('OAuth2', function() {
       it('returns a resolving promise', function(done) {
         this.authenticator.invalidate({ access_token: 'access token!' }).then(function() {
           expect(true).to.be.true;
+          done();
+        });
+      });
+
+      it('strips sensitivate data from the session data', function(done) {
+        this.authenticator.invalidate({ access_token: 'access_token', some: 'property' }).then(function(data) {
+          expect(data).to.eql({ some: 'property' });
           done();
         });
       });

--- a/packages/ember-simple-auth-torii/lib/simple-auth-torii/authenticators/torii.js
+++ b/packages/ember-simple-auth-torii/lib/simple-auth-torii/authenticators/torii.js
@@ -29,7 +29,7 @@ export default Base.extend({
     Restores the session by calling the torii provider's `fetch` method.
 
     @method restore
-    @param {Object} data The data to restore the session from
+    @param {Object} data The current session data
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being authenticated
   */
   restore: function(data) {
@@ -42,11 +42,11 @@ export default Base.extend({
           _this.resolveWith(provider, data, resolve);
         }, function() {
           delete _this.provider;
-          reject();
+          reject(data);
         });
       } else {
         delete _this.provider;
-        reject();
+        reject(data);
       }
     });
   },
@@ -82,8 +82,10 @@ export default Base.extend({
     return new Ember.RSVP.Promise(function(resolve, reject) {
       _this.torii.close(_this.provider).then(function() {
         delete _this.provider;
-        resolve();
-      }, reject);
+        resolve(data);
+      }, function() {
+        reject(data);
+      });
     });
   },
 

--- a/packages/ember-simple-auth-torii/tests/simple-auth-torii/authenticators/torii-test.js
+++ b/packages/ember-simple-auth-torii/tests/simple-auth-torii/authenticators/torii-test.js
@@ -15,6 +15,13 @@ describe('Torii', function() {
         });
       });
 
+      it('rejects with the passed session data', function(done) {
+        this.authenticator.restore(data).then(null, function(theData) {
+          expect(theData).to.eql(data);
+          done();
+        });
+      });
+
       it('unsets the provider', function(done) {
         var _this = this;
         this.authenticator.provider = 'provider';
@@ -57,7 +64,7 @@ describe('Torii', function() {
     });
 
     context('when there is no torii provider in the session data', function() {
-      itDoesNotRestore();
+      itDoesNotRestore({});
     });
   });
 
@@ -110,6 +117,13 @@ describe('Torii', function() {
         });
       });
 
+      it('resolves with the passed session data', function(done) {
+        this.authenticator.invalidate({ some: 'property' }).then(function(data) {
+          expect(data).to.eql({ some: 'property' });
+          done();
+        });
+      });
+
       it('unsets the provider', function(done) {
         var _this = this;
         this.authenticator.provider = 'provider';
@@ -122,12 +136,19 @@ describe('Torii', function() {
 
     context('when torii does not close successfully', function() {
       beforeEach(function() {
-        sinon.stub(this.torii, 'open').returns(Ember.RSVP.reject());
+        sinon.stub(this.torii, 'close').returns(Ember.RSVP.reject());
       });
 
       it('returns a rejecting promise', function(done) {
         this.authenticator.invalidate('provider').then(null, function() {
           expect(true).to.be.true;
+          done();
+        });
+      });
+
+      it('rejects with the passed session data', function(done) {
+        this.authenticator.invalidate({ some: 'property' }).then(null, function(data) {
+          expect(data).to.eql({ some: 'property' });
           done();
         });
       });

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -82,20 +82,24 @@ export default Ember.Object.extend(Ember.Evented, {
     session.
 
     __This method returns a promise. A resolving promise will result in the
-    session being authenticated.__ Any properties the promise resolves with
-    will be saved in and accessible via the session. In most cases the `data`
-    argument will simply be forwarded through the promise. A rejecting promise
-    indicates that authentication failed and the session will remain unchanged.
+    session being authenticated.__ A rejecting promise indicates that the
+    passed session data does not constitute an authenticated session and the
+    session will remain unauthenticated. In any case the data that the returned
+    promise resolves or rejects with will replace the current session data.
+    That means when returning a rejecting pormise that leads to the session
+    being invalidated or remaining unauthenticated, the authenticator has to
+    make sure to delete any sensitive data (e.g. access tokens etc.) from the
+    session data first.
 
     `SimpleAuth.Authenticators.Base`'s implementation always returns a
-    rejecting promise.
+    rejecting promise that rejects with the passed session data.
 
     @method restore
-    @param {Object} data The data to restore the session from
+    @param {Object} data The current session data
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being authenticated
   */
   restore: function(data) {
-    return Ember.RSVP.reject();
+    return Ember.RSVP.reject(data);
   },
 
   /**
@@ -108,8 +112,12 @@ export default Ember.Object.extend(Ember.Evented, {
 
     __This method returns a promise. A resolving promise will result in the
     session being authenticated.__ Any properties the promise resolves with
-    will be saved in and accessible via the session. A rejecting promise
+    will be saved in and be accessible via the session. A rejecting promise
     indicates that authentication failed and the session will remain unchanged.
+    A rejecting promise should reject with an error that will then be
+    propagated to the session's
+    [`sessionAuthenticationFailed`](#SimpleAuth-Session-sessionAuthenticationFailed)
+    event.
 
     `SimpleAuth.Authenticators.Base`'s implementation always returns a
     rejecting promise and thus never authenticates the session.
@@ -132,6 +140,11 @@ export default Ember.Object.extend(Ember.Evented, {
     __This method returns a promise. A resolving promise will result in the
     session being invalidated.__ A rejecting promise will result in the session
     invalidation being intercepted and the session being left authenticated.
+    In any case the data that the returned promise resolves or rejects with
+    will replace the current session data. That means when returning a
+    resolving pormise that leads to the session being invalidated, the
+    authenticator has to make sure to delete any sensitive data (e.g. access
+    tokens etc.) from the session data first.
 
     `SimpleAuth.Authenticators.Base`'s implementation always returns a
     resolving promise and thus never intercepts session invalidation.

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -154,6 +154,6 @@ export default Ember.Object.extend(Ember.Evented, {
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
   */
   invalidate: function(data) {
-    return Ember.RSVP.resolve();
+    return Ember.RSVP.resolve(data);
   }
 });

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -184,8 +184,9 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     the session was successfully invalidated__ while a rejecting promise
     indicates that the promise returned by the `authenticator` rejected and
     thus invalidation was cancelled. In that case the session remains
-    authenticated. Once the session is successfully invalidated it clears all
-    of its data.
+    authenticated. When the authenticator successfully invalidates the session
+    it will also delete all secure data from the session, e.g. access tokens
+    etc.
 
     @method invalidate
     @return {Ember.RSVP.Promise} A promise that resolves when the session was invalidated successfully
@@ -239,7 +240,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   setup: function(authenticator, content, mergeContent) {
     mergeContent = mergeContent || false;
     if (mergeContent) {
-      content = Ember.merge(Ember.merge({}, this.content), content);
+      content = Ember.merge(Ember.merge({}, this.content), content || {});
     }
     this.beginPropertyChanges();
     this.setProperties({

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -163,7 +163,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     Ember.assert('No authenticator for factory "' + authenticator + '" could be found', !Ember.isNone(theAuthenticator));
     return new Ember.RSVP.Promise(function(resolve, reject) {
       theAuthenticator.authenticate.apply(theAuthenticator, args).then(function(content) {
-        _this.setupAuthenticated(authenticator, content, true);
+        _this.setAuthenticated(authenticator, content, true);
         resolve();
       }, function(error) {
         _this.trigger('sessionAuthenticationFailed', error);
@@ -253,10 +253,10 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   },
 
   /**
-    @method setupAuthenticated
+    @method setAuthenticated
     @private
   */
-  setupAuthenticated: function(authenticator, content, mergeContent) {
+  setAuthenticated: function(authenticator, content, mergeContent) {
     var trigger = !this.get('isAuthenticated');
     this.setup(authenticator, content, mergeContent);
     if (trigger) {
@@ -321,7 +321,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       if (!!authenticator) {
         delete content.authenticator;
         _this.container.lookup(authenticator).restore(content).then(function(content) {
-          _this.setupAuthenticated(authenticator, content);
+          _this.setAuthenticated(authenticator, content);
         }, function(content) {
           succeedInvalidation(content);
         });

--- a/packages/ember-simple-auth/tests/simple-auth/authenticators/base-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/authenticators/base-test.js
@@ -14,9 +14,9 @@ describe('Authenticators.Base', function() {
     });
 
     it('rejects with the passed data', function(done) {
-      this.authenticator.restore({ some: 'property' }).then(null, function() {
-        expect(true).to.be.true;
-        done({ some: 'property' });
+      this.authenticator.restore({ some: 'property' }).then(null, function(data) {
+        expect(data).to.eql({ some: 'property' });
+        done();
       });
     });
   });
@@ -34,6 +34,13 @@ describe('Authenticators.Base', function() {
     it('returns a resolving promise', function(done) {
       this.authenticator.invalidate().then(function() {
         expect(true).to.be.true;
+        done();
+      });
+    });
+
+    it('resolves with the passed data', function(done) {
+      this.authenticator.invalidate({ some: 'property' }).then(function(data) {
+        expect(data).to.eql({ some: 'property' });
         done();
       });
     });

--- a/packages/ember-simple-auth/tests/simple-auth/authenticators/base-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/authenticators/base-test.js
@@ -12,6 +12,13 @@ describe('Authenticators.Base', function() {
         done();
       });
     });
+
+    it('rejects with the passed data', function(done) {
+      this.authenticator.restore({ some: 'property' }).then(null, function() {
+        expect(true).to.be.true;
+        done({ some: 'property' });
+      });
+    });
   });
 
   describe('#authenticate', function() {


### PR DESCRIPTION
See #383

Right now Ember Simple Auth allows storing data also in the unauthenticated session but when the session is restored that data is completely ignored. This branch refactors the session/authenticators interplay so that no data gets lost.

### Concept

As both the authenticator's `restore` and `invalidate` method receive the session's current content as an argument it would make sense to - if that session content doesn't constitute an authenticated state which is the authenticator's task to decide anyway - have the authenticator remove the security-relevant attributes from the session content (which would in most cases be the token and if not then the authenticator would know which attributes have to be removed, e.g. expiration times or refresh tokens in the case of the OAuth 2.0 authenticator), resolve or reject with that updated session content and in the session itself simply replace its content with whatever comes back from the authenticator and never completely clear itself (although it probably makes sense to have a method in the public API for that). That solution would have several advantages:

- the public API doesn't need to change
- no new concepts like anonymous authenticators etc. have to be introduced
- the session actually behaves like a real session in the way that it keeps data regardless of whether it's authenticated or not

There's 2 drawbacks that I would consider ok for a pre 1.0 release though:

- custom authenticators would potentially have to be changed so that they always resolve or reject with the updated session content and also delete relevant attributes from it in the `restore` and `invalidate` methods
- if data is persisted in the session that's relevant to security but the authenticator is unaware of, that data would have to be deleted manually (in the `sessionInvalidationSucceeded` action if using the `ApplicationRouteMixin` or by handling the session's `sessionInvalidationSucceeded` event)

### TODO

- [ ] review docs to make sure the new behavior is correctly reflected
- [ ] add docs for the torii authenticator mentioning the need to cleanup the session manually
- [ ] add a new example that shows how to store data in the session manually
- [ ] this seems to break the existing examples somehow so those need to be fixed of course