### PR TITLE
Adding Session event "sessionRestorationSucceeded"

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/lib/simple-auth/mixins/application-route-mixin.js
@@ -60,6 +60,7 @@ export default Ember.Mixin.create({
         'sessionAuthenticationSucceeded',
         'sessionAuthenticationFailed',
         'sessionInvalidationSucceeded',
+        'sessionRestorationSucceeded',
         'sessionInvalidationFailed',
         'authorizationFailed'
       ]).forEach(function(event) {
@@ -210,6 +211,16 @@ export default Ember.Mixin.create({
       if (!Ember.testing) {
         window.location.replace(Configuration.applicationRootUrl);
       }
+    },
+
+    /**
+      This action is invoked whenever session restoration succeeds. This mainly
+      serves as an extension point to add custom behavior and does nothing by
+      default.
+
+      @method actions.sessionRestorationSucceeded
+    */
+    sessionRestorationSucceeded: function() {
     },
 
     /**

--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -67,6 +67,15 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @event sessionInvalidationSucceeded
   */
   /**
+    Triggered __whenever the session is successfully restored__. When the
+    application uses the
+    [`ApplicationRouteMixin` mixin](#SimpleAuth-ApplicationRouteMixin),
+    [`ApplicationRouteMixin.actions#sessionRestorationSucceeded`](#SimpleAuth-ApplicationRouteMixin-sessionRestorationSucceeded)
+    will be invoked whenever this event is triggered.
+
+    @event sessionRestorationSucceeded
+    */
+  /**
     Triggered __whenever an attempt to invalidate the session fails__. When the
     application uses the
     [`ApplicationRouteMixin` mixin](#SimpleAuth-ApplicationRouteMixin),
@@ -220,6 +229,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         delete restoredContent.secure.authenticator;
         _this.container.lookup(authenticator).restore(restoredContent.secure).then(function(content) {
           _this.setup(authenticator, content);
+          _this.trigger('sessionRestorationSucceeded');
           resolve();
         }, function() {
           _this.clear();

--- a/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/mixins/application-route-mixin-test.js
@@ -70,6 +70,15 @@ describe('ApplicationRouteMixin', function() {
         });
       });
 
+      it("translates the session's 'sessionRestorationSucceeded' event into an action invocation", function(done) {
+        this.session.trigger('sessionRestorationSucceeded');
+
+        Ember.run.next(this, function() {
+          expect(this.route.send).to.have.been.calledWith('sessionRestorationSucceeded');
+          done();
+        });
+      });
+
       it("translates the session's 'sessionInvalidationFailed' event into an action invocation", function(done) {
         this.session.trigger('sessionInvalidationFailed', 'error');
 

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -191,6 +191,16 @@ describe('Session', function() {
           });
         });
 
+        it('triggers the "sessionRestorationSucceeded" event', function(done) {
+          var triggered = false;
+          this.session.one('sessionRestorationSucceeded', function() { triggered = true; });
+
+          this.session.restore().then(function() {
+            expect(triggered).to.be.true;
+            done();
+          });
+        });
+
         itHandlesAuthenticatorEvents(function(done) {
           var _this = this;
           this.session.restore().then(function() {


### PR DESCRIPTION
Adding a new Session event that is triggered when authentication is restored (usually on app reload).

**Background:**
I am developing a Cordova + Ember iOS app. When the app is updated via the App Store or TestFlight the Ember app is reloaded the next time the iOS app is brought to the foreground. I need to know when the session is fully restored so that I can access the data in the store.

If there is a better way of achieving this that does not require a code change to this project I am all ears.

**Example initializer using event**
```js
export function initialize(container, application) {
  var session = container.lookup('simple-auth-session:main');
  // handle the session events
  session.on('sessionRestorationSucceeded', function() {
    console.log('RESTORED!');
  });
}

export default {
  name: 'test',
  initialize: initialize
};
```