### PR TITLE
Test failures when mixing Acceptance and Unit tests: Check for presence of secure data before accessing it

### DIFF
--- a/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
+++ b/packages/ember-simple-auth-devise/lib/simple-auth-devise/authorizers/devise.js
@@ -66,12 +66,14 @@ export default Base.extend({
   },
 
   authorize: function(jqXHR, requestOptions) {
-    var secureData         = this.get('session.secure');
-    var userToken          = secureData[this.tokenAttributeName];
-    var userIdentification = secureData[this.identificationAttributeName];
-    if (this.get('session.isAuthenticated') && !Ember.isEmpty(userToken) && !Ember.isEmpty(userIdentification)) {
-      var authData = this.tokenAttributeName + '="' + userToken + '", ' + this.identificationAttributeName + '="' + userIdentification + '"';
-      jqXHR.setRequestHeader('Authorization', 'Token ' + authData);
+    var secureData           = this.get('session.secure');
+    if (secureData) {
+      var userToken          = secureData[this.tokenAttributeName];
+      var userIdentification = secureData[this.identificationAttributeName];
+      if (this.get('session.isAuthenticated') && !Ember.isEmpty(userToken) && !Ember.isEmpty(userIdentification)) {
+        var authData = this.tokenAttributeName + '="' + userToken + '", ' + this.identificationAttributeName + '="' + userIdentification + '"';
+        jqXHR.setRequestHeader('Authorization', 'Token ' + authData);
+      }
     }
   }
 });

--- a/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
+++ b/packages/ember-simple-auth-devise/tests/simple-auth-devise/authorizers/devise-test.js
@@ -109,5 +109,15 @@ describe('Devise', function() {
 
       itDoesNotAuthorizeTheRequest();
     });
+    context('when the session is destroyed', function () {
+      beforeEach(function (done) {
+        var session = Session.create();
+        this.authorizer.set('session', session);
+        session.destroy();
+        Ember.run.next(done);
+      });
+
+      itDoesNotAuthorizeTheRequest();
+    });
   });
 });


### PR DESCRIPTION
When unit tests and acceptance tests are "mixed", i.e. both are executed in the same page, a call to `Ember.$.ajax` fails if an acceptance tests was running before. This is a regression in 0.8.0.
The authorizer in use is Devise.

http://emberjs.jsbin.com/qinuka/edit?js,output

or as screenshot:

![image](https://cloud.githubusercontent.com/assets/768913/9225649/e7c336dc-410a-11e5-9776-85e35eb229fd.png)

The code tries to call `get` on `undefined`, which is fetched from the session object. However, this session object has already been destroyed when the container from the last application instance was destroyed. Due to a glitch in Ember (I'm still investigating) instances of ObjectProxy lose their functionality when destroyed, and thus giving `session.get('secure')` an `undefined`, while `session.get('content.secure')` still works.

(introduced in https://github.com/simplabs/ember-simple-auth/commit/db4d635cfe40d2b2920f33939613c96778097aeb#diff-f4489d454b1136f52fda48e97daec5ddR70 in combination with https://github.com/danwang/ember-simple-auth/commit/668d5aaaf1ec070dba3240aa5190c572d33544ea)

Even though the bug above is easily solvable, one problem remains: Authorizers remain attached to `Ember.$.ajax` long after the application that created them has been destroyed. I'm not sure what kind of functionalities Ember provides to hook into the lifecycle though.

There are two obvious fixes to this bug (getting `content.secure` or asking for presence with an `if`), this PR just contains the one looking less ugly to me. 