### PR TITLE
Update test authenticator to resolve with data in restore method

### DIFF
--- a/addon/authenticators/test.js
+++ b/addon/authenticators/test.js
@@ -4,8 +4,8 @@ import Base from './base';
 const { RSVP } = Ember;
 
 export default Base.extend({
-  restore() {
-    return RSVP.resolve();
+  restore(data) {
+    return RSVP.resolve(data);
   },
 
   authenticate(data) {

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -4,7 +4,7 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import Pretender from 'pretender';
-import { invalidateSession, authenticateSession } from '../helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession, currentSession } from '../helpers/ember-simple-auth';
 
 describe('Acceptance: Authentication', function() {
   let application;
@@ -12,7 +12,6 @@ describe('Acceptance: Authentication', function() {
 
   beforeEach(function() {
     application = startApp();
-    return visit('/');
   });
 
   afterEach(function() {
@@ -34,11 +33,15 @@ describe('Acceptance: Authentication', function() {
       server = new Pretender(function() {
         this.get('/posts', () => [200, { 'Content-Type': 'application/json' }, '{"data":[]}']);
       });
-      authenticateSession(application);
+      authenticateSession(application, { userId: 1, otherData: 'some-data' });
+
       visit('/protected');
 
       return andThen(() => {
         expect(currentPath()).to.eq('protected');
+        let session = currentSession(application);
+        expect(session.get('data.authenticated.userId')).to.eql(1);
+        expect(session.get('data.authenticated.otherData')).to.eql('some-data');
       });
     });
   });

--- a/tests/unit/authenticators/test-test.js
+++ b/tests/unit/authenticators/test-test.js
@@ -17,6 +17,12 @@ describe('TestAuthenticator', () => {
         expect(true).to.be.true;
       });
     });
+
+    it('resolves with session data', () => {
+      return authenticator.restore({ userId: 1, otherData: 'some-data' }).then((data) => {
+        expect(data).to.eql({ userId: 1, otherData: 'some-data' });
+      });
+    });
   });
 
   describe('#authenticate', () => {


### PR DESCRIPTION
While writing some acceptance tests I've noticed that calling `authenticateSession` before visiting any route resulted in losing the `data` passed to `authenticateSession`.

This happened because the `restore` method of the test authenticator was not returning any data and `session.restore()` was overwriting session data previously set using `authenticateSession` with the value returned from the authenticator (`undefined` in this case).