### PR TITLE
log exceptions in custom authenticate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ export default Ember.Controller.extend({
     authenticate() {
       let { identification, password } = this.getProperties('identification', 'password');
       this.get('session').authenticate('authenticator:oauth2', identification, password).catch((reason) => {
-        this.set('errorMessage', reason.error);
+        console.error('exception in your authenticators authenticate method', reason)
       });
     }
   }

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ export default Ember.Controller.extend({
     authenticate() {
       let { identification, password } = this.getProperties('identification', 'password');
       this.get('session').authenticate('authenticator:oauth2', identification, password).catch((reason) => {
-        console.error('exception in your authenticators authenticate method', reason)
+        Ember.Logger.debug('Error when attempting to authenticate user', reason)
       });
     }
   }


### PR DESCRIPTION
If a developer is just going right in and writing a custom authenticator, they need to see errors, and not have them set as an errorMessage property. If we want to use this errorMessage property, which I think is foolish, developers should fully understand and be informed about how to make sure they are seeing this error message...

Resolves https://github.com/simplabs/ember-simple-auth/issues/782