### PR TITLE
add asserts to fix jshint

### DIFF
--- a/packages/ember-simple-auth-testing/README.md
+++ b/packages/ember-simple-auth-testing/README.md
@@ -9,13 +9,13 @@ server responses etc.
 To authenticate the session, use the `authenticateSession` helper, e.g.:
 
 ```js
-test('a protected route is accessible when the session is authenticated', function() {
-  expect(1);
+test('a protected route is accessible when the session is authenticated', function(assert) {
+  assert.expect(1);
   authenticateSession();
   visit('/protected');
 
   andThen(function() {
-    equal(currentRouteName(), 'protected');
+    assert.equal(currentRouteName(), 'protected');
   });
 });
 ```
@@ -23,13 +23,13 @@ test('a protected route is accessible when the session is authenticated', functi
 and to invalidate the session, use the `invaldiateSession` helper, e.g.:
 
 ```js
-test('a protected route is not accessible when the session is not authenticated', function() {
-  expect(1);
+test('a protected route is not accessible when the session is not authenticated', function(assert) {
+  assert.expect(1);
   invalidateSession();
   visit('/protected');
 
   andThen(function() {
-    notEqual(currentRouteName(), 'protected');
+    assert.notEqual(currentRouteName(), 'protected');
   });
 });
 ```
@@ -38,14 +38,14 @@ This package also defines the `currentSession` helper that provides access to
 the session from tests to e.g. set properties on it:
 
 ```js
-test("the current project's name is displayed in the page header", function() {
-  expect(1);
+test("the current project's name is displayed in the page header", function(assert) {
+  assert.expect(1);
   authenticateSession();
   currentSession().set('currentProject', 'some test project');
   visit('/dashboard');
 
   andThen(function() {
-    findWithAssert('h1:contains("some test project")');
+    assert.findWithAssert('h1:contains("some test project")');
   });
 });
 ```


### PR DESCRIPTION
For me, when I run these tests without assert, jshint blows up

![1__node_and_comparing_simplabs_master___mikepmunroe_patch-1_ _simplabs_ember-simple-auth](https://cloud.githubusercontent.com/assets/514063/8047413/0604ed3c-0e13-11e5-80c4-876d2328f27f.png)

Adding the asserts fixing the problem. I think asserts should be the chosen syntax.