### PR TITLE
ember-simple-auth-oauth2 is not accessing the secure session introduced in #414

### DIFF
--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
@@ -183,20 +183,21 @@ export default Base.extend({
       resolve();
     }
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      if (!Ember.isEmpty(_this.serverTokenRevocationEndpoint)) {
+      if (Ember.isEmpty(_this.serverTokenRevocationEndpoint)) {
+        success(resolve);
+      } else {
         var requests = [];
         Ember.A(['access_token', 'refresh_token']).forEach(function(tokenType) {
-          if (!Ember.isEmpty(data[tokenType])) {
+          var token = data[tokenType];
+          if (!Ember.isEmpty(token)) {
             requests.push(_this.makeRequest(_this.serverTokenRevocationEndpoint, {
-              token_type_hint: tokenType, token: data[tokenType]
+              token_type_hint: tokenType, token: token
             }));
           }
         });
         Ember.$.when.apply(Ember.$, requests).always(function(responses) {
           success(resolve);
         });
-      } else {
-        success(resolve);
       }
     });
   },

--- a/packages/ember-simple-auth/README.md
+++ b/packages/ember-simple-auth/README.md
@@ -402,7 +402,7 @@ grunt server
 ```
 
 and then run the tests in the browser at
-[http://localhost:8000](http://localhost:8000).
+[http://localhost:8000/test/](http://localhost:8000/test/).
 
 ## License
 

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -196,7 +196,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var authenticator = _this.container.lookup(_this.authenticator);
-      authenticator.invalidate(_this.content).then(function() {
+      authenticator.invalidate(_this.content.secure).then(function() {
         authenticator.off('sessionDataUpdated');
         _this.clear(true);
         resolve();


### PR DESCRIPTION
Not really a PR (maybe in the future), more of a question about version 0.8.0-beta.1

When using the OAuth authenticator the `invalidateSession` action is not sending a request to the backend even though I have configured the route like this:

    ENV['simple-auth-oauth2'] = {
      serverTokenRevocationEndpoint: '/user/logout'
    };

So, I think that a fix similar to what this PR shows is needed. Is this correct?

Seems like the `invalidateSession` is not aware of the special key **secure**.