### PR TITLE
Switch AJAX request content type to JSON

### DIFF
--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authenticators/devise.js
@@ -152,7 +152,8 @@ export default Base.extend({
     return Ember.$.ajax({
       url:        this.serverTokenEndpoint,
       type:       'POST',
-      data:       data,
+      data:       JSON.stringify(data),
+      contentType: 'application/json; charset=UTF-8',
       dataType:   'json',
       beforeSend: function(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authenticators/devise-test.js
@@ -91,7 +91,8 @@ describe('Devise', function() {
         expect(args).to.eql({
           url:      '/users/sign_in',
           type:     'POST',
-          data:     { user: { email: 'identification', password: 'password' } },
+          data:     '{"user":{"password":"password","email":"identification"}}',
+          contentType: 'application/json; charset=UTF-8',
           dataType: 'json',
         });
         done();


### PR DESCRIPTION
Switch AJAX request content type to JSON instead of 'x-www-form-urlencoded'.

1. In order to process data in Ember CLI Mirage as described in http://www.ember-cli-mirage.com/docs/v0.1.x/defining-routes/#dynamic-paths-and-query-params
1. For consistency purpose: all Ember-data requests are encoded in JSON

Code from: http://stackoverflow.com/questions/12693947/jquery-ajax-how-to-send-json-instead-of-querystring