### PR TITLE
Accessing container from initializer depricated, use instanceInitializer instead

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/ember.js
+++ b/packages/ember-simple-auth/lib/simple-auth/ember.js
@@ -1,5 +1,9 @@
 import initializer from './initializer';
+import instainceInitializer from './instaince-initializer';
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer(initializer);
+  if(Application.instainceInitializer) {
+    Application.instainceInitializer(instainceInitializer);
+  }
 });

--- a/packages/ember-simple-auth/lib/simple-auth/ember.js
+++ b/packages/ember-simple-auth/lib/simple-auth/ember.js
@@ -1,9 +1,9 @@
 import initializer from './initializer';
-import instainceInitializer from './instaince-initializer';
+import instanceInitializer from './instance-initializer';
 
 Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer(initializer);
   if(Application.instainceInitializer) {
-    Application.instainceInitializer(instainceInitializer);
+    Application.instanceInitializer(instanceInitializer);
   }
 });

--- a/packages/ember-simple-auth/lib/simple-auth/initializer.js
+++ b/packages/ember-simple-auth/lib/simple-auth/initializer.js
@@ -4,9 +4,12 @@ import setup from './setup';
 
 export default {
   name:       'simple-auth',
-  initialize: function(container, application) {
-    var config = getGlobalConfig('simple-auth');
-    Configuration.load(container, config);
-    setup(container, application);
+  initialize: function(registry, application) {
+    if(registry.hasOwnProperty('lookup')) {
+      var container = registry;
+      var config = getGlobalConfig('simple-auth');
+      Configuration.load(container, config);
+      setup(container, application);
+    }
   }
 };

--- a/packages/ember-simple-auth/lib/simple-auth/instance-initializer.js
+++ b/packages/ember-simple-auth/lib/simple-auth/instance-initializer.js
@@ -1,0 +1,22 @@
+import Configuration from './configuration';
+import getGlobalConfig from './utils/get-global-config';
+import setup from './setup';
+
+export default {
+  name:       'simple-auth',
+  initialize: function(instance) {
+    var config = getGlobalConfig('simple-auth');
+    var container = instance.container;
+    var appRoute = container.lookup('route:application');
+
+    appRoute.reopen({
+      beforeModel: function(transition) {
+        var _this = this;
+        Configuration.load(container, config);
+        return setup(container, container.lookup('application:main'), true).then(function() {
+          return _this._super(transition);
+        });
+      }
+    });
+  }
+};

--- a/packages/ember-simple-auth/lib/simple-auth/setup.js
+++ b/packages/ember-simple-auth/lib/simple-auth/setup.js
@@ -76,8 +76,10 @@ var didSetupAjaxHooks = false;
   @method setup
   @private
 **/
-export default function(container, application) {
-  application.deferReadiness();
+export default function(container, application, isInRoute) {
+  if(!isInRoute) {
+    application.deferReadiness();
+  }
   registerFactories(application);
 
   var store   = container.lookup(Configuration.store);
@@ -108,7 +110,10 @@ export default function(container, application) {
   }
 
   var advanceReadiness = function() {
-    application.advanceReadiness();
+    if(!isInRoute) {
+      application.advanceReadiness();
+    }
+    return Ember.RSVP.resolve();
   };
-  session.restore().then(advanceReadiness, advanceReadiness);
+  return session.restore().then(advanceReadiness, advanceReadiness);
 }

--- a/packages/ember-simple-auth/tests/simple-auth/instance-initializer-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/instance-initializer-test.js
@@ -1,0 +1,7 @@
+import initializer from 'simple-auth/instaince-initializer';
+
+describe('the "simple-auth" instaince initializer', function() {
+  it('has the correct name', function() {
+    expect(initializer.name).to.eq('simple-auth');
+  });
+});

--- a/packages/ember-simple-auth/tests/simple-auth/instance-initializer-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/instance-initializer-test.js
@@ -1,7 +1,0 @@
-import initializer from 'simple-auth/instaince-initializer';
-
-describe('the "simple-auth" instaince initializer', function() {
-  it('has the correct name', function() {
-    expect(initializer.name).to.eq('simple-auth');
-  });
-});

--- a/packages/ember-simple-auth/tests/simple-auth/setup-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/setup-test.js
@@ -28,7 +28,7 @@ describe('setup', function() {
 
   it("defers the application's readiness", function() {
     sinon.spy(this.application, 'deferReadiness');
-    setup(this.container, this.application, {});
+    setup(this.container, this.application);
 
     expect(this.application.deferReadiness).to.have.been.calledOnce;
   });
@@ -104,7 +104,7 @@ describe('setup', function() {
 
   it("advances the application's readiness", function(done) {
     sinon.spy(this.application, 'advanceReadiness');
-    setup(this.container, this.application, {});
+    setup(this.container, this.application);
 
     Ember.run.next(this, function() {
       expect(this.application.advanceReadiness).to.have.been.calledOnce;

--- a/packages/ember-simple-auth/wrap/browser.end
+++ b/packages/ember-simple-auth/wrap/browser.end
@@ -1,4 +1,5 @@
 var initializer                   = requireModule('simple-auth/initializer')['default'];
+var instanceInitializer           = requireModule('simple-auth/instance-Initializer')['default'];
 var Configuration                 = requireModule('simple-auth/configuration')['default'];
 var Session                       = requireModule('simple-auth/session')['default'];
 var BaseAuthenticator             = requireModule('simple-auth/authenticators/base')['default'];


### PR DESCRIPTION
Since the container can no longer be accessed from an `initializer`, the initializer is pretty much useless so I replaced it with the new `instanceInitializer`. 

But the application has already been made ready by the time this is called so calling `application.deferReadiness()` in `setup` won't work anymore, so I've altered it to setup during the application route's `beforeModel` hook instead (this has the added benefit of allowing the applications loading state to show before trying to setup).

I'm not sure if it's the right approach but it works for me.

All the authenticators would need to be updated as well as the [ember-cli-simple-auth](https://github.com/simplabs/ember-cli-simple-auth), and probably all others that use initializer!

Solves #517 