### PR TITLE
Transition initializer to instance-initializer

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/instance-initializer.js
+++ b/packages/ember-simple-auth/lib/simple-auth/instance-initializer.js
@@ -4,9 +4,9 @@ import setup from './setup';
 
 export default {
   name:       'simple-auth',
-  initialize: function(container, application) {
+  initialize: function(application) {
     var config = getGlobalConfig('simple-auth');
-    Configuration.load(container, config);
-    setup(container, application);
+    Configuration.load(application.container, config);
+    setup(application.container, application);
   }
 };


### PR DESCRIPTION
Calls to `container.lookup` trigger the following deprecation warning:

```
DEPRECATION: `lookup` was called on a Registry. The `initializer` API
no longer receives a container, and you should use an
`instanceInitializer` to look up objects from the container.
See http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers
for more details.
  at Object.Registry.lookup (http://localhost:7357/assets/vendor.js:12215:36)
  at Object.<anonymous> (http://localhost:7357/assets/vendor.js:94544:45)
  at Object.__exports__.default [as load] (http://localhost:7357/assets/vendor.js:95767:20)
  at Object.initialize (http://localhost:7357/assets/myapp.js:11011:32)
  at http://localhost:7357/assets/vendor.js:14881:23
  at http://localhost:7357/assets/vendor.js:14908:9
  at visit (http://localhost:7357/assets/vendor.js:12793:5)
  at DAG.topsort (http://localhost:7357/assets/vendor.js:12904:9)
  at _emberRuntimeSystemNamespace.default.extend._runInitializer (http://localhost:7357/assets/vendor.js:14907:13)
```