### PR TITLE
use separate context objects, which helps solving container deprecation messages

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -6,10 +6,13 @@ const { RSVP, on } = Ember;
 export default Ember.ObjectProxy.extend(Ember.Evented, {
   authenticator:       null,
   store:               null,
-  container:           null,
   isAuthenticated:     false,
   attemptedTransition: null,
-  content:             { authenticated: {} },
+
+  init() {
+    this._super(...arguments);
+    this.set('content', { authenticated: {} });
+  },
 
   authenticate() {
     let args          = Array.prototype.slice.call(arguments);

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -12,9 +12,10 @@ describe('InternalSession', () => {
   let session;
   let store;
   let authenticator;
+  let container;
 
   beforeEach(() => {
-    let container = { lookup() {} };
+    container     = { lookup() {} };
     store         = EphemeralStore.create();
     authenticator = Authenticator.create();
     session       = InternalSession.create({ store, container });
@@ -725,5 +726,11 @@ describe('InternalSession', () => {
         });
       });
     });
+  });
+
+  it('does not share the content object between multiple instances', () => {
+    let session2 = InternalSession.create({ store, container });
+
+    expect(session2.get('content')).to.not.equal(session.get('content'));
   });
 });


### PR DESCRIPTION
See #822 for more discussion. This PR is a rebased, squashed version of #894.