### PR TITLE
Allow for nesting ember-simple-auth in another addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ module.exports = {
   name: 'ember-simple-auth',
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
+
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
 
     app.import('vendor/ember-simple-auth/register-version.js');
   }


### PR DESCRIPTION
This fix allows nesting ember-simple-auth as an addon dependency of another addon.

This PR was inspired by https://github.com/samselikoff/ember-cli-mirage/pull/610
