### PR TITLE
Fixed bug on main repo for issue#523: non-secure session data not bei…

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -142,7 +142,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     `options`. __This delegates the actual authentication work to the
     `authenticator`__ and handles the returned promise accordingly (see
     [`Authenticators.Base#authenticate`](#SimpleAuth-Authenticators-Base-authenticate)).
-    All data the authenticator resolves with will be saved in the session.
+    All data the authenticator resolves with will be saved in the session's `secure` property.
 
     __This method returns a promise itself. A resolving promise indicates that
     the session was successfully authenticated__ while a rejecting promise
@@ -219,6 +219,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
       if (!!authenticator) {
         delete restoredContent.secure.authenticator;
         _this.container.lookup(authenticator).restore(restoredContent.secure).then(function(content) {
+          _this.set('content', restoredContent);
           _this.setup(authenticator, content);
           resolve();
         }, function() {

--- a/packages/ember-simple-auth/tests/simple-auth/session-test.js
+++ b/packages/ember-simple-auth/tests/simple-auth/session-test.js
@@ -162,12 +162,12 @@ describe('Session', function() {
 
         it('persists its content in the store', function(done) {
           var _this = this;
-
+          this.store.persist({ secure: { authenticator: 'authenticator' }, someOther: 'property' });
           this.session.restore().then(function() {
             var properties = _this.store.restore();
             delete properties.authenticator;
 
-            expect(properties).to.eql({ secure: { some: 'property', authenticator: 'authenticator' } });
+            expect(properties).to.eql({ secure: { some: 'property', authenticator: 'authenticator' }, someOther: 'property' });
             done();
           });
         });


### PR DESCRIPTION
References this issue https://github.com/simplabs/ember-simple-auth/issues/523

Issue: non-secure session data was being wiped from the store and not restored when the `session.restore()` method was called. 

I altered a test to check its functionality as well. 

Only issue i could see happening here is that an event attached to session data being changed might fire twice now. 