### PR TITLE
Nake ember-cli-is-package-missing a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-internal-test-helpers": "^0.5.0",
     "ember-cli-mocha": "~0.9.7",
-    "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-pretender": "~0.5.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^1.2.0",
@@ -66,6 +65,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-is-package-missing": "^1.0.0",
     "ember-getowner-polyfill": "1.0.0",
     "silent-error": "^1.0.0"
   },


### PR DESCRIPTION
Previously the package was a dev dependency only, causing errors in projects that don't have the package installed already.

This is a follow up to #911 and will finally close #910.