### PR TITLE
Simplify handling of current user

### DIFF
--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,4 +1,21 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-export default Ember.Route.extend(ApplicationRouteMixin);
+const { service } = Ember.inject;
+
+export default Ember.Route.extend(ApplicationRouteMixin, {
+  sessionAccount: service('session-account'),
+
+  model() {
+    return this._loadCurrentUser();
+  },
+
+  sessionAuthenticated() {
+    this._super(...arguments);
+    this._loadCurrentUser().catch(() => this.get('session').invalidate());
+  },
+
+  _loadCurrentUser() {
+    return this.get('sessionAccount').loadCurrentUser();
+  }
+});

--- a/tests/dummy/app/services/session-account.js
+++ b/tests/dummy/app/services/session-account.js
@@ -1,18 +1,22 @@
 import Ember from 'ember';
-import DS from 'ember-data';
 
-const { service } = Ember.inject;
+const { inject: { service }, RSVP } = Ember;
 
 export default Ember.Service.extend({
   session: service('session'),
   store: service(),
 
-  account: Ember.computed('session.data.authenticated.account_id', function() {
-    const accountId = this.get('session.data.authenticated.account_id');
-    if (!Ember.isEmpty(accountId)) {
-      return DS.PromiseObject.create({
-        promise: this.get('store').find('account', accountId)
-      });
-    }
-  })
+  loadCurrentUser() {
+    return new RSVP.Promise((resolve, reject) => {
+      const accountId = this.get('session.data.authenticated.account_id');
+      if (!Ember.isEmpty(accountId)) {
+        return this.get('store').find('account', accountId).then((account) => {
+          this.set('account', account);
+          resolve();
+        }, reject);
+      } else {
+        resolve();
+      }
+    });
+  }
 });


### PR DESCRIPTION
This changes the sessionAccount service so that it explicitly loads the current user which has the advantage that it doesn't have to use a promise object anymore but when the current user is present it will be an actual record.