### PR TITLE
Fixed issue where the lookup for the torii library was failing

### DIFF
--- a/packages/ember-simple-auth-torii/lib/simple-auth-torii/initializer.js
+++ b/packages/ember-simple-auth-torii/lib/simple-auth-torii/initializer.js
@@ -5,7 +5,7 @@ export default {
   before: 'simple-auth',
   after:  'torii',
   initialize: function(container, application) {
-    var torii         = container.lookup('torii:main');
+    var torii         = container.lookup('service:torii:main');
     var authenticator = Authenticator.create({ torii: torii });
     application.register('simple-auth-authenticator:torii', authenticator, { instantiate: false });
   }


### PR DESCRIPTION
With Torii 0.6.0, the lookup for the torii module in the initializer was failing, returning null. This simple PR fixes the lookup.