### PR TITLE
Add support for setting oauth2 token in an access_token parameter

### DIFF
--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authorizers/oauth2-access-token.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authorizers/oauth2-access-token.js
@@ -1,0 +1,69 @@
+import Base from 'simple-auth/authorizers/base';
+
+/**
+  Authorizer that conforms to OAuth 2
+  ([RFC 6749](http://tools.ietf.org/html/rfc6749)) by sending a bearer token
+  ([RFC 6750](http://tools.ietf.org/html/rfc6750)) in the request's
+  Form-Encoded Body Parameter ([RFC 6750 Section 2.2](http://tools.ietf.org/html/rfc6750#section-2.2)
+  for POST requests and in the URI Query Parameter
+  ([RFC 6750 Section 2.3](http://tools.ietf.org/html/rfc6750#section-2.3)
+  for GET requests.
+
+  _The factory for this authorizer is registered as
+  `'simple-auth-authorizer:oauth2-access-token'` in Ember's container._
+
+  @class OAuth2
+  @namespace SimpleAuth.Authorizers
+  @module simple-auth-oauth2/authorizers/oauth2
+  @extends Base
+*/
+export default Base.extend({
+  /**
+    Authorizes an XHR request by sending the `access_token` property from the
+    session as a bearer token in the Form-Encoded Body Parameter or
+    URI Query Parameter:
+
+    ```
+    POST /resource HTTP/1.1
+    Host: server.example.com
+    Content-Type: application/x-www-form-urlencoded
+
+    access_token=mF_9.B5f-4.1JqM
+    ```
+
+    ```
+    GET /resource?access_token=mF_9.B5f-4.1JqM HTTP/1.1
+    Host: server.example.com
+    ```
+
+    @method authorize
+    @param {jqXHR} jqXHR The XHR request to authorize (see http://api.jquery.com/jQuery.ajax/#jqXHR)
+    @param {Object} requestOptions The options as provided to the `$.ajax` method (see http://api.jquery.com/jQuery.ajaxPrefilter/)
+  */
+  authorize: function(jqXHR, requestOptions) {
+    var accessToken = this.get('session.access_token');
+    if (this.get('session.isAuthenticated') && !Ember.isEmpty(accessToken)) {
+      var data;
+
+      if (requestOptions.contentType && requestOptions.contentType.indexOf('application/json') > -1) {
+        data = requestOptions.data || '{}';
+        data = Ember.$.extend(JSON.parse(data), {access_token: accessToken});
+        requestOptions.data = JSON.stringify(data);
+      } else {
+        data = requestOptions.data || '';
+
+        if (typeof data.append === 'function') { // FormData
+          data.append('access_token', accessToken);
+        } else {
+          var param = Ember.$.param({access_token: accessToken});
+
+          if (data.length === 0) {
+            requestOptions.data = param;
+          } else {
+            requestOptions.data += '&' + param;
+          }
+        }
+      }
+    }
+  }
+});

--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/initializer.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/initializer.js
@@ -1,7 +1,8 @@
 import Configuration from './configuration';
 import getGlobalConfig from 'simple-auth/utils/get-global-config';
 import Authenticator from 'simple-auth-oauth2/authenticators/oauth2';
-import Authorizer from 'simple-auth-oauth2/authorizers/oauth2';
+import BearerAuthorizer from 'simple-auth-oauth2/authorizers/oauth2';
+import AccessTokenAuthorizer from 'simple-auth-oauth2/authorizers/oauth2-access-token';
 
 export default {
   name:       'simple-auth-oauth2',
@@ -9,7 +10,8 @@ export default {
   initialize: function(container, application) {
     var config = getGlobalConfig('simple-auth-oauth2');
     Configuration.load(container, config);
-    container.register('simple-auth-authorizer:oauth2-bearer', Authorizer);
+    container.register('simple-auth-authorizer:oauth2-bearer', BearerAuthorizer);
+    container.register('simple-auth-authorizer:oauth2-access-token', AccessTokenAuthorizer);
     container.register('simple-auth-authenticator:oauth2-password-grant', Authenticator);
   }
 };

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authorizers/oauth2-access-token-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authorizers/oauth2-access-token-test.js
@@ -1,0 +1,119 @@
+import AccessToken from 'simple-auth-oauth2/authorizers/oauth2-access-token';
+import Session from 'simple-auth/session';
+import EphemeralStore from 'simple-auth/stores/ephemeral';
+
+describe('OAuth2 Access Token', function() {
+  beforeEach(function() {
+    this.authorizer     = AccessToken.create();
+    this.request        = {};
+    this.requestOptions = {};
+    var session         = Session.create();
+    session.setProperties({ store: EphemeralStore.create() });
+    this.authorizer.set('session', session);
+  });
+
+  describe('#authorize', function() {
+    function itDoesNotAuthorizeTheRequest() {
+      it('does not add the "access_token" to the requestOptions', function() {
+        this.authorizer.authorize(this.request, this.requestOptions);
+
+        expect(this.requestOptions.data).to.not.contain('access_token');
+      });
+    }
+
+    context('when the session is authenticated', function() {
+      beforeEach(function() {
+        this.authorizer.set('session.isAuthenticated', true);
+      });
+
+      context('when the session contains a non empty access_token', function() {
+        beforeEach(function() {
+          this.authorizer.set('session.access_token', 'secret token!');
+        });
+
+        context('when the contentType is application/json', function(){
+          beforeEach(function(){
+            this.requestOptions.contentType = 'application/json';
+          });
+
+          context('when the data is not set', function(){
+            it('adds the "access_token" to the requestOptions.data', function(){
+              this.authorizer.authorize(this.request, this.requestOptions);
+
+              var jsonData = JSON.parse(this.requestOptions.data);
+              expect(jsonData).to.deep.equal({access_token: 'secret token!'});
+            });
+          });
+
+          context('when the data has existing json', function(){
+            beforeEach(function(){
+              this.requestOptions.data = JSON.stringify({user: {email: 'foo@example.com'}});
+            });
+
+            it('adds the "access_token" to the json', function(){
+              this.authorizer.authorize(this.request, this.requestOptions);
+
+              var jsonData = JSON.parse(this.requestOptions.data);
+              expect(jsonData).to.deep.equal({user: {email: 'foo@example.com'}, access_token: 'secret token!'});
+            });
+          });
+        });
+
+        context('when the contentType is application/x-www-form-urlencoded', function(){
+          beforeEach(function(){
+            this.requestOptions.contentType = 'application/x-www-form-urlencoded';
+          });
+
+          context('when the data is not set', function(){
+            it('adds the "access_token" to the requestOptions.data', function(){
+              this.authorizer.authorize(this.request, this.requestOptions);
+
+              expect(this.requestOptions.data).to.equal('access_token=secret+token!');
+            });
+          });
+
+          context('when the data has existing form data', function(){
+            beforeEach(function(){
+              this.requestOptions.data = Ember.$.param({user: {email: 'foo@example.com'}});
+            });
+
+            it('adds the "access_token" to the json', function(){
+              this.authorizer.authorize(this.request, this.requestOptions);
+
+              expect(this.requestOptions.data).to.equal('user%5Bemail%5D=foo%40example.com&access_token=secret+token!');
+            });
+          });
+
+          context('when the data is a FormData', function(){
+            beforeEach(function(){
+              this.requestOptions.data = { append: function(){} };
+              sinon.spy(this.requestOptions.data, 'append');
+            });
+
+            it('adds the "access_token" to the json', function(){
+              this.authorizer.authorize(this.request, this.requestOptions);
+
+              expect(this.requestOptions.data.append).to.have.been.calledWith('access_token', 'secret token!');
+            });
+          });
+        });
+      });
+
+      context('when the session does not contain an access_token', function() {
+        beforeEach(function() {
+          this.authorizer.set('session.access_token', null);
+        });
+
+        itDoesNotAuthorizeTheRequest();
+      });
+    });
+
+    context('when the session is not authenticated', function() {
+      beforeEach(function() {
+        this.authorizer.set('session.isAuthenticated', false);
+      });
+
+      itDoesNotAuthorizeTheRequest();
+    });
+  });
+});

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/initializer-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/initializer-test.js
@@ -1,6 +1,7 @@
 import initializer from 'simple-auth-oauth2/initializer';
 import Authenticator from 'simple-auth-oauth2/authenticators/oauth2';
-import Authorizer from 'simple-auth-oauth2/authorizers/oauth2';
+import BearerAuthorizer from 'simple-auth-oauth2/authorizers/oauth2';
+import AccessTokenAuthorizer from 'simple-auth-oauth2/authorizers/oauth2-access-token';
 
 describe('the "simple-auth-oauth2" initializer', function() {
   it('has the correct name', function() {
@@ -17,18 +18,26 @@ describe('the "simple-auth-oauth2" initializer', function() {
       sinon.spy(this.container, 'register');
     });
 
-    it('registers the authorizer with the Ember container', function() {
+    it('registers the bearer authorizer with the Ember container', function() {
       initializer.initialize(this.container);
       var spyCall = this.container.register.getCall(0);
 
       expect(spyCall.args[0]).to.eql('simple-auth-authorizer:oauth2-bearer');
-      expect(spyCall.args[1]).to.eql(Authorizer);
+      expect(spyCall.args[1]).to.eql(BearerAuthorizer);
+    });
+
+    it('registers the access token authorizer with the Ember container', function() {
+      initializer.initialize(this.container);
+      var spyCall = this.container.register.getCall(1);
+
+      expect(spyCall.args[0]).to.eql('simple-auth-authorizer:oauth2-access-token');
+      expect(spyCall.args[1]).to.eql(AccessTokenAuthorizer);
     });
 
     it('registers the authenticator with the Ember container', function() {
       initializer.initialize(this.container);
 
-      var spyCall = this.container.register.getCall(1);
+      var spyCall = this.container.register.getCall(2);
 
       expect(spyCall.args[0]).to.eql('simple-auth-authenticator:oauth2-password-grant');
       expect(spyCall.args[1]).to.eql(Authenticator);


### PR DESCRIPTION
This PR implements Section 2.2 and Section 2.3 of the RFC.

We recently had to implement sending the oauth2 token via an `access_token` parameter to support IE9 users. As we host our Ember app on a subdomain, IE9 users use XDomainRequest to perform CORS. XDomainRequest does not support setting request headers so using the  `oauth2-bearer` authorizer doesn't auth our requests.
