### PR TITLE
Fix custom authenticator example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ e.g.:
 // app/authenticators/custom.js
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
 
-export default Base.extend({
+export default BaseAuthenticator.extend({
   restore: function(data) {
     …
   },


### PR DESCRIPTION
Imported variable had a different name than what was being extended in the custom authenticator example.