### PR TITLE
add clientSecret option to oauth2-password-grant with related test

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -42,6 +42,19 @@ export default BaseAuthenticator.extend({
   clientId: null,
 
   /**
+   The client_secret to be sent to the authentication server (see
+   https://tools.ietf.org/html/rfc6749#appendix-A.1). __This should only be
+   used for statistics or logging etc. as it cannot actually be trusted since
+   it could have been manipulated on the client!__
+
+   @property clientSecret
+   @type String
+   @default null
+   @public
+   */
+  clientSecret: null,
+
+  /**
     The endpoint on the server that authentication and token refresh requests
     are sent to.
 
@@ -226,7 +239,10 @@ export default BaseAuthenticator.extend({
     const clientId = this.get('clientId');
 
     if (!isEmpty(clientId)) {
-      const base64ClientId = window.btoa(clientId.concat(':'));
+      let clientSecret = this.get('clientSecret');
+      clientSecret = (clientSecret !== 'undefined') ? clientSecret : '';
+      const clientIdSecret = clientId.concat(':'.concat(clientSecret));
+      const base64ClientId = window.btoa(clientIdSecret);
       Ember.merge(options, {
         headers: {
           Authorization: `Basic ${base64ClientId}`

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -128,7 +128,25 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           data:        { 'grant_type': 'password', username: 'username', password: 'password' },
           dataType:    'json',
           contentType: 'application/x-www-form-urlencoded',
-          headers:     { Authorization: 'Basic dGVzdC1jbGllbnQ6' }
+          headers:     { Authorization: 'Basic dGVzdC1jbGllbnQ6bnVsbA==' }
+        });
+        done();
+      });
+    });
+
+    it('sends an AJAX request to the token endpoint with client_id and client_secret Basic Auth header', function(done) {
+      authenticator.set('clientId', 'test-client');
+      authenticator.set('clientSecret', 'test-client-secret');
+      authenticator.authenticate('username', 'password');
+
+      Ember.run.next(() => {
+        expect(Ember.$.ajax.getCall(0).args[0]).to.eql({
+          url:         '/token',
+          type:        'POST',
+          data:        { 'grant_type': 'password', username: 'username', password: 'password' },
+          dataType:    'json',
+          contentType: 'application/x-www-form-urlencoded',
+          headers:     { Authorization: 'Basic dGVzdC1jbGllbnQ6dGVzdC1jbGllbnQtc2VjcmV0' }
         });
         done();
       });


### PR DESCRIPTION
This adds the ability to pass a clientSecret per https://tools.ietf.org/html/rfc6749#appendix-A.2

This allows implementing an oauth2 authenticator that uses the existing clientId and the clientSecret property that has been added in this PR.  This should not cause any backwards compatibility issues, as it should still return the same value as it did previously `clientId:` for the Authorization header if no clientSecret is provided.  Please let me know if anyone see's any issues with this approach and I'm happy to update based on suggestions here.  

```
// example /app/authenticators/oauth2.js

import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
import config from '../config/environment';

export default OAuth2PasswordGrant.extend({
  clientId: `${config.apiClientId}`,
  clientSecret: `${config.apiClientSecret}`
});
```