### PR TITLE
Added support for additional request data when authorizing with OAuth2 server

### DIFF
--- a/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
+++ b/packages/ember-simple-auth-oauth2/lib/simple-auth-oauth2/authenticators/oauth2.js
@@ -139,6 +139,7 @@ export default Base.extend({
     @param {Object} options
     @param {String} options.identification The resource owner username
     @param {String} options.password The resource owner password
+    @param {Object} options.extras Additional data to send to the OAuth server
     @param {String|Array} [options.scope] The scope of the access request (see [RFC 6749, section 3.3](http://tools.ietf.org/html/rfc6749#section-3.3))
     @return {Ember.RSVP.Promise} A promise that resolves when an access token is successfully acquired from the server and rejects otherwise
   */
@@ -149,6 +150,9 @@ export default Base.extend({
       if (!Ember.isEmpty(options.scope)) {
         var scopesString = Ember.makeArray(options.scope).join(' ');
         Ember.merge(data, { scope: scopesString });
+      }
+      if (!Ember.isEmpty(options.extras) && Ember.typeOf(options.extras) === 'object') {
+        Ember.merge(data, options.extras);
       }
       _this.makeRequest(_this.serverTokenEndpoint, data).then(function(response) {
         Ember.run(function() {

--- a/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
+++ b/packages/ember-simple-auth-oauth2/tests/simple-auth-oauth2/authenticators/oauth2-test.js
@@ -187,6 +187,15 @@ describe('OAuth2', function() {
       });
     });
 
+    it('sends additional data to the token endpooint', function(done) {
+      this.authenticator.authenticate({ identification: 'username', password: 'password', extras: {extra: 'data'} });
+
+      Ember.run.next(function() {
+        expect(Ember.$.ajax.getCall(0).args[0].data.extra).to.eql('data');
+        done();
+      });
+    });
+
     context('when the authentication request is successful', function() {
       beforeEach(function() {
         this.server.respondWith('POST', '/token', [


### PR DESCRIPTION
Hi there,

I've added support for sending additional data to the OAuth2 server when requesting a token. This way the _ember-simple-auth_ library has support for auth SAAS'es like [Auth0](https://auth0.com/docs/protocols#9).
