### PR TITLE
Initialize session content

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/session.js
+++ b/packages/ember-simple-auth/lib/simple-auth/session.js
@@ -135,7 +135,18 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     @property content
     @private
   */
-  content: { secure: {} },
+  content: null,
+
+  /**
+    Initializes the content object so references aren't shared across
+    instances.
+
+    @method initializeContent
+    @private
+  */
+  initializeContent: Ember.on('init', function() {
+    this.set('content', { secure: {} });
+  }),
 
   /**
     Authenticates the session with an `authenticator` and appropriate


### PR DESCRIPTION
The `content` object in `Session` is the same object for all instances of `Session`, which works okay when there's one session but breaks in tests.

See item number 6 in http://codebrief.com/2012/03/eight-ember-dot-js-gotchas-with-workarounds/ .

I didn't use the exact workaround mentioned there (overriding `init`): see https://dockyard.com/blog/2014/04/28/dont-override-init