### PR TITLE
ember-cli-addon - split initializer

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -185,9 +185,7 @@ export default {
       @method load
       @private
     */
-    load: loadConfig(defaults.base, function(container) {
-      this.applicationRootUrl = container.lookup('router:main').get('rootURL') || '/';
-    })
+    load: loadConfig(defaults.base)
   },
 
   cookie: {
@@ -347,9 +345,9 @@ export default {
     load: loadConfig(defaults.oauth2)
   },
 
-  load(container, config) {
+  load(config) {
     Ember.A(['base', 'cookie', 'devise', 'oauth2']).forEach((section) => {
-      this[section].load(container, config[section]);
+      this[section].load(config[section]);
     });
   }
 };

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -57,22 +57,19 @@ export default Ember.Mixin.create({
   beforeModel(transition) {
     setup(this.container).finally(() => {
       this._super(transition);
-      if (!this.get('_authEventListenersAssigned')) {
-        this.set('_authEventListenersAssigned', true);
-        Ember.A([
-          'sessionAuthenticationSucceeded',
-          'sessionAuthenticationFailed',
-          'sessionInvalidationSucceeded',
-          'sessionInvalidationFailed',
-          'authorizationFailed'
-        ]).forEach((event) => {
-          this.get(Configuration.base.sessionPropertyName).on(event, Ember.run.bind(this, function() {
-            Array.prototype.unshift.call(arguments, event);
-            let target = routeEntryComplete ? this : transition;
-            target.send.apply(target, arguments);
-          }));
-        });
-      }
+      Ember.A([
+        'sessionAuthenticationSucceeded',
+        'sessionAuthenticationFailed',
+        'sessionInvalidationSucceeded',
+        'sessionInvalidationFailed',
+        'authorizationFailed'
+      ]).forEach((event) => {
+        this.get(Configuration.base.sessionPropertyName).on(event, Ember.run.bind(this, function() {
+          Array.prototype.unshift.call(arguments, event);
+          let target = routeEntryComplete ? this : transition;
+          target.send.apply(target, arguments);
+        }));
+      });
     });
   },
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Configuration from './../configuration';
+import setup from '../setup';
 
 let routeEntryComplete = false;
 
@@ -54,23 +55,25 @@ export default Ember.Mixin.create({
     @private
   */
   beforeModel(transition) {
-    this._super(transition);
-    if (!this.get('_authEventListenersAssigned')) {
-      this.set('_authEventListenersAssigned', true);
-      Ember.A([
-        'sessionAuthenticationSucceeded',
-        'sessionAuthenticationFailed',
-        'sessionInvalidationSucceeded',
-        'sessionInvalidationFailed',
-        'authorizationFailed'
-      ]).forEach((event) => {
-        this.get(Configuration.base.sessionPropertyName).on(event, Ember.run.bind(this, function() {
-          Array.prototype.unshift.call(arguments, event);
-          let target = routeEntryComplete ? this : transition;
-          target.send.apply(target, arguments);
-        }));
-      });
-    }
+    setup(this.container).finally(() => {
+      this._super(transition);
+      if (!this.get('_authEventListenersAssigned')) {
+        this.set('_authEventListenersAssigned', true);
+        Ember.A([
+          'sessionAuthenticationSucceeded',
+          'sessionAuthenticationFailed',
+          'sessionInvalidationSucceeded',
+          'sessionInvalidationFailed',
+          'authorizationFailed'
+        ]).forEach((event) => {
+          this.get(Configuration.base.sessionPropertyName).on(event, Ember.run.bind(this, function() {
+            Array.prototype.unshift.call(arguments, event);
+            let target = routeEntryComplete ? this : transition;
+            target.send.apply(target, arguments);
+          }));
+        });
+      }
+    });
   },
 
   actions: {

--- a/addon/utils/load-config.js
+++ b/addon/utils/load-config.js
@@ -1,15 +1,12 @@
 import Ember from 'ember';
 
-export default function(defaults, callback) {
-  return function(container, config) {
+export default function(defaults) {
+  return function(config) {
     let wrappedConfig = Ember.Object.create(config);
     for (let property in this) {
       if (this.hasOwnProperty(property) && Ember.typeOf(this[property]) !== 'function') {
         this[property] = wrappedConfig.getWithDefault(property, defaults[property]);
       }
-    }
-    if (callback) {
-      callback.apply(this, [container, config]);
     }
   };
 }

--- a/app/initializers/simple-auth.js
+++ b/app/initializers/simple-auth.js
@@ -1,12 +1,12 @@
 import Configuration from 'ember-simple-auth/configuration';
 import getGlobalConfig from 'ember-simple-auth/utils/get-global-config';
-import setup from 'ember-simple-auth/setup';
+import { register } from 'ember-simple-auth/setup';
 
 export default {
   name:       'simple-auth',
-  initialize: function(container, application) {
+  initialize: function(registry, application) {
     var config = getGlobalConfig('simple-auth');
-    Configuration.load(container, config);
-    setup(container, application);
+    Configuration.load(config);
+    register(application);
   }
 };

--- a/app/instance-initializers/simple-auth.js
+++ b/app/instance-initializers/simple-auth.js
@@ -1,0 +1,9 @@
+import { inject } from 'ember-simple-auth/setup';
+
+export default {
+  name:       'simple-auth',
+  initialize: function(instance) {
+    let application = instance.container.lookup('application:main');
+    inject(application);
+  }
+};

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -20,7 +20,7 @@ describe('Configuration', () => {
   });
 
   afterEach(() => {
-    Configuration.load(container, {});
+    Configuration.load({});
   });
 
   describe('authenticationRoute', () => {
@@ -139,122 +139,116 @@ describe('Configuration', () => {
   });
 
   describe('.load', () => {
-    it("sets applicationRootUrl to the application's root URL", () => {
-      Configuration.load(container, {});
-
-      expect(Configuration.base.applicationRootUrl).to.eql('rootURL');
-    });
-
     it('sets authenticationRoute correctly', () => {
-      Configuration.load(container, { base: { authenticationRoute: 'authenticationRoute' } });
+      Configuration.load({ base: { authenticationRoute: 'authenticationRoute' } });
 
       expect(Configuration.base.authenticationRoute).to.eql('authenticationRoute');
     });
 
     it('sets routeAfterAuthentication correctly', () => {
-      Configuration.load(container, { base: { routeAfterAuthentication: 'routeAfterAuthentication' } });
+      Configuration.load({ base: { routeAfterAuthentication: 'routeAfterAuthentication' } });
 
       expect(Configuration.base.routeAfterAuthentication).to.eql('routeAfterAuthentication');
     });
 
     it('sets routeIfAlreadyAuthenticated correctly', () => {
-      Configuration.load(container, { base: { routeIfAlreadyAuthenticated: 'routeIfAlreadyAuthenticated' } });
+      Configuration.load({ base: { routeIfAlreadyAuthenticated: 'routeIfAlreadyAuthenticated' } });
 
       expect(Configuration.base.routeIfAlreadyAuthenticated).to.eql('routeIfAlreadyAuthenticated');
     });
 
     it('sets sessionPropertyName correctly', () => {
-      Configuration.load(container, { base: { sessionPropertyName: 'sessionPropertyName' } });
+      Configuration.load({ base: { sessionPropertyName: 'sessionPropertyName' } });
 
       expect(Configuration.base.sessionPropertyName).to.eql('sessionPropertyName');
     });
 
     it('sets authorizer correctly', () => {
-      Configuration.load(container, { base: { authorizer: 'authorizer' } });
+      Configuration.load({ base: { authorizer: 'authorizer' } });
 
       expect(Configuration.base.authorizer).to.eql('authorizer');
     });
 
     it('sets session correctly', () => {
-      Configuration.load(container, { base: { session: 'session' } });
+      Configuration.load({ base: { session: 'session' } });
 
       expect(Configuration.base.session).to.eql('session');
     });
 
     it('sets store correctly', () => {
-      Configuration.load(container, { base: { store: 'store' } });
+      Configuration.load({ base: { store: 'store' } });
 
       expect(Configuration.base.store).to.eql('store');
     });
 
     it('sets localStorageKey correctly', () => {
-      Configuration.load(container, { base: { localStorageKey: 'localStorageKey' } });
+      Configuration.load({ base: { localStorageKey: 'localStorageKey' } });
 
       expect(Configuration.base.localStorageKey).to.eql('localStorageKey');
     });
 
     it('sets crossOriginWhitelist correctly', () => {
-      Configuration.load(container, { base: { crossOriginWhitelist: ['https://some.origin:1234'] } });
+      Configuration.load({ base: { crossOriginWhitelist: ['https://some.origin:1234'] } });
 
       expect(Configuration.base.crossOriginWhitelist).to.eql(['https://some.origin:1234']);
     });
 
     it('sets cookieDomain correctly', () => {
-      Configuration.load(container, { cookie: { domain: '.example.com' } });
+      Configuration.load({ cookie: { domain: '.example.com' } });
 
       expect(Configuration.cookie.domain).to.eql('.example.com');
     });
 
     it('sets cookieName correctly', () => {
-      Configuration.load(container, { cookie: { name: 'cookieName' } });
+      Configuration.load({ cookie: { name: 'cookieName' } });
 
       expect(Configuration.cookie.name).to.eql('cookieName');
     });
 
     it('sets cookieExpirationTime correctly', () => {
-      Configuration.load(container, { cookie: { expirationTime: 1 } });
+      Configuration.load({ cookie: { expirationTime: 1 } });
 
       expect(Configuration.cookie.expirationTime).to.eql(1);
     });
 
     it('sets serverTokenEndpoint correctly', () => {
-      Configuration.load(container, { devise: { serverTokenEndpoint: 'serverTokenEndpoint' } });
+      Configuration.load({ devise: { serverTokenEndpoint: 'serverTokenEndpoint' } });
 
       expect(Configuration.devise.serverTokenEndpoint).to.eql('serverTokenEndpoint');
     });
 
     it('sets resourceName correctly', () => {
-      Configuration.load(container, { devise: { resourceName: 'resourceName' } });
+      Configuration.load({ devise: { resourceName: 'resourceName' } });
 
       expect(Configuration.devise.resourceName).to.eql('resourceName');
     });
 
     it('sets identificationAttributeName correctly', () => {
-      Configuration.load(container, { devise: { identificationAttributeName: 'identificationAttributeName' } });
+      Configuration.load({ devise: { identificationAttributeName: 'identificationAttributeName' } });
 
       expect(Configuration.devise.identificationAttributeName).to.eql('identificationAttributeName');
     });
 
     it('sets tokenAttributeName correctly', () => {
-      Configuration.load(container, { devise: { tokenAttributeName: 'tokenAttributeName' } });
+      Configuration.load({ devise: { tokenAttributeName: 'tokenAttributeName' } });
 
       expect(Configuration.devise.tokenAttributeName).to.eql('tokenAttributeName');
     });
 
     it('sets serverTokenEndpoint correctly', () => {
-      Configuration.load(container, { oauth2: { serverTokenEndpoint: 'serverTokenEndpoint' } });
+      Configuration.load({ oauth2: { serverTokenEndpoint: 'serverTokenEndpoint' } });
 
       expect(Configuration.oauth2.serverTokenEndpoint).to.eql('serverTokenEndpoint');
     });
 
     it('sets serverTokenRevocationEndpoint correctly', () => {
-      Configuration.load(container, { oauth2: { serverTokenRevocationEndpoint: 'serverTokenRevocationEndpoint' } });
+      Configuration.load({ oauth2: { serverTokenRevocationEndpoint: 'serverTokenRevocationEndpoint' } });
 
       expect(Configuration.oauth2.serverTokenRevocationEndpoint).to.eql('serverTokenRevocationEndpoint');
     });
 
     it('sets refreshAccessTokens correctly', () => {
-      Configuration.load(container, { oauth2: { refreshAccessTokens: false } });
+      Configuration.load({ oauth2: { refreshAccessTokens: false } });
 
       expect(Configuration.oauth2.refreshAccessTokens).to.be.false;
     });


### PR DESCRIPTION
Hopefully this should be the last of the initializer pulls! Targets the ember-cli-addon branch.

As per https://github.com/emberjs/ember.js/pull/10256#issuecomment-113846021, it no longer relies on `deferRediness`, and incorporates most of the setup into the `ApplicationRouteMixin.beforeModel` method.

The `initializer` now only registers the stores/session, and `instanceInitializer` now only injects `session` into components, controllers, routes.