### PR TITLE
add method adjustAjaxConfig to allow customization of ajax request

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -140,7 +140,7 @@ export default BaseAuthenticator.extend({
   */
   makeRequest(data) {
     const serverTokenEndpoint = this.get('serverTokenEndpoint');
-    return Ember.$.ajax({
+    return Ember.$.ajax(this.adjustAjaxConfig({
       url:      serverTokenEndpoint,
       type:     'POST',
       dataType: 'json',
@@ -148,6 +148,19 @@ export default BaseAuthenticator.extend({
       beforeSend(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);
       }
-    });
+    }));
+  },
+
+  /**
+    Optional hook that can be over-ridden if the ajax request needs tweaking
+
+    @method adjustAjaxConfig
+    @param {Object} config The argument to be sent to `$.ajax`.
+    @return {Object} The adjusted version of the config.
+    @public
+  */
+  adjustAjaxConfig(config) {
+    /* Default implementation is to not make any adjustments. */
+    return config;
   }
 });

--- a/tests/unit/authenticators/devise-test.js
+++ b/tests/unit/authenticators/devise-test.js
@@ -63,6 +63,19 @@ describe('DeviseAuthenticator', () => {
       Ember.$.ajax.restore();
     });
 
+    it('can customize the ajax request', (done) => {
+      sinon.stub(authenticator, 'adjustAjaxConfig', function(config) {
+        config.contentType = 'application/json';
+        return config;
+      });
+      authenticator.authenticate('identification', 'password');
+      Ember.run.next(() => {
+        let [args] = Ember.$.ajax.getCall(0).args;
+        expect(args.contentType).to.eql('application/json');
+        done();
+      });
+    });
+
     it('sends an AJAX request to the sign in endpoint', (done) => {
       authenticator.authenticate('identification', 'password');
 


### PR DESCRIPTION
Customization the ajax request is necessary if one wants to use `contentType: 'application/json'` for example.