### PR TITLE
Resolve container deprecation warnings

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 const { on } = Ember;
 
@@ -14,7 +15,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     let args          = Array.prototype.slice.call(arguments);
     let authenticator = args.shift();
     Ember.assert(`Session#authenticate requires the authenticator to be specified, was "${authenticator}"!`, !Ember.isEmpty(authenticator));
-    let theAuthenticator = this.container.lookup(authenticator);
+    let theAuthenticator = getOwner(this).lookup(authenticator);
     Ember.assert(`No authenticator for factory "${authenticator}" could be found!`, !Ember.isNone(theAuthenticator));
     return new Ember.RSVP.Promise((resolve, reject) => {
       theAuthenticator.authenticate.apply(theAuthenticator, args).then((content) => {

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
 
@@ -218,7 +219,7 @@ export default Ember.Service.extend(Ember.Evented, {
   */
   authorize(authorizerFactory, block) {
     if (this.get('isAuthenticated')) {
-      const authorizer = this.container.lookup(authorizerFactory);
+      const authorizer = getOwner(this).lookup(authorizerFactory);
       const sessionData = this.get('data.authenticated');
       authorizer.authorize(sessionData, block);
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-sinon": "~0.3.0",
     "ember-suave": "~1.2.2",
     "ember-try": "~0.0.8",


### PR DESCRIPTION
ESA was causing deprecation warnings when used with Ember 2.3.0-beta.1. This was due to Ember 2.3 deprecating access the container property on framework generated objects.

This PR implements the new getOwner public API introduced in Ember 2.3 via the [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill) add-on.