### PR TITLE
Unnecessary to set container

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -82,7 +82,7 @@ export default function(container, application) {
 
   var store   = container.lookup(Configuration.store);
   var session = container.lookup(Configuration.session);
-  session.setProperties({ store: store, container: container });
+  session.set('store', store);
   Ember.A(['controller', 'route', 'component']).forEach(function(component) {
     application.inject(component, Configuration.sessionPropertyName, Configuration.session);
   });


### PR DESCRIPTION
All objects fetched from the container already have the container property set.