### PR TITLE
Move ember-getowner-polyfill into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-getowner-polyfill": "1.0.0",
     "ember-sinon": "~0.3.0",
     "ember-suave": "~1.2.2",
     "ember-try": "~0.0.8",
@@ -59,7 +58,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-getowner-polyfill": "1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Currently ember-getowner-polyfill is not being installed alongside ESA due to it being in the devDependencies rather than the regular dependencies. This resolves the issue.