### PR TITLE
Assert that authorizer is set when using DataAdapterMixin

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -30,10 +30,14 @@ export default Ember.Mixin.create({
   session: service('session'),
 
   ajaxOptions() {
+    const authorizer = this.get('authorizer');
     let hash = this._super(...arguments);
     let { beforeSend } = hash;
+
+    Ember.assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", Ember.isPresent(authorizer));
+
     hash.beforeSend = (xhr) => {
-      this.get('session').authorize(this.get('authorizer'), (headerName, headerValue) => {
+      this.get('session').authorize(authorizer, (headerName, headerValue) => {
         xhr.setRequestHeader(headerName, headerValue);
       });
       if (beforeSend) {

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -31,10 +31,10 @@ export default Ember.Mixin.create({
 
   ajaxOptions() {
     const authorizer = this.get('authorizer');
+    Ember.assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", Ember.isPresent(authorizer));
+
     let hash = this._super(...arguments);
     let { beforeSend } = hash;
-
-    Ember.assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", Ember.isPresent(authorizer));
 
     hash.beforeSend = (xhr) => {
       this.get('session').authorize(authorizer, (headerName, headerValue) => {

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -39,6 +39,13 @@ describe('DataAdapterMixin', () => {
       expect(hash).to.have.ownProperty('beforeSend');
     });
 
+    it('asserts the presence of authorizer', () => {
+      adapter.set('authorizer', null);
+      expect(function() {
+        adapter.ajaxOptions();
+      }).to.throw(/You\'re using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: \'authorizer:application\'` to your adapter\./);
+    });
+
     it('preserves an existing beforeSend hook', () => {
       const existingBeforeSend = sinon.spy();
       hash.beforeSend = existingBeforeSend;

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -43,7 +43,7 @@ describe('DataAdapterMixin', () => {
       adapter.set('authorizer', null);
       expect(function() {
         adapter.ajaxOptions();
-      }).to.throw(/You\'re using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: \'authorizer:application\'` to your adapter\./);
+      }).to.throw(/Assertion Failed/);
     });
 
     it('preserves an existing beforeSend hook', () => {


### PR DESCRIPTION
This PR adds a simple assertion to alert the end developer that they need to add an `authorizer` in their adapter. 