### PR TITLE
ember-simple-auth-testing/README: Don't suggest overwriting `ENV['simple-auth']`

### DIFF
--- a/packages/ember-simple-auth-testing/README.md
+++ b/packages/ember-simple-auth-testing/README.md
@@ -59,9 +59,7 @@ tests might influence each other.
 ```js
 //config/environment.js
 if (environment === 'test') {
-  ENV['simple-auth'] = {
-    store: 'simple-auth-session-store:ephemeral'
-  }
+  ENV['simple-auth'].store = 'simple-auth-session-store:ephemeral';
 }
 ```
 


### PR DESCRIPTION
I had a hard time figuring out why my tests didn't use an authorizer. Turned out it was because by following this readme i overwrote `ENV['simple-auth']` and disabled the authorizer.