### PR TITLE
Restructure test helpers

### DIFF
--- a/addon/initializers/setup-session.js
+++ b/addon/initializers/setup-session.js
@@ -1,7 +1,9 @@
 import Session from '../session';
 import Configuration from '../configuration';
+import TestAuthenticator from '../authenticators/test';
 
 export default function setupSession(registry) {
   registry.register('simple-auth-session:main', Session);
+  registry.register('simple-auth-authenticator:test', TestAuthenticator);
   registry.injection('simple-auth-session:main', 'store', Configuration.base.store);
 }

--- a/test-support/helpers/simple-auth.js
+++ b/test-support/helpers/simple-auth.js
@@ -1,22 +1,18 @@
-import Configuration from 'configuration';
+Ember.Test.registerAsyncHelper('authenticateSession', function(app, sessionData) {
+  var session = app.__container__.lookup('simple-auth-session:main');
+  session.authenticate('simple-auth-authenticator:test', sessionData);
+  return wait();
+});
 
-export default function() {
-  Ember.Test.registerAsyncHelper('authenticateSession', function(app, sessionData) {
-    var session = app.__container__.lookup(Configuration.session);
-    session.authenticate('simple-auth-authenticator:test', sessionData);
-    return wait();
-  });
+Ember.Test.registerHelper('currentSession', function(app) {
+  var session = app.__container__.lookup('simple-auth-session:main');
+  return session;
+});
 
-  Ember.Test.registerHelper('currentSession', function(app) {
-    var session = app.__container__.lookup(Configuration.session);
-    return session;
-  });
-
-  Ember.Test.registerAsyncHelper('invalidateSession', function(app) {
-    var session = app.__container__.lookup(Configuration.session);
-    if (session.get('isAuthenticated')) {
-      session.invalidate();
-    }
-    return wait();
-  });
-}
+Ember.Test.registerAsyncHelper('invalidateSession', function(app) {
+  var session = app.__container__.lookup('simple-auth-session:main');
+  if (session.get('isAuthenticated')) {
+    session.invalidate();
+  }
+  return wait();
+});

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,9 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "authenticateSession",
+    "invalidateSession"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/protected-test.js
+++ b/tests/acceptance/protected-test.js
@@ -1,0 +1,32 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+describe('Acceptance: Protected', function() {
+  let application;
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    Ember.run(application, 'destroy');
+  });
+
+  it('can visit /protected if logged in', function() {
+    authenticateSession();
+
+    visit('/protected');
+
+    andThen(function() {
+      expect(currentPath()).to.equal('protected');
+    });
+  });
+});

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import './simple-auth';
 
 export default function startApp(attrs) {
   let application;


### PR DESCRIPTION
This should update the test helpers to work with the new addon style. Everything seems to get loaded correctly.

I also added an acceptance test to test the behavior, but it currently fails with `Cannot call get with 'currentPath' on an undefined object.` - no idea why.