### PR TITLE
Pass session data to torii close

### DIFF
--- a/packages/ember-simple-auth-torii/lib/simple-auth-torii/authenticators/torii.js
+++ b/packages/ember-simple-auth-torii/lib/simple-auth-torii/authenticators/torii.js
@@ -80,7 +80,7 @@ export default Base.extend({
   invalidate: function(data) {
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      _this.torii.close(_this.provider).then(function() {
+      _this.torii.close(_this.provider, data).then(function() {
         delete _this.provider;
         resolve();
       }, reject);


### PR DESCRIPTION
Related https://github.com/simplabs/ember-simple-auth/issues/295

This PR passes the session information to torii using the ```options``` argument for the ```close``` method. This is useful for doing things like revoking access tokens. 


