### PR TITLE
Allow customization of ajax request in devise authenticator.

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -135,12 +135,14 @@ export default BaseAuthenticator.extend({
 
     @method makeRequest
     @param {Object} data The request data
+    @param {Object} options Ajax configuration object merged into argument of `$.ajax`
     @return {jQuery.Deferred} A promise like jQuery.Deferred as returned by `$.ajax`
     @protected
   */
-  makeRequest(data) {
+  makeRequest(data, options) {
     const serverTokenEndpoint = this.get('serverTokenEndpoint');
-    return Ember.$.ajax({
+    options = options || {};
+    return Ember.$.ajax(Ember.$.extend({}, {
       url:      serverTokenEndpoint,
       type:     'POST',
       dataType: 'json',
@@ -148,6 +150,6 @@ export default BaseAuthenticator.extend({
       beforeSend(xhr, settings) {
         xhr.setRequestHeader('Accept', settings.accepts.json);
       }
-    });
+    }, options));
   }
 });

--- a/tests/unit/authenticators/devise-test.js
+++ b/tests/unit/authenticators/devise-test.js
@@ -113,6 +113,20 @@ describe('DeviseAuthenticator', () => {
         });
       });
     });
+
+    it('can customize the ajax request', (done) => {
+      authenticator = Devise.extend({
+        makeRequest(config) {
+          return this._super(config, { contentType: 'application/json' });
+        }
+      }).create();
+      authenticator.authenticate('identification', 'password');
+      Ember.run.next(() => {
+        let [args] = Ember.$.ajax.getCall(0).args;
+        expect(args.contentType).to.eql('application/json');
+        done();
+      });
+    });
   });
 
   describe('#invalidate', () => {


### PR DESCRIPTION
Allow makeRequest to be overridden to provide a second parameter that gets merge into .ajax() config argument. Here's an example of how this could be used to have devise with a json body instead of request parameters:

    export default DeviseAuthenticator.extend({
      makeRequest: function(data) {
        if (typeof(data) === "object") {
          data = JSON.stringify(data);
        }
        return this._super(data, {contentType: 'application/json'});
      }
    });
