### PR TITLE
fix localStorageKey documentation

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/configuration.js
+++ b/packages/ember-simple-auth/lib/simple-auth/configuration.js
@@ -120,7 +120,7 @@ export default {
   /**
     The key the store stores the data in.
 
-    @property key
+    @property localStorageKey
     @type String
     @default 'ember_simple_auth:session'
   */


### PR DESCRIPTION
the doc says still 'key' on the website. Was wondering why it is not working. Looking at the code revealed it :)