### PR TITLE
Store secure session data under a special key

### DIFF
--- a/examples/3-token-refresh.html
+++ b/examples/3-token-refresh.html
@@ -48,7 +48,7 @@
       </div>
       {{#if session.isAuthenticated}}
       <div class="alert alert-info">
-        The token is automatically refreshed every 5 to 10 seconds, it currently is: <code>{{ session.access_token }}</code>.
+        The token is automatically refreshed every 5 to 10 seconds, it currently is: <code>{{ session.secure.access_token }}</code>.
       </div>
       {{else}}
         <div class="alert alert-info">

--- a/examples/4-authenticated-account.html
+++ b/examples/4-authenticated-account.html
@@ -131,11 +131,11 @@
       // the custom session that handles an authenticated account
       App.CustomSession = SimpleAuth.Session.extend({
         account: function() {
-          var accountId = this.get('account_id');
+          var accountId = this.get('secure.account_id');
           if (!Ember.isEmpty(accountId)) {
             return this.container.lookup('store:main').find('account', accountId);
           }
-        }.property('account_id')
+        }.property('secure.account_id')
       });
 
       // the custom authenticator that handles the authenticated account

--- a/examples/6-custom-server.html
+++ b/examples/6-custom-server.html
@@ -162,8 +162,8 @@
       // the custom authorizer that authorizes requests against the custom server
       App.CustomAuthorizer = SimpleAuth.Authorizers.Base.extend({
         authorize: function(jqXHR, requestOptions) {
-          if (this.get('session.isAuthenticated') && !Ember.isEmpty(this.get('session.token'))) {
-            jqXHR.setRequestHeader('Authorization', 'Token: ' + this.get('session.token'));
+          if (this.get('session.isAuthenticated') && !Ember.isEmpty(this.get('session.secure.token'))) {
+            jqXHR.setRequestHeader('Authorization', 'Token: ' + this.get('session.secure.token'));
           }
         }
       });

--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
@@ -66,8 +66,9 @@ export default Base.extend({
   },
 
   authorize: function(jqXHR, requestOptions) {
-    var userToken          = this.get('session').get(this.tokenAttributeName);
-    var userIdentification = this.get('session').get(this.identificationAttributeName);
+    var secureData         = this.get('session.secure');
+    var userToken          = secureData[this.tokenAttributeName];
+    var userIdentification = secureData[this.identificationAttributeName];
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(userToken) && !Ember.isEmpty(userIdentification)) {
       var authData = this.tokenAttributeName + '="' + userToken + '", ' + this.identificationAttributeName + '="' + userIdentification + '"';
       jqXHR.setRequestHeader('Authorization', 'Token ' + authData);

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
@@ -47,8 +47,8 @@ describe('Devise', function() {
 
       context('when the session contains a non empty token and email', function() {
         beforeEach(function() {
-          this.authorizer.set('session.token', 'secret token!');
-          this.authorizer.set('session.email', 'user@email.com');
+          this.authorizer.set('session.secure.token', 'secret token!');
+          this.authorizer.set('session.secure.email', 'user@email.com');
         });
 
         it('adds the "token" and "email" query string fields to the request', function() {
@@ -69,8 +69,8 @@ describe('Devise', function() {
         context('when the session contains a non empty employee_token and employee_email', function() {
           beforeEach(function() {
             this.authorizer.set('session', this.session);
-            this.authorizer.set('session.employee_token', 'secret token!');
-            this.authorizer.set('session.employee_email', 'user@email.com');
+            this.authorizer.set('session.secure.employee_token', 'secret token!');
+            this.authorizer.set('session.secure.employee_email', 'user@email.com');
           });
 
           it('adds the "employee_token" and "employee_email" query string fields to the request', function() {
@@ -87,7 +87,7 @@ describe('Devise', function() {
 
       context('when the session does not contain an token', function() {
         beforeEach(function() {
-          this.authorizer.set('session.token', null);
+          this.authorizer.set('session.secure.token', null);
         });
 
         itDoesNotAuthorizeTheRequest();
@@ -95,7 +95,7 @@ describe('Devise', function() {
 
       context('when the session does not contain an email', function() {
         beforeEach(function() {
-          this.authorizer.set('session.email', null);
+          this.authorizer.set('session.secure.email', null);
         });
 
         itDoesNotAuthorizeTheRequest();

--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authorizers/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authorizers/oauth2.js
@@ -28,7 +28,7 @@ export default Base.extend({
     @param {Object} requestOptions The options as provided to the `$.ajax` method (see http://api.jquery.com/jQuery.ajaxPrefilter/)
   */
   authorize: function(jqXHR, requestOptions) {
-    var accessToken = this.get('session.access_token');
+    var accessToken = this.get('session.secure.access_token');
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(accessToken)) {
       jqXHR.setRequestHeader('Authorization', 'Bearer ' + accessToken);
     }

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authorizers/oauth2-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authorizers/oauth2-test.js
@@ -28,7 +28,7 @@ describe('OAuth2', function() {
 
       context('when the session contains a non empty access_token', function() {
         beforeEach(function() {
-          this.authorizer.set('session.access_token', 'secret token!');
+          this.authorizer.set('session.secure.access_token', 'secret token!');
         });
 
         it('adds the "Authorization" header to the request', function() {
@@ -40,7 +40,7 @@ describe('OAuth2', function() {
 
       context('when the session does not contain an access_token', function() {
         beforeEach(function() {
-          this.authorizer.set('session.access_token', null);
+          this.authorizer.set('session.secure.access_token', null);
         });
 
         itDoesNotAuthorizeTheRequest();

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -54,9 +54,9 @@ export default Ember.Object.extend(Ember.Evented, {
   /**
     __Triggered when the data that constitutes the session is updated by the
     authenticator__. This might happen e.g. because the authenticator refreshes
-    it or an event from is triggered from an external authentication provider.
-    The session automatically catches that event, passes the updated data back
-    to the authenticator's
+    it or an event is triggered from an external authentication provider. The
+    session automatically catches that event, passes the updated data back to
+    the authenticator's
     [SimpleAuth.Authenticators.Base#restore](#SimpleAuth-Authenticators-Base-restore)
     method and handles the result of that invocation accordingly.
 

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -70,7 +70,6 @@ export default Ember.Object.extend(Ember.Evented, {
     automatically catches that event and invalidates itself.
 
     @event sessionDataInvalidated
-    @param {Object} data The updated session data
   */
 
   /**

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -82,9 +82,10 @@ export default Ember.Object.extend(Ember.Evented, {
 
     __This method returns a promise. A resolving promise will result in the
     session being authenticated.__ Any properties the promise resolves with
-    will be saved in and accessible via the session. In most cases the `data`
-    argument will simply be forwarded through the promise. A rejecting promise
-    indicates that authentication failed and the session will remain unchanged.
+    will be saved in and accessible via the session's `secure` property. In
+    most cases the `data` argument will simply be forwarded through the
+    promise. A rejecting promise indicates that authentication failed and the
+    session will remain unchanged.
 
     `SimpleAuth.Authenticators.Base`'s implementation always returns a
     rejecting promise.
@@ -107,8 +108,9 @@ export default Ember.Object.extend(Ember.Evented, {
 
     __This method returns a promise. A resolving promise will result in the
     session being authenticated.__ Any properties the promise resolves with
-    will be saved in and accessible via the session. A rejecting promise
-    indicates that authentication failed and the session will remain unchanged.
+    will be saved in and accessible via the session's `secure` property. A
+    rejecting promise indicates that authentication failed and the session will
+    remain unchanged.
 
     `SimpleAuth.Authenticators.Base`'s implementation always returns a
     rejecting promise and thus never authenticates the session.

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -269,9 +269,9 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     this.beginPropertyChanges();
     this.setProperties({
       isAuthenticated: false,
-      authenticator:   null,
-      content:         {}
+      authenticator:   null
     });
+    Ember.set(this.content, 'secure', {});
     this.store.clear();
     this.endPropertyChanges();
     if (trigger) {

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -321,7 +321,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   bindToStoreEvents: Ember.observer('store', function() {
-    //TODO: reflect all updated properties in the session (setup will only set the secure part)
     var _this = this;
     this.store.on('sessionDataUpdated', function(content) {
       var authenticator = (content.secure || {}).authenticator;

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -284,7 +284,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   setUnknownProperty: function(key, value) {
-    //TODO: assert that key is not 'secure' as that is reserved to the session itself
+    Ember.assert('"secure" is a reserved key used by Ember Simple Auth!', key !== 'secure');
     var result = this._super(key, value);
     this.updateStore();
     return result;

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -245,6 +245,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   setup: function(authenticator, secureContent, trigger) {
+    //TODO: clean this up, it's so messy!
     trigger = !!trigger && !this.get('isAuthenticated');
     this.beginPropertyChanges();
     this.setProperties({
@@ -265,6 +266,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   clear: function(trigger, content) {
+    //TODO: clean this up, it's so messy!
     trigger = !!trigger && this.get('isAuthenticated');
     content = content || this.get('content');
     this.beginPropertyChanges();
@@ -309,6 +311,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   bindToAuthenticatorEvents: function() {
+    //TODO: authenticators only update/invalidate the secure content of the section
     var _this = this;
     var authenticator = this.container.lookup(this.authenticator);
     authenticator.off('sessionDataUpdated');

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -226,7 +226,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       var authenticator   = (restoredContent.secure || {}).authenticator;
       if (!!authenticator) {
         delete restoredContent.secure.authenticator;
-        _this.container.lookup(authenticator).restore(restoredContent).then(function(content) {
+        _this.container.lookup(authenticator).restore(restoredContent.secure).then(function(content) {
           _this.setup(authenticator, content);
           resolve();
         }, function() {
@@ -334,7 +334,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       var authenticator = (content.secure || {}).authenticator;
       if (!!authenticator) {
         delete content.secure.authenticator;
-        _this.container.lookup(authenticator).restore(content).then(function(content) {
+        _this.container.lookup(authenticator).restore(content.secure).then(function(content) {
           _this.setup(authenticator, content, true);
         }, function() {
           _this.clear(true, content);

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -135,14 +135,14 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @property content
     @private
   */
-  content: {},
+  content: { secure: {} },
 
   /**
     @method init
     @private
   */
   init: function() {
-    this.set('content', {});
+    this.set('content', { secure: {} });
   },
 
   /**

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -230,11 +230,11 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
           _this.setup(authenticator, content);
           resolve();
         }, function() {
-          _this.store.clear();
+          _this.clear();
           reject();
         });
       } else {
-        _this.store.clear();
+        _this.clear();
         reject();
       }
     });

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -311,7 +311,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   bindToAuthenticatorEvents: function() {
-    //TODO: authenticators only update/invalidate the secure content of the section
     var _this = this;
     var authenticator = this.container.lookup(this.authenticator);
     authenticator.off('sessionDataUpdated');
@@ -329,6 +328,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   bindToStoreEvents: Ember.observer('store', function() {
+    //TODO: reflect all updated properties in the session (setup will only set the secure part)
     var _this = this;
     this.store.on('sessionDataUpdated', function(content) {
       var authenticator = (content.secure || {}).authenticator;

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -264,15 +264,17 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @method clear
     @private
   */
-  clear: function(trigger) {
+  clear: function(trigger, content) {
     trigger = !!trigger && this.get('isAuthenticated');
+    content = content || this.get('content');
     this.beginPropertyChanges();
     this.setProperties({
       isAuthenticated: false,
       authenticator:   null
     });
+    Ember.set(this, 'content', content || {});
     Ember.set(this.content, 'secure', {});
-    this.store.clear();
+    this.updateStore();
     this.endPropertyChanges();
     if (trigger) {
       this.trigger('sessionInvalidationSucceeded');
@@ -299,9 +301,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     if (!Ember.isEmpty(this.authenticator)) {
       data.secure = Ember.merge({ authenticator: this.authenticator }, data.secure || {});
     }
-    if (!Ember.isEmpty(data)) {
-      this.store.persist(data);
-    }
+    this.store.persist(data);
   },
 
   /**
@@ -317,7 +317,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       _this.setup(_this.authenticator, content);
     });
     authenticator.on('sessionDataInvalidated', function(content) {
-      _this.clear(true);
+      _this.clear(true, content);
     });
   },
 
@@ -334,10 +334,10 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         _this.container.lookup(authenticator).restore(content).then(function(content) {
           _this.setup(authenticator, content, true);
         }, function() {
-          _this.clear(true);
+          _this.clear(true, content);
         });
       } else {
-        _this.clear(true);
+        _this.clear(true, content);
       }
     });
   })

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -257,16 +257,14 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @method clear
     @private
   */
-  clear: function(trigger, content) {
+  clear: function(trigger) {
     //TODO: clean this up, it's so messy!
     trigger = !!trigger && this.get('isAuthenticated');
-    content = content || this.get('content');
     this.beginPropertyChanges();
     this.setProperties({
       isAuthenticated: false,
       authenticator:   null
     });
-    Ember.set(this, 'content', content || {});
     Ember.set(this.content, 'secure', {});
     this.updateStore();
     this.endPropertyChanges();
@@ -311,7 +309,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       _this.setup(_this.authenticator, content);
     });
     authenticator.on('sessionDataInvalidated', function(content) {
-      _this.clear(true, content);
+      _this.clear(true);
     });
   },
 
@@ -329,10 +327,12 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
           _this.set('content', content);
           _this.setup(authenticator, secureContent, true);
         }, function() {
-          _this.clear(true, content);
+          _this.set('content', content);
+          _this.clear(true);
         });
       } else {
-        _this.clear(true, content);
+        _this.set('content', content);
+        _this.clear(true);
       }
     });
   })

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -289,7 +289,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   updateStore: function() {
     var data = this.content;
     if (!Ember.isEmpty(this.authenticator)) {
-      data.secure = Ember.merge({ authenticator: this.authenticator }, data.secure || {});
+      Ember.set(data, 'secure', Ember.merge({ authenticator: this.authenticator }, data.secure || {}));
     }
     this.store.persist(data);
   },

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -237,7 +237,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   setup: function(authenticator, secureContent, trigger) {
-    //TODO: clean this up, it's so messy!
     trigger = !!trigger && !this.get('isAuthenticated');
     this.beginPropertyChanges();
     this.setProperties({
@@ -258,7 +257,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @private
   */
   clear: function(trigger) {
-    //TODO: clean this up, it's so messy!
     trigger = !!trigger && this.get('isAuthenticated');
     this.beginPropertyChanges();
     this.setProperties({

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -163,7 +163,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     Ember.assert('No authenticator for factory "' + authenticator + '" could be found!', !Ember.isNone(theAuthenticator));
     return new Ember.RSVP.Promise(function(resolve, reject) {
       theAuthenticator.authenticate.apply(theAuthenticator, args).then(function(content) {
-        _this.setup(authenticator, _this.get('content'), content, true);
+        _this.setup(authenticator, content, true);
         resolve();
       }, function(error) {
         _this.clear();
@@ -219,7 +219,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       if (!!authenticator) {
         delete restoredContent.secure.authenticator;
         _this.container.lookup(authenticator).restore(restoredContent.secure).then(function(content) {
-          _this.setup(authenticator, _this.get('content'), content);
+          _this.setup(authenticator, content);
           resolve();
         }, function() {
           _this.clear();
@@ -236,7 +236,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @method setup
     @private
   */
-  setup: function(authenticator, content, secureContent, trigger) {
+  setup: function(authenticator, secureContent, trigger) {
     //TODO: clean this up, it's so messy!
     trigger = !!trigger && !this.get('isAuthenticated');
     this.beginPropertyChanges();
@@ -244,7 +244,6 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       isAuthenticated: true,
       authenticator:   authenticator
     });
-    Ember.set(this, 'content', content || {});
     Ember.set(this.content, 'secure', secureContent);
     this.bindToAuthenticatorEvents();
     this.updateStore();
@@ -309,7 +308,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     authenticator.off('sessionDataUpdated');
     authenticator.off('sessionDataInvalidated');
     authenticator.on('sessionDataUpdated', function(content) {
-      _this.setup(_this.authenticator, _this.get('content'), content);
+      _this.setup(_this.authenticator, content);
     });
     authenticator.on('sessionDataInvalidated', function(content) {
       _this.clear(true, content);
@@ -327,7 +326,8 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       if (!!authenticator) {
         delete content.secure.authenticator;
         _this.container.lookup(authenticator).restore(content.secure).then(function(secureContent) {
-          _this.setup(authenticator, content, secureContent, true);
+          _this.set('content', content);
+          _this.setup(authenticator, secureContent, true);
         }, function() {
           _this.clear(true, content);
         });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -16,12 +16,11 @@ describe('Session', function() {
         preparation.apply(this, [done]);
       });
 
-      it('merges its content to the data the event is triggered with', function(done) {
-        this.session.set('existing', 'property');
-        this.authenticator.trigger('sessionDataUpdated', { some: 'other property' });
+      it('stores the data the event is triggered with in its secure section', function(done) {
+        this.authenticator.trigger('sessionDataUpdated', { some: 'property' });
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({ existing: 'property', some: 'other property' });
+          expect(this.session.get('secure')).to.eql({ some: 'property', authenticator: 'authenticator' });
           done();
         });
       });
@@ -117,12 +116,12 @@ describe('Session', function() {
 
     context('when the restored data contains an authenticator factory', function() {
       beforeEach(function() {
-        this.store.persist({ authenticator: 'authenticator' });
+        this.store.persist({ secure: { authenticator: 'authenticator' } });
       });
 
       context('when the authenticator resolves restoration', function() {
         beforeEach(function() {
-          sinon.stub(this.authenticator, 'restore').returns(Ember.RSVP.resolve({ some: 'properties' }));
+          sinon.stub(this.authenticator, 'restore').returns(Ember.RSVP.resolve({ some: 'property' }));
         });
 
         it('returns a resolving promise', function(done) {
@@ -141,16 +140,15 @@ describe('Session', function() {
           });
         });
 
-        it('merges its content to the data the authenticator resolves with', function(done) {
+        it('stores the data the authenticator resolves with in its secure section', function(done) {
           var _this = this;
-          this.session.set('existing', 'property');
-          this.store.persist({ authenticator: 'authenticator' });
+          this.store.persist({ secure: { authenticator: 'authenticator' } });
 
           this.session.restore().then(function() {
             var properties = _this.store.restore();
             delete properties.authenticator;
 
-            expect(_this.session.get('content')).to.eql({ existing: 'property', some: 'properties' });
+            expect(_this.session.get('secure')).to.eql({ some: 'property', authenticator: 'authenticator' });
             done();
           });
         });
@@ -162,7 +160,7 @@ describe('Session', function() {
             var properties = _this.store.restore();
             delete properties.authenticator;
 
-            expect(properties).to.eql({ some: 'properties' });
+            expect(properties).to.eql({ secure: { some: 'property', authenticator: 'authenticator' } });
             done();
           });
         });
@@ -171,7 +169,7 @@ describe('Session', function() {
           var _this = this;
 
           this.session.restore().then(function() {
-            expect(_this.store.restore().authenticator).to.eql('authenticator');
+            expect(_this.store.restore().secure.authenticator).to.eql('authenticator');
             done();
           });
         });
@@ -218,7 +216,7 @@ describe('Session', function() {
 
     context('when the authenticator resolves authentication', function() {
       beforeEach(function() {
-        sinon.stub(this.authenticator, 'authenticate').returns(Ember.RSVP.resolve({ some: 'properties' }));
+        sinon.stub(this.authenticator, 'authenticate').returns(Ember.RSVP.resolve({ some: 'property' }));
       });
 
       it('is authenticated', function(done) {
@@ -237,12 +235,11 @@ describe('Session', function() {
         });
       });
 
-      it('merges its content to the data the authenticator resolves with', function(done) {
+      it('stores the data the authenticator resolves with in its secure section', function(done) {
         var _this = this;
-        this.session.set('existing', 'property');
 
         this.session.authenticate('authenticator').then(function() {
-          expect(_this.session.get('content')).to.eql({ existing: 'property', some: 'properties' });
+          expect(_this.session.get('secure')).to.eql({ some: 'property', authenticator: 'authenticator' });
           done();
         });
       });
@@ -254,7 +251,7 @@ describe('Session', function() {
           var properties = _this.store.restore();
           delete properties.authenticator;
 
-          expect(properties).to.eql({ some: 'properties' });
+          expect(properties).to.eql({ secure: { some: 'property', authenticator: 'authenticator' } });
           done();
         });
       });
@@ -263,7 +260,7 @@ describe('Session', function() {
         var _this = this;
 
         this.session.authenticate('authenticator').then(function() {
-          expect(_this.store.restore().authenticator).to.eql('authenticator');
+          expect(_this.store.restore().secure.authenticator).to.eql('authenticator');
           done();
         });
       });
@@ -456,7 +453,7 @@ describe('Session', function() {
         var _this = this;
 
         this.session.invalidate().then(null, function() {
-          expect(_this.session.get('content')).to.eql({ some: 'property' });
+          expect(_this.session.get('secure')).to.eql({ some: 'property', authenticator: 'authenticator' });
           done();
         });
       });
@@ -465,7 +462,7 @@ describe('Session', function() {
         var _this = this;
 
         this.session.invalidate().then(null, function() {
-          expect(_this.store.restore()).to.eql({ some: 'property', authenticator: 'authenticator' });
+          expect(_this.store.restore()).to.eql({ secure: { some: 'property', authenticator: 'authenticator' } });
           done();
         });
       });
@@ -546,7 +543,7 @@ describe('Session', function() {
         });
 
         it('is authenticated', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             expect(this.session.get('isAuthenticated')).to.be.true;
@@ -554,26 +551,23 @@ describe('Session', function() {
           });
         });
 
-        it('merges its content to the data the authenticator resolves with', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+        it('stores the data the authenticator resolves with in its secure section', function(done) {
+          this.store.trigger('sessionDataUpdated', { some: 'property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
-            var properties = this.store.restore();
-            delete properties.authenticator;
-
-            expect(this.session.get('content')).to.eql({ some: 'other property', multiple: 'properties' });
+            expect(this.session.get('secure')).to.eql({ some: 'other property', authenticator: 'authenticator' });
             done();
           });
         });
 
         it('persists its content in the store', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             var properties = this.store.restore();
             delete properties.authenticator;
 
-            expect(properties).to.eql({ some: 'other property', multiple: 'properties' });
+            expect(properties).to.eql({ secure: { some: 'other property', authenticator: 'authenticator' } });
             done();
           });
         });
@@ -586,7 +580,7 @@ describe('Session', function() {
           it('does not trigger the "sessionAuthenticationSucceeded" event', function(done) {
             var triggered = false;
             this.session.one('sessionAuthenticationSucceeded', function() { triggered = true; });
-            this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+            this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
             Ember.run.next(this, function() {
               expect(triggered).to.be.false;
@@ -606,7 +600,7 @@ describe('Session', function() {
               done();
             });
 
-            this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+            this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
           });
         });
       });
@@ -617,7 +611,7 @@ describe('Session', function() {
         });
 
         it('is not authenticated', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             expect(this.session.get('isAuthenticated')).to.be.false;
@@ -626,7 +620,7 @@ describe('Session', function() {
         });
 
         it('clears its content', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             expect(this.session.get('content')).to.eql({});
@@ -635,7 +629,7 @@ describe('Session', function() {
         });
 
         it('clears the store', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             expect(this.store.restore()).to.eql({});
@@ -654,7 +648,7 @@ describe('Session', function() {
               done();
             });
 
-            this.store.trigger('sessionDataUpdated', { some: 'other property', authenticator: 'authenticator' });
+            this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
           });
         });
 

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -568,13 +568,12 @@ describe('Session', function() {
         });
 
         it('persists its content in the store', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
+          this.store.trigger('sessionDataUpdated', { some: 'property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
             var properties = this.store.restore();
-            delete properties.authenticator;
 
-            expect(properties).to.eql({ secure: { some: 'other property', authenticator: 'authenticator' } });
+            expect(properties).to.eql({ some: 'property', secure: { some: 'other property', authenticator: 'authenticator' } });
             done();
           });
         });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -10,6 +10,12 @@ describe('Session', function() {
     sinon.stub(this.container, 'lookup').returns(this.authenticator);
   });
 
+  it('does not allow data to be stored for the key "secure"', function() {
+    expect(function() {
+      this.session.set('secure', 'test');
+    }).to.throw(Error);
+  });
+
   function itHandlesAuthenticatorEvents(preparation) {
     context('when the authenticator triggers the "sessionDataUpdated" event', function() {
       beforeEach(function(done) {

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -100,12 +100,12 @@ describe('Session', function() {
         });
       });
 
-      it('updates the store', function(done) {
+      it('clears its secure section', function(done) {
         var _this = this;
-        this.store.persist({ some: 'property' });
+        this.session.set('content', { secure: { some: 'other property' } });
 
         this.session.restore().then(null, function() {
-          expect(_this.store.restore()).to.eql({ some: 'other property', secure: {} });
+          expect(_this.session.get('content')).to.eql({ secure: {} });
           done();
         });
       });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -48,19 +48,19 @@ describe('Session', function() {
 
       it('clears its secure section', function(done) {
         this.session.set('content', { some: 'property', secure: { some: 'other property' } });
-        this.authenticator.trigger('sessionDataInvalidated', {});
+        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
+          expect(this.session.get('content')).to.eql({ some: 'other property', secure: {} });
           done();
         });
       });
 
-      it('clears the store', function(done) {
+      it('updates the store', function(done) {
         this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
 
         Ember.run.next(this, function() {
-          expect(this.store.restore()).to.eql({});
+          expect(this.store.restore()).to.eql({ some: 'other property', secure: {} });
           done();
         });
       });
@@ -100,12 +100,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears the store', function(done) {
+      it('updates the store', function(done) {
         var _this = this;
-        this.store.persist({ some: 'properties' });
+        this.store.persist({ some: 'property' });
 
         this.session.restore().then(null, function() {
-          expect(_this.store.restore()).to.eql({});
+          expect(_this.store.restore()).to.eql({ some: 'other property', secure: {} });
           done();
         });
       });
@@ -330,12 +330,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears the store', function(done) {
+      it('updates the store', function(done) {
         var _this = this;
         this.store.persist({ some: 'property' });
 
         this.session.authenticate('authenticator').then(null, function() {
-          expect(_this.store.restore()).to.eql({});
+          expect(_this.store.restore()).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -404,12 +404,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears the store', function(done) {
+      it('updates the store', function(done) {
         var _this = this;
         this.store.persist({ some: 'property' });
 
         this.session.invalidate().then(function() {
-          expect(_this.store.restore()).to.eql({});
+          expect(_this.store.restore()).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -628,19 +628,20 @@ describe('Session', function() {
 
         it('clears its secure section', function(done) {
           this.session.set('content', { some: 'property', secure: { some: 'other property' } });
-          this.store.trigger('sessionDataUpdated', { some: 'property', secure: { authenticator: 'authenticator' } });
+          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
-            expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
+            expect(this.session.get('content')).to.eql({ some: 'other property', secure: {} });
             done();
           });
         });
 
-        it('clears the store', function(done) {
+        it('updates the store', function(done) {
+          this.session.set('content', { some: 'property', secure: { some: 'other property' } });
           this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
-            expect(this.store.restore()).to.eql({});
+            expect(this.store.restore()).to.eql({ some: 'other property', secure: {} });
             done();
           });
         });
@@ -690,19 +691,20 @@ describe('Session', function() {
 
       it('clears its secure section', function(done) {
         this.session.set('content', { some: 'property', secure: { some: 'other property' } });
-        this.store.trigger('sessionDataUpdated', { some: 'property' });
+        this.store.trigger('sessionDataUpdated', { some: 'other property' });
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
+          expect(this.session.get('content')).to.eql({ some: 'other property', secure: {} });
           done();
         });
       });
 
-      it('clears the store', function(done) {
+      it('updates the store', function(done) {
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
         this.store.trigger('sessionDataUpdated', { some: 'other property' });
 
         Ember.run.next(this, function() {
-          expect(this.store.restore()).to.eql({});
+          expect(this.store.restore()).to.eql({ some: 'other property', secure: {} });
           done();
         });
       });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -40,11 +40,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears its content', function(done) {
-        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
+      it('clears its secure section', function(done) {
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
+        this.authenticator.trigger('sessionDataInvalidated', {});
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({});
+          expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -313,12 +314,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears its content', function(done) {
+      it('clears its secure section', function(done) {
         var _this = this;
-        this.session.set('some', 'property');
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
 
         this.session.authenticate('authenticator').then(null, function() {
-          expect(_this.session.get('content')).to.eql({});
+          expect(_this.session.get('content')).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -387,12 +388,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears its content', function(done) {
+      it('clears its secure section', function(done) {
         var _this = this;
-        this.session.set('some', 'property');
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
 
         this.session.invalidate().then(function() {
-          expect(_this.session.get('content')).to.eql({});
+          expect(_this.session.get('content')).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -619,11 +620,12 @@ describe('Session', function() {
           });
         });
 
-        it('clears its content', function(done) {
-          this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
+        it('clears its secure section', function(done) {
+          this.session.set('content', { some: 'property', secure: { some: 'other property' } });
+          this.store.trigger('sessionDataUpdated', { some: 'property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
-            expect(this.session.get('content')).to.eql({});
+            expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
             done();
           });
         });
@@ -680,11 +682,12 @@ describe('Session', function() {
         });
       });
 
-      it('clears its content', function(done) {
-        this.store.trigger('sessionDataUpdated', { some: 'other property' });
+      it('clears its secure section', function(done) {
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
+        this.store.trigger('sessionDataUpdated', { some: 'property' });
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({});
+          expect(this.session.get('content')).to.eql({ some: 'property', secure: {} });
           done();
         });
       });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -332,7 +332,7 @@ describe('Session', function() {
 
       it('updates the store', function(done) {
         var _this = this;
-        this.store.persist({ some: 'property' });
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
 
         this.session.authenticate('authenticator').then(null, function() {
           expect(_this.store.restore()).to.eql({ some: 'property', secure: {} });
@@ -406,7 +406,7 @@ describe('Session', function() {
 
       it('updates the store', function(done) {
         var _this = this;
-        this.store.persist({ some: 'property' });
+        this.session.set('content', { some: 'property', secure: { some: 'other property' } });
 
         this.session.invalidate().then(function() {
           expect(_this.store.restore()).to.eql({ some: 'property', secure: {} });
@@ -512,7 +512,7 @@ describe('Session', function() {
           var properties = this.store.restore();
           delete properties.authenticator;
 
-          expect(properties).to.eql({ some: 'property' });
+          expect(properties).to.eql({ some: 'property', secure: {} });
           done();
         });
       });
@@ -530,7 +530,7 @@ describe('Session', function() {
           var properties = this.store.restore();
           delete properties.authenticator;
 
-          expect(properties).to.eql({ some: 'property', multiple: 'properties' });
+          expect(properties).to.eql({ some: 'property', multiple: 'properties', secure: {} });
           done();
         });
       });

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -38,7 +38,7 @@ describe('Session', function() {
       });
 
       it('is not authenticated', function(done) {
-        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
+        this.authenticator.trigger('sessionDataInvalidated');
 
         Ember.run.next(this, function() {
           expect(this.session.get('isAuthenticated')).to.be.false;
@@ -48,19 +48,19 @@ describe('Session', function() {
 
       it('clears its secure section', function(done) {
         this.session.set('content', { some: 'property', secure: { some: 'other property' } });
-        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
+        this.authenticator.trigger('sessionDataInvalidated');
 
         Ember.run.next(this, function() {
-          expect(this.session.get('content')).to.eql({ some: 'other property', secure: {} });
+          expect(this.session.get('content.secure')).to.eql({});
           done();
         });
       });
 
       it('updates the store', function(done) {
-        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
+        this.authenticator.trigger('sessionDataInvalidated');
 
         Ember.run.next(this, function() {
-          expect(this.store.restore()).to.eql({ some: 'other property', secure: {} });
+          expect(this.store.restore().secure).to.eql({});
           done();
         });
       });
@@ -71,7 +71,7 @@ describe('Session', function() {
           done();
         });
 
-        this.authenticator.trigger('sessionDataInvalidated', { some: 'other property' });
+        this.authenticator.trigger('sessionDataInvalidated');
       });
     });
   }
@@ -105,7 +105,7 @@ describe('Session', function() {
         this.session.set('content', { secure: { some: 'other property' } });
 
         this.session.restore().then(null, function() {
-          expect(_this.session.get('content')).to.eql({ secure: {} });
+          expect(_this.session.get('content.secure')).to.eql({});
           done();
         });
       });
@@ -630,7 +630,7 @@ describe('Session', function() {
           this.store.trigger('sessionDataUpdated', { some: 'other property', secure: { authenticator: 'authenticator' } });
 
           Ember.run.next(this, function() {
-            expect(this.session.get('content')).to.eql({ some: 'other property', secure: {} });
+            expect(this.session.get('content.secure')).to.eql({});
             done();
           });
         });


### PR DESCRIPTION
This will fix #383 as an alternative approach to #410.

The idea is to use a special session subkey `secure` to store all data that's relevant to the session's authentication state (e.g. the used authenticator, the token etc.). That subkey of the session data is the only data that Ember Simple Auth manages and especially clears when the session is invalidated. All other session data is left intact.