### PR TITLE
Remove container from internal session to fix deprecation message

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -6,7 +6,6 @@ const { RSVP, on } = Ember;
 export default Ember.ObjectProxy.extend(Ember.Evented, {
   authenticator:       null,
   store:               null,
-  container:           null,
   isAuthenticated:     false,
   attemptedTransition: null,
   content:             { authenticated: {} },

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -17,7 +17,7 @@ describe('InternalSession', () => {
     let container = { lookup() {} };
     store         = EphemeralStore.create();
     authenticator = Authenticator.create();
-    session       = InternalSession.create({ store, container });
+    session       = InternalSession.create({ store });
     sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
   });
 

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -17,7 +17,7 @@ describe('InternalSession', () => {
     let container = { lookup() {} };
     store         = EphemeralStore.create();
     authenticator = Authenticator.create();
-    session       = InternalSession.create({ store });
+    session       = InternalSession.create({ store, container });
     sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
   });
 

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -20,7 +20,7 @@ describe('SessionService', () => {
     };
     let container = { lookup() {} };
     sinon.stub(container, 'lookup').withArgs('authorizer').returns(authorizer);
-    sessionService = Session.create({ session });
+    sessionService = Session.create({ container, session });
   });
 
   it('forwards the "authenticationSucceeded" event from the session', (done) => {

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -20,7 +20,7 @@ describe('SessionService', () => {
     };
     let container = { lookup() {} };
     sinon.stub(container, 'lookup').withArgs('authorizer').returns(authorizer);
-    sessionService = Session.create({ container, session });
+    sessionService = Session.create({ session });
   });
 
   it('forwards the "authenticationSucceeded" event from the session', (done) => {


### PR DESCRIPTION
more changes related to Ember 2.3 deprecating access to the container property on framework generated objects, feedback wanted