### PR TITLE
Adding ability to pass authenticator name and session data

### DIFF
--- a/addon/authenticators/torii.js
+++ b/addon/authenticators/torii.js
@@ -104,23 +104,11 @@ export default BaseAuthenticator.extend({
     @public
   */
   invalidate(data) {
-    this._assertToriiIsPresent();
-
-    data = data || {};
     return new RSVP.Promise((resolve, reject) => {
-      if (!isEmpty(data.provider)) {
-        let { provider } = data;
-        this.get('torii').close(data.provider, data).then((data) => {
-          data = data || {};
-          this._resolveWith(provider, data, resolve);
-        }, () => {
-          delete this._provider;
-          reject();
-        });
-      } else {
+      this.get('torii').close(this._provider, data).then(() => {
         delete this._provider;
-        reject();
-      }
+        resolve();
+      }, reject);
     });
   },
 

--- a/addon/authenticators/torii.js
+++ b/addon/authenticators/torii.js
@@ -103,12 +103,24 @@ export default BaseAuthenticator.extend({
     @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
     @public
   */
-  invalidate() {
+  invalidate(data) {
+    this._assertToriiIsPresent();
+
+    data = data || {};
     return new RSVP.Promise((resolve, reject) => {
-      this.get('torii').close(this._provider).then(() => {
+      if (!isEmpty(data.provider)) {
+        let { provider } = data;
+        this.get('torii').close(data.provider, data).then((data) => {
+          data = data || {};
+          this._resolveWith(provider, data, resolve);
+        }, () => {
+          delete this._provider;
+          reject();
+        });
+      } else {
         delete this._provider;
-        resolve();
-      }, reject);
+        reject();
+      }
     });
   },
 


### PR DESCRIPTION
This change enables custom Torii authentication providers to use session data when the close() method is called. 