### PR TITLE
Fixed 'approval_prompt' in ext. provider example

### DIFF
--- a/examples/7-multiple-external-providers.html
+++ b/examples/7-multiple-external-providers.html
@@ -163,7 +163,7 @@
             gapi.auth.authorize({
               client_id:        '694766332436-1g5bakjoo5flkfpv3t2mfsch9ghg7ggd.apps.googleusercontent.com',
               scope:            ['https://www.googleapis.com/auth/plus.me'],
-              'approvalprompt': 'force',
+              'approval_prompt': 'force',
               immediate:        false
             }, function(authResult) {
               if (authResult && !authResult.error) {


### PR DESCRIPTION
I believe this is a typo that prevented logging in with Google from working.