### PR TITLE
Instructions in Readme for user_token cause session invalidation

### DIFF
--- a/packages/ember-simple-auth-devise/README.md
+++ b/packages/ember-simple-auth-devise/README.md
@@ -64,7 +64,7 @@ class SessionsController < Devise::SessionsController
         self.resource = warden.authenticate!(auth_options)
         sign_in(resource_name, resource)
         data = {
-          token:      self.resource.authentication_token,
+          user_token:      self.resource.authentication_token,
           user_email: self.resource.email
         }
         render json: data, status: 201


### PR DESCRIPTION
In the SessionsController, you return the token as "token" - but when retrieving the session on page load, the authenticator looks for "user_token" so the user is logged out on page load if we follow these instructions.

If you return "user_token" with "user_email", then the user stays logged in.