### PR TITLE
Basic FastBoot support

### DIFF
--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 import Base from 'ember-simple-auth/session-stores/base';
 import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
 import Cookie from 'ember-simple-auth/session-stores/cookie';
+import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 
 const { computed } = Ember;
 
@@ -82,7 +83,9 @@ export default Base.extend({
     this._super(...arguments);
 
     let store;
-    if (this.get('_isLocalStorageAvailable')) {
+    if (typeof FastBoot !== "undefined") {
+      store = this._createStore(Ephemeral);
+    } else if (this.get('_isLocalStorageAvailable')) {
       const options = { key: this.get('localStorageKey') };
       store = this._createStore(LocalStorage, options);
     } else {

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -76,7 +76,9 @@ export default BaseStore.extend({
   */
   cookieExpirationTime: null,
 
-  _secureCookies: window.location.protocol === 'https:',
+  _secureCookies: computed(function() {
+    return window.location.protocol === 'https:';
+  }),
 
   _syncDataTimeout: null,
 
@@ -157,7 +159,7 @@ export default BaseStore.extend({
     let path        = '; path=/';
     let domain      = Ember.isEmpty(this.cookieDomain) ? '' : `; domain=${this.cookieDomain}`;
     let expires     = Ember.isEmpty(expiration) ? '' : `; expires=${new Date(expiration).toUTCString()}`;
-    let secure      = !!this._secureCookies ? ';secure' : '';
+    let secure      = !!this.get("_secureCookies") ? ';secure' : '';
     document.cookie = `${this.cookieName}=${encodeURIComponent(value)}${domain}${path}${expires}${secure}`;
     if (expiration !== null) {
       let cachedExpirationTime = this._read(`${this.cookieName}:expiration_time`);


### PR DESCRIPTION
This is the minimum set of changes I had to make for our app to boot & run under FastBoot.

* use ephemeral store if running under FastBoot
* lazily evaluate protocol in cookie store so it doesn’t break under node