### PR TITLE
Add note on how to simulate CI runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,9 @@ Here's a few steps to follow to make sure your pull request gets accepted:
 
 ## Run Tests
 
-After you forked the repository run `npm install` and `bower install`.
+After you have forked the repository, run `npm install` and `bower install`.
 Also install [PhantomJS](http://phantomjs.org/) to run the tests.
 
-Afterwards you can run all tests with `ember test`. If you want to test your
-change against multiple versions of Ember and Ember Data run `ember try:testall`.
+To run tests against the currently installed Ember version, run `ember test`. To
+simulate a CI run -- testing multiple versions of Ember, Ember Data and the
+included addon generators -- run `npm test && npm run nodetest`.


### PR DESCRIPTION
This should help new devs avoid failed CI jobs after running `npm test`, which runs tests against multiple Ember/Ember Data versions, but does not test the generators as CI does.