### PR TITLE
seperated transition block as an action on sessionAuthenticated

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -66,23 +66,14 @@ export default Ember.Mixin.create({
   /**
     This method handles the session's
     {{#crossLink "SessionService/authenticationSucceeded:event"}}{{/crossLink}}
-    event. If there is a transition that was previously intercepted by
-    {{#crossLink "AuthenticatedRouteMixin/beforeModel:method"}}the
-    AuthenticatedRouteMixin's `beforeModel` method{{/crossLink}} it will retry
-    it. If there is no such transition, this action transitions to the
-    {{#crossLink "Configuration/routeAfterAuthentication:property"}}{{/crossLink}}.
+    event.
 
     @method sessionAuthenticated
     @public
   */
   sessionAuthenticated() {
-    let attemptedTransition = this.get('session.attemptedTransition');
-    if (attemptedTransition) {
-      attemptedTransition.retry();
-      this.set('session.attemptedTransition', null);
-    } else {
-      this.transitionTo(Configuration.routeAfterAuthentication);
-    }
+    this.send('authenticatedTransition');
+
   },
 
   /**
@@ -104,5 +95,30 @@ export default Ember.Mixin.create({
     if (!Ember.testing) {
       window.location.replace(Configuration.baseURL);
     }
+  },
+
+  actions: {
+    /**
+      If there is a transition that was previously intercepted by
+      {{#crossLink "AuthenticatedRouteMixin/beforeModel:method"}}the
+      AuthenticatedRouteMixin's `beforeModel` method{{/crossLink}} it will retry
+      it. If there is no such transition, this action transitions to the
+      {{#crossLink "Configuration/routeAfterAuthentication:property"}}{{/crossLink}}.
+
+      @method authenticatedTransition
+      @public
+    */
+    authenticatedTransition() {
+      const attemptedTransition = this.get('session.attemptedTransition');
+
+      if (attemptedTransition) {
+        attemptedTransition.retry();
+        this.set('session.attemptedTransition', null);
+      } else {
+        this.transitionTo(Configuration.routeAfterAuthentication);
+      }
+
+    }
   }
+
 });


### PR DESCRIPTION
Take this example for reason for PR:

```
    sessionAuthenticated() {
        let _this = this;
        this._loadSomething().catch(function() {
            _this.get('session').invalidate();
        }).finally(function() {
            _this._super(...arguments);
        });

    }
```

The call to _this._super(...arguments) in the finally block is not possible, since Ember does not support calling super on asynchronous blocks, only synchronous blocks. The only thing that is left in this case is to copy and paste the transition code from the ember-simple-auth sessionAuthenticated method, not very convenient for someone who wants to extend while resolving promise/s.

```
    sessionAuthenticated() {
        let _this = this;
        this._loadSomething().catch(function() {
            _this.get('session').invalidate();
        }).finally(function() {
            _this.send('authenticatedTransition');//->much more convenient
        });

    }

```