### PR TITLE
fix typo in readme (misspelled authenticate)

### DIFF
--- a/packages/ember-simple-auth-oauth2/README.md
+++ b/packages/ember-simple-auth-oauth2/README.md
@@ -68,7 +68,7 @@ This route displays the login form with fields for `identification` and
 </form>
 ```
 
-The `auhtenticate` action authenticates the session with the
+The `authenticate` action authenticates the session with the
 `'simple-auth-authenticator:oauth2-password-grant'` authenticator:
 
 ```js


### PR DESCRIPTION
Pretty self explanatory, authenticate is misspelled, noticed it while browsing the documentation and figured I'd open a pull for it.