### PR TITLE
Move `app/service/session` to `addon`

### DIFF
--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+
+const { computed, on }  = Ember;
+const { alias, oneWay } = computed;
+
+export default Ember.Service.extend(Ember.Evented, {
+  isAuthenticated: oneWay('session.isAuthenticated'),
+  data:            alias('session.content'),
+
+  _forwardSessionEvents: on('init', function() {
+    Ember.A([
+      'authenticationSucceeded',
+      'invalidationSucceeded'
+    ]).forEach((event) => {
+      this.get('session').on(event, () => {
+        this.trigger(event, ...arguments);
+      });
+    });
+  }),
+
+  authenticate() {
+    const session = this.get('session');
+    return session.authenticate.apply(session, arguments);
+  },
+
+  invalidate() {
+    const session = this.get('session');
+    return session.invalidate.apply(session, arguments);
+  },
+
+  authorize(authorizerFactory, block) {
+    const authorizer = this.container.lookup(authorizerFactory);
+    authorizer.authorize(block);
+  }
+});

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,35 +1,3 @@
-import Ember from 'ember';
+import SessionService from 'ember-simple-auth/services/session';
 
-const { computed, on }  = Ember;
-const { alias, oneWay } = computed;
-
-export default Ember.Service.extend(Ember.Evented, {
-  isAuthenticated: oneWay('session.isAuthenticated'),
-  data:            alias('session.content'),
-
-  _forwardSessionEvents: on('init', function() {
-    Ember.A([
-      'authenticationSucceeded',
-      'invalidationSucceeded'
-    ]).forEach((event) => {
-      this.get('session').on(event, () => {
-        this.trigger(event, ...arguments);
-      });
-    });
-  }),
-
-  authenticate() {
-    const session = this.get('session');
-    return session.authenticate.apply(session, arguments);
-  },
-
-  invalidate() {
-    const session = this.get('session');
-    return session.invalidate.apply(session, arguments);
-  },
-
-  authorize(authorizerFactory, block) {
-    const authorizer = this.container.lookup(authorizerFactory);
-    authorizer.authorize(block);
-  }
-});
+export default SessionService;


### PR DESCRIPTION
According to [Dockyard's Blog Post][dockyard] (section #2):

> A consumer should have the ability to easily extend your addon
> to do whatever they want. This means organizing your code a
> certain way.
> To provide this you should put all of your business logic into
> `addon/` and then include wrapper classes in `app/` that just `import`
> then `export` the extended class.

[dockyard]: https://dockyard.com/blog/2015/03/22/tips-for-writing-ember-addons