### PR TITLE
Removed use of observes in favor of Ember.observer

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -317,7 +317,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @method bindToStoreEvents
     @private
   */
-  bindToStoreEvents: function() {
+  bindToStoreEvents: Ember.observer('store', function() {
     var _this = this;
     this.store.on('sessionDataUpdated', function(content) {
       var authenticator = content.authenticator;
@@ -332,5 +332,5 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         _this.clear(true);
       }
     });
-  }.observes('store')
+  })
 });


### PR DESCRIPTION
While disabling the Ember EXTEND_PROTOTYPES feature I noticed that the Application was not able to start.

This was related with the use of the "observes" prototype extension.