### PR TITLE
Default Configuration.baseURL to ''

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
+const { getWithDefault } = Ember;
+
 const DEFAULTS = {
+  baseURL:                     '',
   authenticationRoute:         'login',
   routeAfterAuthentication:    'index',
   routeIfAlreadyAuthenticated: 'index'
@@ -32,10 +35,10 @@ export default {
     @readOnly
     @static
     @type String
-    @default '/'
+    @default ''
     @public
   */
-  baseURL: null,
+  baseURL: DEFAULTS.baseURL,
 
   /**
     The route to transition to for authentication. The
@@ -79,10 +82,9 @@ export default {
   routeIfAlreadyAuthenticated: DEFAULTS.routeIfAlreadyAuthenticated,
 
   load(config) {
-    let wrappedConfig = Ember.Object.create(config);
     for (let property in this) {
       if (this.hasOwnProperty(property) && Ember.typeOf(this[property]) !== 'function') {
-        this[property] = wrappedConfig.getWithDefault(property, DEFAULTS[property]);
+        this[property] = getWithDefault(config, property, DEFAULTS[property]);
       }
     }
   }

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -9,6 +9,14 @@ describe('Configuration', () => {
     Configuration.load({});
   });
 
+  describe('baseURL', () => {
+    it('defaults to ""', () => {
+      Configuration.load({});
+
+      expect(Configuration.baseURL).to.eql('');
+    });
+  });
+
   describe('authenticationRoute', () => {
     it('defaults to "login"', () => {
       expect(Configuration.authenticationRoute).to.eql('login');
@@ -28,6 +36,12 @@ describe('Configuration', () => {
   });
 
   describe('.load', () => {
+    it('sets baseURL correctly', () => {
+      Configuration.load({ baseURL: '/baseURL' });
+
+      expect(Configuration.baseURL).to.eql('/baseURL');
+    });
+
     it('sets authenticationRoute correctly', () => {
       Configuration.load({ authenticationRoute: 'authenticationRoute' });
 


### PR DESCRIPTION
…as a value of `undefined` (e.g. if the setting isn't configured in `config/environment.js` at all) would lead to the user being redirected to `/undefined` after logout.

This closes #868 