### PR TITLE
Fix #927

### DIFF
--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -82,13 +82,15 @@ export default BaseStore.extend({
   },
 
   _bindToStorageEvents() {
-    Ember.$(window).bind('storage', () => {
-      this.restore().then((data) => {
-        if (!objectsAreEqual(data, this._lastData)) {
-          this._lastData = data;
-          this.trigger('sessionDataUpdated', data);
-        }
-      });
+    Ember.$(window).bind('storage', (e) => {
+      if (e.originalEvent.key === this.key) {
+        this.restore().then((data) => {
+          if (!objectsAreEqual(data, this._lastData)) {
+            this._lastData = data;
+            this.trigger('sessionDataUpdated', data);
+          }
+        });
+      }
     });
   }
 });


### PR DESCRIPTION
This pr prevents the `localStorage` store from triggering the `sessionDataUpdated` event when other `localStorage` keys then the one used by ember-simple-auth have been updated. Should fix #927.