### PR TITLE
Switch AJAX request content type to JSON 

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -159,8 +159,9 @@ export default Base.extend({
     return Ember.$.ajax({
       url:        this.serverTokenEndpoint,
       type:       'POST',
+      data: JSON.stringify(data),
+      contentType: 'application/json; charset=UTF-8',
       dataType:   'json',
-      data,
       beforeSend(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);
       }

--- a/tests/unit/authenticators/devise-test.js
+++ b/tests/unit/authenticators/devise-test.js
@@ -109,7 +109,8 @@ describe('Devise', () => {
         expect(args).to.eql({
           url:      '/users/sign_in',
           type:     'POST',
-          data:     { user: { email: 'identification', password: 'password' } },
+          data:     '{"user":{"password":"password","email":"identification"}}',
+          contentType: 'application/json; charset=UTF-8',
           dataType: 'json'
         });
         done();


### PR DESCRIPTION
Switch AJAX request content type to JSON instead of 'x-www-form-urlencoded'.

In order to process data in Ember CLI Mirage as described in http://www.ember-cli-mirage.com/docs/v0.1.x/defining-routes/#dynamic-paths-and-query-params
For consistency purpose: all Ember-data requests are encoded in JSON
Code from: http://stackoverflow.com/questions/12693947/jquery-ajax-how-to-send-json-instead-of-querystring