### PR TITLE
Thow error on AuthenticatedRouteMixin

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -57,7 +57,11 @@ export default Ember.Mixin.create({
       transition.abort();
       this.get('session').set('attemptedTransition', transition);
       Ember.assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== Configuration.authenticationRoute);
-      this.transitionTo(Configuration.authenticationRoute);
+      try {
+        this.transitionTo(Configuration.authenticationRoute);
+      } catch(e) {
+        Ember.Logger.error(e.message);
+      }
     } else {
       return this._super(...arguments);
     }


### PR DESCRIPTION
A couple of days ago I ran into an issue and I managed to fix it.

When an unauthorized user tries to access a route that extends `AuthenticatedRouteMixin`, (s)he would be redirected to the `authenticationRoute`. If the `authenticationRoute` is wrong for whatever reason (the developer forgot to update `config/environment.js` when refactoring things (guilty of that :grimacing:)), the user would not be redirected, the template would not be loaded and there would be no error on the console either.

![silent-error](https://cloud.githubusercontent.com/assets/266400/12716399/58e7872a-c8c7-11e5-984f-b10c0ad2a18d.png)

This PR adds a try/catch before redirecting to `Configuration.authenticationRoute` just to make sure the `authenticationRoute` is there.

![explicit-error](https://cloud.githubusercontent.com/assets/266400/12716409/72632bfa-c8c7-11e5-8a56-c4a9cfc3f7d2.png)
