### PR TITLE
Fix container deprecations, refactor internal-session tests

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -6,7 +6,6 @@ const { RSVP, on } = Ember;
 export default Ember.ObjectProxy.extend(Ember.Evented, {
   authenticator:       null,
   store:               null,
-  container:           null,
   isAuthenticated:     false,
   attemptedTransition: null,
   content:             { authenticated: {} },

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -8,7 +8,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   store:               null,
   isAuthenticated:     false,
   attemptedTransition: null,
-  content:             { authenticated: {} },
+  content:             null,
 
   authenticate() {
     let args          = Array.prototype.slice.call(arguments);
@@ -182,5 +182,9 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         this._clear(true);
       }
     });
+  }),
+
+  _setupContent: on('init', function() {
+    this.set('content', { authenticated: {} });
   })
 });

--- a/tests/dummy/app/internal-session.js
+++ b/tests/dummy/app/internal-session.js
@@ -1,0 +1,3 @@
+import InternalSession from 'ember-simple-auth/internal-session';
+
+export default InternalSession.extend();

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -11,8 +11,10 @@ describeModule('internal-session:main', 'InternalSession', {}, () => {
   let session;
   let store;
   let authenticator;
+  let emberTestContext;
 
   beforeEach(function() {
+    emberTestContext = this;
     store         = EphemeralStore.create();
     session       = this.subject({ store });
     authenticator = Authenticator.create();
@@ -722,6 +724,23 @@ describeModule('internal-session:main', 'InternalSession', {}, () => {
           });
         });
       });
+    });
+  });
+
+  describe('multiple internal sessions', () => {
+    let session2;
+
+    beforeEach(() => {
+      let internalSessionFactory = emberTestContext.container.lookupFactory('internal-session:main');
+      session2 = internalSessionFactory.create({ store: EphemeralStore.create() });
+    });
+
+    it('uses separate content objects', (done) => {
+      Ember.run(function() {
+        session.set('content.secret', 'I see dead people.');
+      });
+      expect(session2.get('content.secret')).to.be.undefined;
+      done();
     });
   });
 });

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -1,24 +1,22 @@
 /* jshint expr:true */
 import Ember from 'ember';
-import { it } from 'ember-mocha';
+import { describeModule, it } from 'ember-mocha';
 import { describe, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import Authenticator from 'ember-simple-auth/authenticators/base';
 
-describe('InternalSession', () => {
+describeModule('internal-session:main', 'InternalSession', {}, () => {
   let session;
   let store;
   let authenticator;
 
-  beforeEach(() => {
-    let container = { lookup() {} };
+  beforeEach(function() {
     store         = EphemeralStore.create();
+    session       = this.subject({ store });
     authenticator = Authenticator.create();
-    session       = InternalSession.create({ store, container });
-    sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
+    this.register('authenticator:test', authenticator, { instantiate: false });
   });
 
   it('does not allow data to be stored for the key "authenticated"', () => {
@@ -37,7 +35,7 @@ describe('InternalSession', () => {
         authenticator.trigger('sessionDataUpdated', { some: 'property' });
 
         Ember.run.next(() => {
-          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator' });
+          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator:test' });
           done();
         });
       });
@@ -118,7 +116,7 @@ describe('InternalSession', () => {
 
     describe('when the restored data contains an authenticator factory', () => {
       beforeEach(() => {
-        store.persist({ authenticated: { authenticator: 'authenticator' } });
+        store.persist({ authenticated: { authenticator: 'authenticator:test' } });
       });
 
       describe('when the authenticator resolves restoration', () => {
@@ -139,24 +137,24 @@ describe('InternalSession', () => {
         });
 
         it('stores the data the authenticator resolves with in its authenticated section', () => {
-          return store.persist({ authenticated: { authenticator: 'authenticator' } }).then(() => {
+          return store.persist({ authenticated: { authenticator: 'authenticator:test' } }).then(() => {
             return session.restore().then(() => {
               return store.restore().then((properties) => {
                 delete properties.authenticator;
 
-                expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator' });
+                expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator:test' });
               });
             });
           });
         });
 
         it('persists its content in the store', () => {
-          return store.persist({ authenticated: { authenticator: 'authenticator' }, someOther: 'property' }).then(() => {
+          return store.persist({ authenticated: { authenticator: 'authenticator:test' }, someOther: 'property' }).then(() => {
             return session.restore().then(() => {
               return store.restore().then((properties) => {
                 delete properties.authenticator;
 
-                expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator' }, someOther: 'property' });
+                expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator:test' }, someOther: 'property' });
               });
             });
           });
@@ -165,7 +163,7 @@ describe('InternalSession', () => {
         it('persists the authenticator factory in the store', () => {
           return session.restore().then(() => {
             return store.restore().then((properties) => {
-              expect(properties.authenticated.authenticator).to.eql('authenticator');
+              expect(properties.authenticated.authenticator).to.eql('authenticator:test');
             });
           });
         });
@@ -230,7 +228,7 @@ describe('InternalSession', () => {
 
         describe('when the store resolves restoration', function() {
           beforeEach(() => {
-            sinon.stub(store, 'restore').returns({ authenticated: { authenticator: 'authenticator' } });
+            sinon.stub(store, 'restore').returns({ authenticated: { authenticator: 'authenticator:test' } });
           });
 
           it('is authenticated', () => {
@@ -262,37 +260,37 @@ describe('InternalSession', () => {
       });
 
       it('is authenticated', () => {
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           expect(session.get('isAuthenticated')).to.be.true;
         });
       });
 
       it('returns a resolving promise', () => {
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           expect(true).to.be.true;
         });
       });
 
       it('stores the data the authenticator resolves with in its authenticated section', () => {
-        return session.authenticate('authenticator').then(() => {
-          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator' });
+        return session.authenticate('authenticator:test').then(() => {
+          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator:test' });
         });
       });
 
       it('persists its content in the store', () => {
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           return store.restore().then((properties) => {
             delete properties.authenticator;
 
-            expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator' } });
+            expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator:test' } });
           });
         });
       });
 
       it('persists the authenticator factory in the store', () => {
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           return store.restore().then((properties) => {
-            expect(properties.authenticated.authenticator).to.eql('authenticator');
+            expect(properties.authenticated.authenticator).to.eql('authenticator:test');
           });
         });
       });
@@ -301,13 +299,13 @@ describe('InternalSession', () => {
         let triggered = false;
         session.one('authenticationSucceeded', () => triggered = true);
 
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           expect(triggered).to.be.true;
         });
       });
 
       itHandlesAuthenticatorEvents(() => {
-        return session.authenticate('authenticator');
+        return session.authenticate('authenticator:test');
       });
     });
 
@@ -315,7 +313,7 @@ describe('InternalSession', () => {
       it('is not authenticated', () => {
         sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.reject('error auth'));
 
-        return session.authenticate('authenticator').catch(() => {
+        return session.authenticate('authenticator:test').catch(() => {
           expect(session.get('isAuthenticated')).to.be.false;
         });
       });
@@ -323,7 +321,7 @@ describe('InternalSession', () => {
       it('returns a rejecting promise', () => {
         sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.reject('error auth'));
 
-        return session.authenticate('authenticator').catch(() => {
+        return session.authenticate('authenticator:test').catch(() => {
           expect(true).to.be.true;
         });
       });
@@ -332,7 +330,7 @@ describe('InternalSession', () => {
         sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.reject('error auth'));
         session.set('content', { some: 'property', authenticated: { some: 'other property' } });
 
-        return session.authenticate('authenticator').catch(() => {
+        return session.authenticate('authenticator:test').catch(() => {
           expect(session.get('content')).to.eql({ some: 'property', authenticated: {} });
         });
       });
@@ -341,7 +339,7 @@ describe('InternalSession', () => {
         sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.reject('error auth'));
         session.set('content', { some: 'property', authenticated: { some: 'other property' } });
 
-        return session.authenticate('authenticator').catch(() => {
+        return session.authenticate('authenticator:test').catch(() => {
           return store.restore().then((properties) => {
             expect(properties).to.eql({ some: 'property', authenticated: {} });
           });
@@ -353,7 +351,7 @@ describe('InternalSession', () => {
         sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.reject('error auth'));
         session.one('authenticationSucceeded', () => triggered = true);
 
-        return session.authenticate('authenticator').catch(() => {
+        return session.authenticate('authenticator:test').catch(() => {
           expect(triggered).to.be.false;
         });
       });
@@ -365,7 +363,7 @@ describe('InternalSession', () => {
       });
 
       it('is not authenticated', () => {
-        return session.authenticate('authenticator').then(() => {
+        return session.authenticate('authenticator:test').then(() => {
           expect(session.get('isAuthenticated')).to.be.false;
         });
       });
@@ -375,7 +373,7 @@ describe('InternalSession', () => {
   describe('invalidation', () => {
     beforeEach(() => {
       sinon.stub(authenticator, 'authenticate').returns(Ember.RSVP.resolve({ some: 'property' }));
-      return session.authenticate('authenticator');
+      return session.authenticate('authenticator:test');
     });
 
     describe('when the authenticator resolves invaldiation', () => {
@@ -444,7 +442,7 @@ describe('InternalSession', () => {
         sinon.stub(authenticator, 'invalidate').returns(Ember.RSVP.reject('error'));
 
         return session.invalidate().catch(() => {
-          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator' });
+          expect(session.get('authenticated')).to.eql({ some: 'property', authenticator: 'authenticator:test' });
         });
       });
 
@@ -453,7 +451,7 @@ describe('InternalSession', () => {
 
         return session.invalidate().catch(() => {
           return store.restore().then((properties) => {
-            expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator' } });
+            expect(properties).to.eql({ authenticated: { some: 'property', authenticator: 'authenticator:test' } });
           });
         });
       });
@@ -523,7 +521,7 @@ describe('InternalSession', () => {
         });
 
         it('is authenticated', (done) => {
-          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
             expect(session.get('isAuthenticated')).to.be.true;
@@ -532,21 +530,21 @@ describe('InternalSession', () => {
         });
 
         it('stores the data the authenticator resolves with in its authenticated section', (done) => {
-          store.trigger('sessionDataUpdated', { some: 'property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
-            expect(session.get('authenticated')).to.eql({ some: 'other property', authenticator: 'authenticator' });
+            expect(session.get('authenticated')).to.eql({ some: 'other property', authenticator: 'authenticator:test' });
             done();
           });
         });
 
         it('persists its content in the store', (done) => {
-          store.trigger('sessionDataUpdated', { some: 'property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
             store.restore().then((properties) => {
 
-              expect(properties).to.eql({ some: 'property', authenticated: { some: 'other property', authenticator: 'authenticator' } });
+              expect(properties).to.eql({ some: 'property', authenticated: { some: 'other property', authenticator: 'authenticator:test' } });
               done();
             });
           });
@@ -560,7 +558,7 @@ describe('InternalSession', () => {
           it('does not trigger the "authenticationSucceeded" event', (done) => {
             let triggered = false;
             session.one('authenticationSucceeded', () => triggered = true);
-            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
             Ember.run.next(() => {
               expect(triggered).to.be.false;
@@ -577,7 +575,7 @@ describe('InternalSession', () => {
           it('triggers the "authenticationSucceeded" event', (done) => {
             let triggered = false;
             session.one('authenticationSucceeded', () => triggered = true);
-            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
             Ember.run.next(() => {
               expect(triggered).to.be.true;
@@ -593,7 +591,7 @@ describe('InternalSession', () => {
         });
 
         it('is not authenticated', (done) => {
-          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
             expect(session.get('isAuthenticated')).to.be.false;
@@ -603,7 +601,7 @@ describe('InternalSession', () => {
 
         it('clears its authenticated section', (done) => {
           session.set('content', { some: 'property', authenticated: { some: 'other property' } });
-          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
             expect(session.get('content')).to.eql({ some: 'other property', authenticated: {} });
@@ -613,7 +611,7 @@ describe('InternalSession', () => {
 
         it('updates the store', (done) => {
           session.set('content', { some: 'property', authenticated: { some: 'other property' } });
-          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+          store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
           Ember.run.next(() => {
             store.restore().then((properties) => {
@@ -631,7 +629,7 @@ describe('InternalSession', () => {
           it('triggers the "invalidationSucceeded" event', (done) => {
             let triggered = false;
             session.one('invalidationSucceeded', () => triggered = true);
-            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
             Ember.run.next(() => {
               expect(triggered).to.be.true;
@@ -648,7 +646,7 @@ describe('InternalSession', () => {
           it('does not trigger the "invalidationSucceeded" event', (done) => {
             let triggered = false;
             session.one('invalidationSucceeded', () => triggered = true);
-            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator' } });
+            store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
 
             Ember.run.next(() => {
               expect(triggered).to.be.false;


### PR DESCRIPTION
I have refactored the tests of `internal-session` to use `describeModule`, which provides an isolated container so stubbing one isn't necessary. In order to use `describeModule`, I needed to have a resolvable name, and so I put an `internal-session.js` into the dummy app, which allows `describeModule` to use the resolvable name `internal-session:main`. This is only necessary for testing, because in regular use the initializer sets up `InternalSession`. I also needed to change the authenticator's name to something that Ember is happy with, and so chose `authenticator:test` (i.e., it needed a colon). 

These changes appear to solve the container deprecation warnings, and do so in a way that all tests pass.

I believe this solves issues #857 and #822.