### PR TITLE
Better instance initialiser example for ApplicationRouteMixin API docs

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -3,6 +3,8 @@ import Configuration from './../configuration';
 
 const { inject, on } = Ember;
 
+
+
 /**
   The mixin for the application route; __defines methods that are called when
   the session was successfully authenticated (see
@@ -15,20 +17,22 @@ const { inject, on } = Ember;
 
   ```js
   // app/instance-initializers/session-events.js
-  Ember.Application.initializer({
-    name:       'session-events',
-    after:      'ember-simple-auth',
-    initialize: function(container, application) {
-      var applicationRoute = container.lookup('route:application');
-      var session          = container.lookup('service:session');
+  export function initialize(instance) {
+      var applicationRoute = instance.container.lookup('route:application');
+      var session          = instance.container.lookup('service:session');
       session.on('authenticationSucceeded', function() {
         applicationRoute.transitionTo('index');
       });
       session.on('invalidationSucceeded', function() {
         window.location.reload();
       });
-    }
   });
+
+  export default {
+    name:       'session-events',
+    after:      'ember-simple-auth',
+    initialize: initialize
+  };
   ```
 
   __When using the `ApplicationRouteMixin` you need to specify

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -3,8 +3,6 @@ import Configuration from './../configuration';
 
 const { inject, on } = Ember;
 
-
-
 /**
   The mixin for the application route; __defines methods that are called when
   the session was successfully authenticated (see
@@ -29,9 +27,9 @@ const { inject, on } = Ember;
   });
 
   export default {
-    name:       'session-events',
-    after:      'ember-simple-auth',
-    initialize: initialize
+    initialize,
+    name:    'session-events',
+    after:   'ember-simple-auth',
   };
   ```
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -28,8 +28,8 @@ const { inject, on } = Ember;
 
   export default {
     initialize,
-    name:    'session-events',
-    after:   'ember-simple-auth',
+    name:  'session-events',
+    after: 'ember-simple-auth'
   };
   ```
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -16,14 +16,14 @@ const { inject, on } = Ember;
   ```js
   // app/instance-initializers/session-events.js
   export function initialize(instance) {
-      var applicationRoute = instance.container.lookup('route:application');
-      var session          = instance.container.lookup('service:session');
-      session.on('authenticationSucceeded', function() {
-        applicationRoute.transitionTo('index');
-      });
-      session.on('invalidationSucceeded', function() {
-        window.location.reload();
-      });
+    var applicationRoute = instance.container.lookup('route:application');
+    var session          = instance.container.lookup('service:session');
+    session.on('authenticationSucceeded', function() {
+      applicationRoute.transitionTo('index');
+    });
+    session.on('invalidationSucceeded', function() {
+      window.location.reload();
+    });
   });
 
   export default {


### PR DESCRIPTION
The current instance initialiser example doesn’t work. I’ve replaced it with an example that works correctly.