### PR TITLE
Match example given in readme for session service's authorize method to the api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,11 +395,11 @@ import OAuth2Bearer from 'ember-simple-auth/authorizers/oauth2-bearer';
 export default OAuth2Bearer.extend();
 ```
 
-and invoke the session service's `authorize` method with the respective name:
+and invoke the session service's [`authorize`](http://ember-simple-auth.com/api/classes/SessionService.html#method_authorize) method with the respective name:
 
 ```js
-this.get('session').authorize('authorizer:some', () => {
-  …
+this.get('session').authorize('authorizer:some', (/*authorization data*/) => {
+  // Use authorization data
 });
 ```
 


### PR DESCRIPTION
Following on from https://github.com/simplabs/ember-simple-auth/issues/884.

It was unclear in the readme that headerName and headerValue are available, whereas the api docs shows the method in full.