### PR TITLE
Update auth token when password changes.

### DIFF
--- a/packages/ember-simple-auth-devise/README.md
+++ b/packages/ember-simple-auth-devise/README.md
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
   before_save :ensure_authentication_token
 
   def ensure_authentication_token
-    if authentication_token.blank?
+    if authentication_token.blank? || encrypted_password_changed?
       self.authentication_token = generate_authentication_token
     end
   end


### PR DESCRIPTION
This way, in the case of a user's account being compromised, a password change will render the attacker's token obsolete.