### PR TITLE
Make silent-error a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "mocha-only-detector": "0.0.2",
     "morgan": "^1.5.2",
     "rimraf": "^2.3.2",
-    "silent-error": "^1.0.0",
     "sinon-chai": "~2.8.0",
     "torii": "~0.6.1"
   },
@@ -67,7 +66,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-getowner-polyfill": "1.0.0"
+    "ember-getowner-polyfill": "1.0.0",
+    "silent-error": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
`silent-error` was previously only added as a dev dependency…

This fixes #910 