### PR TITLE
add note on required ember data version for DataAdapterMixin

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -22,6 +22,8 @@ const { service } = Ember.inject;
   });
   ```
 
+  __The `DataAdapterMixin` requires Ember Data 1.13 or later.__
+
   @class DataAdapterMixin
   @module ember-simple-auth/mixins/data-adapter-mixin
   @extends Ember.Mixin


### PR DESCRIPTION
minimum version is 1.13

This closes #759 