### PR TITLE
Update README - correct config key in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ environment object:
 
 ```js
 //config/environment.js
-ENV['simple-auth'] = {
+ENV['ember-simple-auth'] = {
   base: {
     store: 'session-store:local-storage'
   }


### PR DESCRIPTION
The configuration key seems to have to changed from simple-auth to ember-simple-auth, let's update the README to let people know.