### PR TITLE
Use shorthand method syntax consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default Ember.Controller.extend({
   …
 
   actions: {
-    invalidateSession: function() {
+    invalidateSession() {
       this.get('session').invalidate();
     }
   }
@@ -342,13 +342,13 @@ methods:
 import Base from 'ember-simple-auth/authenticators/base';
 
 export default Base.extend({
-  restore: function(data) {
+  restore(data) {
     …
   },
-  authenticate: function(options) {
+  authenticate(options) {
     …
   },
-  invalidate: function(data) {
+  invalidate(data) {
     …
   }
 });


### PR DESCRIPTION
Some of the examples used the new syntax, while others didn't. I converted all of the examples to
use the new syntax.