### PR TITLE
Update README.md to fix login controller error

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the __session can be authenticated with the
 // app/controllers/login.js
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+export default Ember.Controller.extend({
   session: Ember.inject.service('session'),
 
   actions: {


### PR DESCRIPTION
 from wrong Ember.Component class in example

If set controller with Ember.conponent will return : `Error while processing route: login controller._updateCacheParams is not a function TypeError: controller._updateCacheParams is not a function`