### PR TITLE
Prefer overriding init over on('init', …

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import getOwner from 'ember-getowner-polyfill';
 
-const { RSVP, on, isNone, isEmpty } = Ember;
+const { RSVP, isNone, isEmpty } = Ember;
 
 export default Ember.ObjectProxy.extend(Ember.Evented, {
   authenticator:       null,
@@ -12,6 +12,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   init() {
     this._super(...arguments);
     this.set('content', { authenticated: {} });
+    this._bindToStoreEvents();
   },
 
   authenticate(authenticatorFactory, ...args) {
@@ -156,7 +157,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
     });
   },
 
-  _bindToStoreEvents: on('init', function() {
+  _bindToStoreEvents() {
     this.store.on('sessionDataUpdated', (content) => {
       let { authenticator: authenticatorFactory } = (content.authenticated || {});
       if (!!authenticatorFactory) {
@@ -176,7 +177,7 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         this._clearWithContent(content, true);
       }
     });
-  }),
+  },
 
   _lookupAuthenticator(authenticator) {
     return getOwner(this).lookup(authenticator);

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Configuration from './../configuration';
 
-const { inject, on } = Ember;
+const { inject } = Ember;
 
 /**
   The mixin for the application route; __defines methods that are called when
@@ -52,7 +52,12 @@ export default Ember.Mixin.create({
   */
   session: inject.service('session'),
 
-  _subscribeToSessionEvents: on('init', function() {
+  init() {
+    this._super(...arguments);
+    this._subscribeToSessionEvents();
+  },
+
+  _subscribeToSessionEvents() {
     Ember.A([
       ['authenticationSucceeded', 'sessionAuthenticated'],
       ['invalidationSucceeded', 'sessionInvalidated']
@@ -61,7 +66,7 @@ export default Ember.Mixin.create({
         this[method](...arguments);
       }));
     });
-  }),
+  },
 
   /**
     This method handles the session's

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -3,7 +3,7 @@ import getOwner from 'ember-getowner-polyfill';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
 
-const { computed, on }  = Ember;
+const { computed }  = Ember;
 
 /**
   __The session service provides access to the current session as well as
@@ -114,6 +114,11 @@ export default Ember.Service.extend(Ember.Evented, {
   */
   attemptedTransition: computed.alias('session.attemptedTransition'),
 
+  init() {
+    this._super(...arguments);
+    this._forwardSessionEvents();
+  },
+
   set(key, value) {
     const setsSessionData = SESSION_DATA_KEY_PREFIX.test(key);
     if (setsSessionData) {
@@ -124,7 +129,7 @@ export default Ember.Service.extend(Ember.Evented, {
     }
   },
 
-  _forwardSessionEvents: on('init', function() {
+  _forwardSessionEvents() {
     Ember.A([
       'authenticationSucceeded',
       'invalidationSucceeded'
@@ -137,7 +142,7 @@ export default Ember.Service.extend(Ember.Evented, {
         });
       }
     });
-  }),
+  },
 
   /**
     __Authenticates the session with an `authenticator`__ and appropriate

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 
-const { RSVP, computed, on, run: { next } } = Ember;
+const { RSVP, computed, run: { next } } = Ember;
 
 /**
   Session store that persists data in a cookie.
@@ -87,13 +87,15 @@ export default BaseStore.extend({
     return visibilityState === 'visible';
   }).volatile(),
 
-  _setup: on('init', function() {
+  init() {
+    this._super(...arguments);
+
     next(() => {
       this._syncData().then(() => {
         this._renewExpiration();
       });
     });
-  }),
+  },
 
   /**
     Persists the `data` in the cookie.

--- a/addon/session-stores/ephemeral.js
+++ b/addon/session-stores/ephemeral.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import BaseStore from './base';
 
-const { RSVP, on } = Ember;
+const { RSVP } = Ember;
 
 /**
   Session store that __persists data in memory and thus is not actually
@@ -15,9 +15,10 @@ const { RSVP, on } = Ember;
   @public
 */
 export default BaseStore.extend({
-  _setup: on('init', function() {
+  init() {
+    this._super(...arguments);
     this.clear();
-  }),
+  },
 
   /**
     Persists the `data`. This replaces all currently stored data.


### PR DESCRIPTION
Overriding the `init` method is actually preferrable over using `_someMethod: on('init', …` for various reasons.