### PR TITLE
Deprecations

### DIFF
--- a/docs/theme/main.hbs
+++ b/docs/theme/main.hbs
@@ -69,6 +69,11 @@
         top: -55px;
         height: 1px;
       }
+      span.label-deprecation {
+        float: left;
+        line-height: inherit;
+        margin-right: 5px;
+      }
     </style>
   </head>
   <body>
@@ -110,6 +115,9 @@
           </div>
           <div class="row">
             <div class="col-md-9" id="main-content">
+              {{#if deprecated}}
+                <span class="label label-warning label-deprecation">deprecated</span>{{markdown deprecationMessage}}
+              {{/if}}
               {{markdown description}}
               <h4 class="section">Importing</h4>
               <dl>

--- a/docs/theme/partials/action.hbs
+++ b/docs/theme/partials/action.hbs
@@ -7,6 +7,9 @@
     </h3>
   </div>
   <div class="panel-body">
+    {{#if deprecated}}
+      <span class="label label-warning label-deprecation">deprecated</span>{{markdown deprecationMessage}}
+    {{/if}}
     {{markdown description}}
     {{#if params}}
       <h4 class="subsection">Arguments</h4>

--- a/docs/theme/partials/event.hbs
+++ b/docs/theme/partials/event.hbs
@@ -7,6 +7,9 @@
     </h3>
   </div>
   <div class="panel-body">
+    {{#if deprecated}}
+      <span class="label label-warning label-deprecation">deprecated</span>{{markdown deprecationMessage}}
+    {{/if}}
     {{markdown description}}
     {{#if params}}
       <h4 class="subsection">Parameters</h4>

--- a/docs/theme/partials/method.hbs
+++ b/docs/theme/partials/method.hbs
@@ -16,6 +16,9 @@
     </h3>
   </div>
   <div class="panel-body">
+    {{#if deprecated}}
+      <span class="label label-warning label-deprecation">deprecated</span>{{markdown deprecationMessage}}
+    {{/if}}
     {{markdown description}}
     {{#if params}}
       <h4 class="subsection">Arguments</h4>

--- a/docs/theme/partials/property.hbs
+++ b/docs/theme/partials/property.hbs
@@ -11,6 +11,9 @@
     <h3 class="panel-title property">{{name}} <span class="type">{{{type}}}</span></h3>
   </div>
   <div class="panel-body">
+    {{#if deprecated}}
+      <span class="label label-warning label-deprecation">deprecated</span>{{markdown deprecationMessage}}
+    {{/if}}
     {{markdown description}}
     {{#if default}}
       Defaults to <code>{{default}}</code>

--- a/examples/1-simple.html
+++ b/examples/1-simple.html
@@ -100,8 +100,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/1-simple.html
+++ b/examples/1-simple.html
@@ -101,8 +101,13 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials);
+          }
+        }
       });
 
       // make this route protected

--- a/examples/10-devise.html
+++ b/examples/10-devise.html
@@ -105,8 +105,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/10-devise.html
+++ b/examples/10-devise.html
@@ -106,8 +106,13 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:devise'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:devise', credentials);
+          }
+        }
       });
 
       // make this route protected

--- a/examples/11-amd.html
+++ b/examples/11-amd.html
@@ -102,8 +102,14 @@
       var AuthenticatedRouteMixin = requireModule('simple-auth/mixins/authenticated-route-mixin').default;
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/11-amd.html
+++ b/examples/11-amd.html
@@ -99,13 +99,17 @@
       });
 
       var ApplicationRouteMixin   = requireModule('simple-auth/mixins/application-route-mixin').default;
-      var LoginControllerMixin    = requireModule('simple-auth/mixins/login-controller-mixin').default;
       var AuthenticatedRouteMixin = requireModule('simple-auth/mixins/authenticated-route-mixin').default;
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials);
+          }
+        }
       });
 
       // make this route protected

--- a/examples/12-torii.html
+++ b/examples/12-torii.html
@@ -107,7 +107,13 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
 
       // define the login route that defines the authentication actions
       App.LoginRoute = Ember.Route.extend({

--- a/examples/2-errors.html
+++ b/examples/2-errors.html
@@ -129,8 +129,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginRoute       = Ember.Route.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginRoute = Ember.Route.extend({
         // clear a potentially stale error message from previous login attempts
         setupController: function(controller, model) {
           controller.set('errorMessage', null);

--- a/examples/2-errors.html
+++ b/examples/2-errors.html
@@ -136,13 +136,13 @@
           controller.set('errorMessage', null);
         }
       });
-      App.LoginController = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant',
+      App.LoginController = Ember.Controller.extend({
         actions: {
           // display an error when authentication fails
           authenticate: function() {
             var _this = this;
-            this._super().then(null, function(error) {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials).then(null, function(error) {
               var message = error.error;
               _this.set('errorMessage', message);
             });

--- a/examples/3-token-refresh.html
+++ b/examples/3-token-refresh.html
@@ -111,8 +111,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/3-token-refresh.html
+++ b/examples/3-token-refresh.html
@@ -112,8 +112,13 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials);
+          }
+        }
       });
 
       // make this route protected

--- a/examples/4-authenticated-account.html
+++ b/examples/4-authenticated-account.html
@@ -164,8 +164,13 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'authenticator:custom'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('authenticator:custom', credentials);
+          }
+        }
       });
 
       // clear a potentially stale error message from previous login attempts

--- a/examples/4-authenticated-account.html
+++ b/examples/4-authenticated-account.html
@@ -163,8 +163,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/5-ember-data.html
+++ b/examples/5-ember-data.html
@@ -124,8 +124,13 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant'
+      App.LoginController  = Ember.Controller.extend({
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials);
+          }
+        }
       });
 
       // make these routes protected

--- a/examples/5-ember-data.html
+++ b/examples/5-ember-data.html
@@ -123,8 +123,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
         actions: {
           authenticate: function() {
             var credentials = this.getProperties('identification', 'password');

--- a/examples/6-custom-server.html
+++ b/examples/6-custom-server.html
@@ -176,13 +176,13 @@
           controller.set('errorMessage', null);
         }
       });
-      App.LoginController = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'authenticator:custom',
+      App.LoginController = Ember.Controller.extend({
         actions: {
           // display an error when authentication fails
           authenticate: function() {
             var _this = this;
-            this._super().then(null, function(message) {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('authenticator:custom', credentials).then(null, function(message) {
               _this.set('errorMessage', message);
             });
           }

--- a/examples/6-custom-server.html
+++ b/examples/6-custom-server.html
@@ -169,8 +169,14 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginRoute       = Ember.Route.extend({
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginRoute = Ember.Route.extend({
         // clear a potentially stale error message from previous login attempts
         setupController: function(controller, model) {
           controller.set('errorMessage', null);

--- a/examples/7-multiple-external-providers.html
+++ b/examples/7-multiple-external-providers.html
@@ -180,7 +180,13 @@
       });
 
       // use the provided mixin in the application route
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
 
       // define the login route that defines the authentication actions
       App.LoginRoute = Ember.Route.extend({

--- a/examples/8-cookie-store.html
+++ b/examples/8-cookie-store.html
@@ -108,14 +108,20 @@
 
       // use the provided mixins in the application route and login controller
       App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, {
-        authenticator: 'simple-auth-authenticator:oauth2-password-grant',
+      App.LoginController  = Ember.Controller.extend({
         rememberMe:    false,
 
         // change the store's cookie expiration time depending on whether "remember me" is checked or not
         rememberMeChanged: function() {
           this.get('session.store').cookieExpirationTime = this.get('rememberMe') ? 1209600 : null;
-        }.observes('rememberMe')
+        }.observes('rememberMe'),
+
+        actions: {
+          authenticate: function() {
+            var credentials = this.getProperties('identification', 'password');
+            this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', credentials);
+          }
+        }
       });
 
       // make this route protected

--- a/examples/8-cookie-store.html
+++ b/examples/8-cookie-store.html
@@ -107,9 +107,15 @@
       });
 
       // use the provided mixins in the application route and login controller
-      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin);
-      App.LoginController  = Ember.Controller.extend({
-        rememberMe:    false,
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          invalidateSession: function() {
+            this.get('session').invalidate();
+          }
+        }
+      });
+      App.LoginController = Ember.Controller.extend({
+        rememberMe: false,
 
         // change the store's cookie expiration time depending on whether "remember me" is checked or not
         rememberMeChanged: function() {

--- a/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/stores/cookie.js
+++ b/packages/ember-simple-auth-cookie-store/lib/simple-auth-cookie-store/stores/cookie.js
@@ -22,9 +22,7 @@ import Configuration from './../configuration';
 
   ```js
   // app/controllers/login.js
-  import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin';
-
-  export default Ember.Controller.extend(LoginControllerMixin, {
+  export default Ember.Controller.extend({
     rememberMe: false,
 
     rememberMeChanged: function() {

--- a/packages/ember-simple-auth-devise/README.md
+++ b/packages/ember-simple-auth-devise/README.md
@@ -155,20 +155,14 @@ This route displays the login form with fields for `identification`,
 </form>
 ```
 
-The `authenticate` action that is triggered by submitting the form is provided
-by the `LoginControllerMixin` that the respective controller in the application
-can include (the controller can also implement its own action and use the
-session API directly; see the
-[API docs for `Session`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
-It then also needs to specify the Devise authenticator to be used:
+The `auhtenticate` action authenticates the session with the
+`'simple-auth-authenticator:devise'` authenticator:
 
 ```js
-// app/controllers/login.js
-import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin'
-
-export default Ember.Controller.extend(LoginControllerMixin, {
-  authenticator: 'simple-auth-authenticator:devise'
-});
+authenticate: function() {
+  var data = this.getProperties('identification', 'password');
+  return this.get('session').authenticate('simple-auth-authenticator:devise', data);
+}
 ```
 
 ## The Authorizer

--- a/packages/ember-simple-auth-oauth2/README.md
+++ b/packages/ember-simple-auth-oauth2/README.md
@@ -68,20 +68,14 @@ This route displays the login form with fields for `identification` and
 </form>
 ```
 
-The `authenticate` action that is triggered by submitting the form is provided
-by the `LoginControllerMixin` that the respective controller in the application
-can include (the controller can also implement its own action and use the
-session API directly; see the
-[API docs for `Session`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session)).
-It then also needs to specify the OAuth 2.0 authenticator to be used:
+The `auhtenticate` action authenticates the session with the
+`'simple-auth-authenticator:oauth2-password-grant'` authenticator:
 
 ```js
-// app/controllers/login.js
-import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin';
-
-export default Ember.Controller.extend(LoginControllerMixin, {
-  authenticator: 'simple-auth-authenticator:oauth2-password-grant'
-});
+authenticate: function() {
+  var data = this.getProperties('identification', 'password');
+  return this.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', data);
+}
 ```
 
 ### Compatible Middlewares

--- a/packages/ember-simple-auth/README.md
+++ b/packages/ember-simple-auth/README.md
@@ -105,18 +105,6 @@ The authenticator to use is chosen when authentication is triggered:
 this.get('session').authenticate('authenticator:some', {});
 ```
 
-or when using the
-[`LoginControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-LoginControllerMixin):
-
-```js
-// app/controllers/login.js
-import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin';
-
-export default Ember.Controller.extend(LoginControllerMixin, {
-  authenticator: 'authenticator:some'
-});
-```
-
 Ember Simple Auth does not include any authenticators in the base library but
 has extension libraries that can be loaded as needed:
 
@@ -158,18 +146,6 @@ registered factory's name to the session's `authenticate` method (see the
 this.get('session').authenticate('authenticator:custom', {});
 ```
 
-or when using the
-[`LoginControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-LoginControllerMixin):
-
-```js
-// app/controllers/login.js
-import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin';
-
-export default Ember.Controller.extend(LoginControllerMixin, {
-  authenticator: 'authenticator:custom'
-});
-```
-
 **Note that when you're not using Ember CLI the authenticator will not be
 registered with the container automatically and you need to do that in an
 initializer:**
@@ -186,12 +162,6 @@ export default {
   }
 };
 ```
-
-Also see the
-[API docs for `Session#authenticate`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-Session-authenticate),
-[`LoginControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-LoginControllerMixin)
-and
-[`AuthenticationControllerMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-AuthenticationControllerMixin).
 
 ### Authorizers
 

--- a/packages/ember-simple-auth/README.md
+++ b/packages/ember-simple-auth/README.md
@@ -56,9 +56,8 @@ import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
 export default Ember.Route.extend(ApplicationRouteMixin);
 ```
 
-This adds some actions to the application route like `authenticateSession` and
-`invalidateSession` as well as callback actions that are triggered when the
-session's authentication state changes like `sessionAuthenticationSucceeded` or
+This adds some callback actions that are triggered when the session's
+authentication state changes like `sessionAuthenticationSucceeded` or
 `sessionInvalidationSucceeded` (see the
 [API docs for `ApplicationRouteMixin`](http://ember-simple-auth.com/ember-simple-auth-api-docs.html#SimpleAuth-ApplicationRouteMixin)).
 Displaying e.g. login/logout buttons in the UI depending on the session's
@@ -70,6 +69,14 @@ authentication state then is as easy as:
 {{else}}
   {{#link-to 'login'}}Login{{/link-to}}
 {{/if}}
+```
+
+In the `invalidateSession` action simply call the session's `invalidate` method:
+
+```js
+invalidateSession: function() {
+  this.get('session').invalidate();
+}
 ```
 
 To make a route in the application require the session to be authenticated,

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -104,9 +104,8 @@ export default Ember.Object.extend(Ember.Evented, {
     Authenticates the session with the specified `options`. These options vary
     depending on the actual authentication mechanism the authenticator
     implements (e.g. a set of credentials or a Facebook account id etc.). __The
-    session will invoke this method when an action in the application triggers
-    authentication__ (see
-    [SimpleAuth.AuthenticationControllerMixin.actions#authenticate](#SimpleAuth-AuthenticationControllerMixin-authenticate)).
+    session will invoke this method when it is being authenticated__ (see
+    [SimpleAuth.Session#authenticate](#SimpleAuth-Session-authenticate)).
 
     __This method returns a promise. A resolving promise will result in the
     session being authenticated.__ Any properties the promise resolves with

--- a/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
+++ b/packages/ember-simple-auth/lib/simple-auth/authenticators/base.js
@@ -37,10 +37,12 @@
 
   ```js
   // app/controllers/login.js
-  import AuthenticationControllerMixin from 'simple-auth/mixins/authentication-controller-mixin';
-
-  export default Ember.Controller.extend(AuthenticationControllerMixin, {
-    authenticator: 'authenticator:custom'
+  export default Ember.Controller.extend({
+    actions: {
+      authenticate: function() {
+        this.get('session').authenticate('authenticator:custom');
+      }
+    }
   });
   ```
 

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -125,6 +125,7 @@ export default Ember.Mixin.create({
       ```
 
       @method actions.authenticateSession
+      @deprecated use [`ApplicationRouteMixin#sessionRequiresAuthentication`](#SimpleAuth-ApplicationRouteMixin-sessionRequiresAuthentication) instead
     */
     authenticateSession: function() {
       Ember.deprecate('The authenticateSession action is deprecated. Use sessionRequiresAuthentication instead.');
@@ -183,6 +184,7 @@ export default Ember.Mixin.create({
       [`ApplicationRouteMixin#sessionInvalidationSucceeded`](#SimpleAuth-ApplicationRouteMixin-sessionInvalidationSucceeded)).
 
       @method actions.invalidateSession
+      @deprecated use [`Session#invalidate`](#SimpleAuth-Session-invalidate) instead
     */
     invalidateSession: function() {
       Ember.deprecate("The invalidateSession action is deprecated. Use the session's invalidate method directly instead.");

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -3,32 +3,11 @@ import Configuration from './../configuration';
 var routeEntryComplete = false;
 
 /**
-  The mixin for the application route; defines actions to authenticate the
-  session as well as to invalidate it. These actions can be used in all
-  templates like this:
-
-  ```handlebars
-  {{#if session.isAuthenticated}}
-    <a {{ action 'invalidateSession' }}>Logout</a>
-  {{else}}
-    <a {{ action 'authenticateSession' }}>Login</a>
-  {{/if}}
-  ```
-
-  or in the case that the application uses a dedicated route for logging in:
-
-  ```handlebars
-  {{#if session.isAuthenticated}}
-    <a {{ action 'invalidateSession' }}>Logout</a>
-  {{else}}
-    {{#link-to 'login'}}Login{{/link-to}}
-  {{/if}}
-  ```
-
-  This mixin also defines actions that are triggered whenever the session is
-  successfully authenticated or invalidated and whenever authentication or
-  invalidation fails. These actions provide a good starting point for adding
-  custom behavior to these events.
+  The mixin for the application route; defines actions that are triggered
+  when authentication is required, when the session has successfully been
+  authenticated or invalidated or when authentication or invalidation fails or
+  authorization is rejected by the server. These actions provide a good
+  starting point for adding custom behavior to these events.
 
   __When this mixin is used and the application's `ApplicationRoute` defines
   the `beforeModel` method, that method has to call `_super`.__

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -177,6 +177,7 @@ export default Ember.Mixin.create({
       @method actions.invalidateSession
     */
     invalidateSession: function() {
+      Ember.deprecate("The invalidateSession action is deprecated. Use the session's invalidate method directly instead.");
       this.get(Configuration.sessionPropertyName).invalidate();
     },
 

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -74,7 +74,35 @@ export default Ember.Mixin.create({
 
   actions: {
     /**
-      This action triggers transition to the
+      This action triggers a transition to the
+      [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute).
+      It is triggered automatically by the
+      [`AuthenticatedRouteMixin`](#SimpleAuth-AuthenticatedRouteMixin) whenever
+      a route that requries authentication is accessed but the session is not
+      currently authenticated.
+
+      __For an application that works without an authentication route (e.g.
+      because it opens a new window to handle authentication there), this is
+      the action to override, e.g.:__
+
+      ```js
+      App.ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, {
+        actions: {
+          sessionRequiresAuthentication: function() {
+            this.get('session').authenticate('authenticator:custom', {});
+          }
+        }
+      });
+      ```
+
+      @method actions.sessionRequiresAuthentication
+    */
+    sessionRequiresAuthentication: function() {
+      this.transitionTo(Configuration.authenticationRoute);
+    },
+
+    /**
+      This action triggers a transition to the
       [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute).
       It can be used in templates as shown above. It is also triggered
       automatically by the
@@ -99,7 +127,8 @@ export default Ember.Mixin.create({
       @method actions.authenticateSession
     */
     authenticateSession: function() {
-      this.transitionTo(Configuration.authenticationRoute);
+      Ember.deprecate('The authenticateSession action is deprecated. Use sessionRequiresAuthentication instead.');
+      this.send('sessionRequiresAuthentication');
     },
 
     /**

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/authenticated-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/authenticated-route-mixin.js
@@ -46,7 +46,7 @@ export default Ember.Mixin.create({
       transition.abort();
       this.get(Configuration.sessionPropertyName).set('attemptedTransition', transition);
       Ember.assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== Configuration.authenticationRoute);
-      transition.send('authenticateSession');
+      transition.send('sessionRequiresAuthentication');
     }
 
     return superResult;

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
@@ -11,6 +11,7 @@ import Configuration from './../configuration';
   @namespace SimpleAuth
   @module simple-auth/mixins/authentication-controller-mixin
   @extends Ember.Mixin
+  @deprecated use [`Session#authenticate`](#SimpleAuth-Session-authenticate) instead
 */
 export default Ember.Mixin.create({
   /**

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
@@ -1,7 +1,5 @@
 import Configuration from './../configuration';
 
-Ember.deprecate("The AuthenticationControllerMixin is deprecated. Use the session's authenticate method directly instead.");
-
 /**
   This mixin is for the controller that handles the
   [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute).
@@ -37,6 +35,7 @@ export default Ember.Mixin.create({
       @param {Object} options Any options the authenticator needs to authenticate the session
     */
     authenticate: function(options) {
+      Ember.deprecate("The AuthenticationControllerMixin is deprecated. Use the session's authenticate method directly instead.");
       var authenticator = this.get('authenticator');
       Ember.assert('AuthenticationControllerMixin/LoginControllerMixin require the authenticator property to be set on the controller!', !Ember.isEmpty(authenticator));
       return this.get(Configuration.sessionPropertyName).authenticate(authenticator, options);

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/authentication-controller-mixin.js
@@ -1,5 +1,7 @@
 import Configuration from './../configuration';
 
+Ember.deprecate("The AuthenticationControllerMixin is deprecated. Use the session's authenticate method directly instead.");
+
 /**
   This mixin is for the controller that handles the
   [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute).

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
@@ -29,6 +29,7 @@ import AuthenticationControllerMixin from './authentication-controller-mixin';
   @namespace SimpleAuth
   @module simple-auth/mixins/login-controller-mixin
   @extends SimpleAuth.AuthenticationControllerMixin
+  @deprecated use [`Session#authenticate`](#SimpleAuth-Session-authenticate) instead
 */
 export default Ember.Mixin.create(AuthenticationControllerMixin, {
   actions: {

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
@@ -1,6 +1,8 @@
 import Configuration from './../configuration';
 import AuthenticationControllerMixin from './authentication-controller-mixin';
 
+Ember.deprecate("The LoginControllerMixin is deprecated. Use the session's authenticate method directly instead.");
+
 /**
   This mixin is for the controller that handles the
   [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute)

--- a/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/login-controller-mixin.js
@@ -1,8 +1,6 @@
 import Configuration from './../configuration';
 import AuthenticationControllerMixin from './authentication-controller-mixin';
 
-Ember.deprecate("The LoginControllerMixin is deprecated. Use the session's authenticate method directly instead.");
-
 /**
   This mixin is for the controller that handles the
   [`Configuration.authenticationRoute`](#SimpleAuth-Configuration-authenticationRoute)
@@ -47,6 +45,7 @@ export default Ember.Mixin.create(AuthenticationControllerMixin, {
       @method actions.authenticate
     */
     authenticate: function() {
+      Ember.deprecate("The LoginControllerMixin is deprecated. Use the session's authenticate method directly instead.");
       var data = this.getProperties('identification', 'password');
       this.set('password', null);
       return this._super(data);

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
@@ -100,9 +100,26 @@ describe('ApplicationRouteMixin', function() {
     });
   });
 
+  describe('the "sessionRequiresAuthentication" action', function() {
+    beforeEach(function() {
+      sinon.spy(this.route, 'transitionTo');
+    });
+
+    it('transitions to "Configuration.authenticationRoute"', function() {
+      this.route._actions.sessionRequiresAuthentication.apply(this.route);
+
+      expect(this.route.transitionTo).to.have.been.calledWith(Configuration.authenticationRoute);
+    });
+  });
+
   describe('the "authenticateSession" action', function() {
     beforeEach(function() {
       sinon.spy(this.route, 'transitionTo');
+      this.route.send = function(name) {
+        if (name === 'sessionRequiresAuthentication') {
+          this.route._actions.sessionRequiresAuthentication.apply(this.route);
+        }
+      }.bind(this);
     });
 
     it('transitions to "Configuration.authenticationRoute"', function() {

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
@@ -114,12 +114,13 @@ describe('ApplicationRouteMixin', function() {
 
   describe('the "authenticateSession" action', function() {
     beforeEach(function() {
-      sinon.spy(this.route, 'transitionTo');
-      this.route.send = function(name) {
+      var route = this.route;
+      sinon.spy(route, 'transitionTo');
+      route.send = function(name) {
         if (name === 'sessionRequiresAuthentication') {
-          this.route._actions.sessionRequiresAuthentication.apply(this.route);
+          route._actions.sessionRequiresAuthentication.apply(route);
         }
-      }.bind(this);
+      };
     });
 
     it('transitions to "Configuration.authenticationRoute"', function() {

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/authenticated-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/authenticated-route-mixin-test.js
@@ -45,7 +45,7 @@ describe('AuthenticatedRouteMixin', function() {
         expect(this.transition.abort).to.not.have.been.called;
       });
 
-      it('does not invoke the "authenticateSession" action', function() {
+      it('does not invoke the "sessionRequiresAuthentication" action', function() {
         this.route.beforeModel(this.transition);
 
         expect(this.transition.send).to.not.have.been.called;
@@ -68,10 +68,10 @@ describe('AuthenticatedRouteMixin', function() {
         expect(this.transition.abort).to.have.been.called;
       });
 
-      it('invokes the "authenticateSession" action', function() {
+      it('invokes the "sessionRequiresAuthentication" action', function() {
         this.route.beforeModel(this.transition);
 
-        expect(this.transition.send).to.have.been.calledWith('authenticateSession');
+        expect(this.transition.send).to.have.been.calledWith('sessionRequiresAuthentication');
       });
     });
   });


### PR DESCRIPTION
This deprecates the `LoginControllerMixin`, `AuthenticationControllerMixin` and the `ApplicationRouteMixin`'s `invalidateSession` method as these don't really add any value anyways.

### TODO

- [x] remove the `ApplicationRouteMixin`'s `invalidateSession` method from the docs and examples.
- [x] deprecate the `ApplicationRouteMixin`'s `authenticateSession` method as well and add a new `sessionRequiresAuthentication` method instead.