### PR TITLE
Don't start syncing cookie before first restore

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 
-const { RSVP, computed, on } = Ember;
+const { RSVP, computed, on, run: { next } } = Ember;
 
 /**
   Session store that persists data in a cookie.
@@ -88,8 +88,10 @@ export default BaseStore.extend({
   }).volatile(),
 
   _setup: on('init', function() {
-    this._syncData().then(() => {
-      this._renewExpiration();
+    next(() => {
+      this._syncData().then(() => {
+        this._renewExpiration();
+      });
     });
   }),
 

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -79,8 +79,10 @@ export default function(options) {
       sync(store);
 
       Ember.run.next(() => {
-        expect(triggered).to.be.true;
-        done();
+        Ember.run.next(() => {
+          expect(triggered).to.be.true;
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
This fixes a regression in the cookie store that caused strange behavior when the session was restored from a cookie.

This closes #908