### PR TITLE
Restore session before running application route's beforeModel hook

### DIFF
--- a/addon/instance-initializers/setup-session-restoration.js
+++ b/addon/instance-initializers/setup-session-restoration.js
@@ -4,8 +4,8 @@ export default function setupSessionRestoration(instance) {
   const session = container.lookup('session:main');
   applicationRoute.reopen({
     beforeModel() {
-      const superResult = this._super(...arguments);
-      return session.restore().then(() => superResult, () => superResult);
+      const boundSuper = this._super.bind(this);
+      return session.restore().then(() => boundSuper(...arguments), () => boundSuper(...arguments));
     }
   });
 }


### PR DESCRIPTION
See issue #608 and pull request #609.

Inspired by https://github.com/emberjs/ember.js/issues/4632#issuecomment-120581786, thanks @marcoow for the suggestion.