### PR TITLE
Authenticate tests with data

### DIFF
--- a/addon/authenticators/test.js
+++ b/addon/authenticators/test.js
@@ -6,8 +6,8 @@ export default Base.extend({
     return Ember.RSVP.resolve();
   },
 
-  authenticate() {
-    return Ember.RSVP.resolve();
+  authenticate(data) {
+    return Ember.RSVP.resolve(data);
   },
 
   invalidate() {

--- a/test-support/helpers/simple-auth.js
+++ b/test-support/helpers/simple-auth.js
@@ -1,9 +1,9 @@
 import Configuration from 'configuration';
 
 export default function() {
-  Ember.Test.registerAsyncHelper('authenticateSession', function(app) {
+  Ember.Test.registerAsyncHelper('authenticateSession', function(app, sessionData) {
     var session = app.__container__.lookup(Configuration.session);
-    session.authenticate('simple-auth-authenticator:test');
+    session.authenticate('simple-auth-authenticator:test', sessionData);
     return wait();
   });
 

--- a/tests/unit/authenticators/test-test.js
+++ b/tests/unit/authenticators/test-test.js
@@ -23,6 +23,12 @@ describe('Authenticators.Test', function() {
         done();
       });
     });
+
+    it('resolves with session data', function() {
+      return this.authenticator.authenticate({ userId: 1, otherData: 'some-data' }).then(function(data) {
+        expect(data).to.eql({ userId: 1, otherData: 'some-data' });
+      });
+    });
   });
 
   describe('#invalidate', function() {


### PR DESCRIPTION
Added option in test helpers to authenticate with session data.

Closes https://github.com/simplabs/ember-simple-auth/issues/553