### PR TITLE
Let all responses be handled by Ember Data handleResponse

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -95,13 +95,9 @@ export default Ember.Mixin.create({
     @protected
   */
   handleResponse(status) {
-    if (status === 401) {
-      if (this.get('session.isAuthenticated')) {
-        this.get('session').invalidate();
-      }
-      return true;
-    } else {
-      return this._super(...arguments);
+    if (status === 401 && this.get('session.isAuthenticated')) {
+      this.get('session').invalidate();
     }
+    return this._super(...arguments);
   }
 });

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -116,10 +116,6 @@ describe('DataAdapterMixin', () => {
 
           expect(sessionService.invalidate).to.have.been.calledOnce;
         });
-
-        it('returns true', () => {
-          expect(adapter.handleResponse(401)).to.be.true;
-        });
       });
 
       describe('when the session is not authenticated', () => {
@@ -132,10 +128,6 @@ describe('DataAdapterMixin', () => {
 
           expect(sessionService.invalidate).to.not.have.been.called;
         });
-
-        it('returns true', () => {
-          expect(adapter.handleResponse(401)).to.be.true;
-        });
       });
     });
 
@@ -145,10 +137,10 @@ describe('DataAdapterMixin', () => {
 
         expect(sessionService.invalidate).to.not.have.been.called;
       });
+    });
 
-      it("returns _super's return value", () => {
-        expect(adapter.handleResponse(200)).to.eq('_super return value');
-      });
+    it("returns _super's return value", () => {
+      expect(adapter.handleResponse(401)).to.eq('_super return value');
     });
   });
 });


### PR DESCRIPTION
When the backend responds with a 401 still invalidate the session but
then let Ember Data handle the response. In the case of a 401 it would
raise an `AdapterError`

fixes #858