### PR TITLE
Add blueprints for authorizer and authenticator

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false,
+  "node": true
+}

--- a/blueprints/authenticator/files/__root__/authenticators/__name__.js
+++ b/blueprints/authenticator/files/__root__/authenticators/__name__.js
@@ -1,0 +1,8 @@
+<%= imports %>
+
+export default <%= baseClass %>.extend({
+  <%= properties %>
+  authenticate: function(data) {
+    return Ember.RSVP.resolve(data);
+  }
+});

--- a/blueprints/authenticator/index.js
+++ b/blueprints/authenticator/index.js
@@ -1,0 +1,40 @@
+var EOL = require('os').EOL;
+
+module.exports = {
+  description: 'Generates an ember-simple-auth authenticator',
+
+  availableOptions: [
+    { name: 'torii', type: Boolean },
+    { name: 'devise', type: Boolean },
+    { name: 'oauth2', type: Boolean },
+    { name: 'base', type: Boolean }
+  ],
+
+  locals: function(options) {
+    if (options.torii) {
+      return {
+        imports: 'import Ember from \'ember\';' + EOL + 'import Torii from \'ember-simple-auth/authenticators/torii\';',
+        baseClass: 'Torii',
+        properties: 'torii: Ember.inject.service(\'torii\'),' + EOL
+      };
+    } else if (options.oauth2) {
+      return {
+        imports: 'import Ember from \'ember\';' + EOL + 'import OAuth2PasswordGrant from \'ember-simple-auth/authenticators/oauth2-password-grant\';',
+        baseClass: 'OAuth2PasswordGrant',
+        properties: 'serverTokenRevocationEndpoint: \'/revoke\',' + EOL
+      };
+    } else if (options.devise) {
+      return {
+        imports: 'import Ember from \'ember\';' + EOL + 'import Devise from \'ember-simple-auth/authenticators/devise\';',
+        baseClass: 'Devise',
+        properties: ''
+      };
+    } else {
+      return {
+        imports: 'import Ember from \'ember\';' + EOL + 'import BaseAuthenticator from \'ember-simple-auth/authenticators/base\';',
+        baseClass: 'BaseAuthenticator',
+        properties: ''
+      };
+    }
+  }
+};

--- a/blueprints/authorizer/files/__root__/authorizers/__name__.js
+++ b/blueprints/authorizer/files/__root__/authorizers/__name__.js
@@ -1,0 +1,7 @@
+<%= imports %>
+
+export default <%= baseClass %>.extend({
+  authorize: function(/*data, block*/) {
+
+  }
+});

--- a/blueprints/authorizer/index.js
+++ b/blueprints/authorizer/index.js
@@ -1,0 +1,28 @@
+module.exports = {
+  description: 'Generates an ember-simple-auth authorizer',
+
+  availableOptions: [
+    { name: 'devise', type: Boolean },
+    { name: 'oauth2', type: Boolean },
+    { name: 'base', type: Boolean }
+  ],
+
+  locals: function(options) {
+    if (options.oauth2) {
+      return {
+        imports: 'import OAuth2Bearer from \'ember-simple-auth/authorizers/oauth2-bearer\';',
+        baseClass: 'OAuth2Bearer'
+      };
+    } else if (options.devise) {
+      return {
+        imports: 'import Devise from \'ember-simple-auth/authorizers/devise\';',
+        baseClass: 'Devise'
+      };
+    } else {
+      return {
+        imports: 'import BaseAuthorizer from \'ember-simple-auth/authorizers/base\';',
+        baseClass: 'BaseAuthorizer'
+      };
+    }
+  }
+};


### PR DESCRIPTION
I think `ember-simple-auth` should provide blueprints for authorizer and authenticator. Consuming apps are expected to define their own authenticators and authorizers so these blueprints will be handy.