### PR TITLE
make clientSecret work

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -224,9 +224,10 @@ export default BaseAuthenticator.extend({
       contentType: 'application/x-www-form-urlencoded'
     };
     const clientId = this.get('clientId');
+    const clientSecret = this.get('clientSecret');
 
     if (!isEmpty(clientId)) {
-      const base64ClientId = window.btoa(clientId.concat(':'));
+      const base64ClientId = window.btoa(clientId.concat(':', clientSecret));
       Ember.merge(options, {
         headers: {
           Authorization: `Basic ${base64ClientId}`


### PR DESCRIPTION
I wasn't able to update my simple-auth implementation to ember-simple-auth without this little modification.

My `app/authenticators/oauth2.js` changed to:
```
import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
import ENV from 'appname/config/environment';
 
export default OAuth2PasswordGrant.extend({
       serverTokenEndpoint: ENV.oauth2.serverTokenEndpoint,
       serverTokenRevocationEndpoint: ENV.oauth2.serverTokenRevocationEndpoint,
       clientId: ENV.APP.client_id,
       clientSecret: ENV.APP.client_secret
});
```