### PR TITLE
Stop the baseURL config property from being overridden

### DIFF
--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -7,12 +7,8 @@ import setupSessionService from 'ember-simple-auth/initializers/setup-session-se
 export default {
   name:       'ember-simple-auth',
   initialize: function(registry) {
-    const config = ENV['ember-simple-auth'] || {};
-    
-    // We need to use the default Ember baseURL if one hasn't been set
-    if (!(ENV['ember-simple-auth'] && ENV['ember-simple-auth'].baseURL)) {
-      config.baseURL = ENV.baseURL;
-    }
+    const config   = ENV['ember-simple-auth'] || {};
+    config.baseURL = config.baseURL || ENV.baseURL;
     
     Configuration.load(config);
 

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -8,7 +8,14 @@ export default {
   name:       'ember-simple-auth',
   initialize: function(registry) {
     const config = ENV['ember-simple-auth'] || {};
-    config.baseURL = ENV['ember-simple-auth'].baseURL || ENV.baseURL;
+    
+    // We need to use the default Ember baseURL if one hasn't been set
+    if (ENV['ember-simple-auth'] && ENV['ember-simple-auth'].baseURL) {
+      config.baseURL = ENV['ember-simple-auth'].baseURL;
+    } else {
+      config.baseURL = ENV.baseURL;
+    }
+    
     Configuration.load(config);
 
     setupSession(registry);

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -8,6 +8,7 @@ export default {
   name:       'ember-simple-auth',
   initialize: function(registry) {
     const config = ENV['ember-simple-auth'] || {};
+    config.baseURL = ENV['ember-simple-auth'].baseURL || ENV.baseURL;
     Configuration.load(config);
 
     setupSession(registry);

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -7,8 +7,7 @@ import setupSessionService from 'ember-simple-auth/initializers/setup-session-se
 export default {
   name:       'ember-simple-auth',
   initialize: function(registry) {
-    const config   = ENV['ember-simple-auth'] || {};
-    config.baseURL = ENV.baseURL;
+    const config = ENV['ember-simple-auth'] || {};
     Configuration.load(config);
 
     setupSession(registry);

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -10,9 +10,7 @@ export default {
     const config = ENV['ember-simple-auth'] || {};
     
     // We need to use the default Ember baseURL if one hasn't been set
-    if (ENV['ember-simple-auth'] && ENV['ember-simple-auth'].baseURL) {
-      config.baseURL = ENV['ember-simple-auth'].baseURL;
-    } else {
+    if (!(ENV['ember-simple-auth'] && ENV['ember-simple-auth'].baseURL)) {
       config.baseURL = ENV.baseURL;
     }
     


### PR DESCRIPTION
Ember app authors can currently specify a `baseURL` in the `config/environment.js` file. e.g.

```javascript
ENV['ember-simple-auth'].baseURL = 'http://localhost:4200';
```

However, the configuration is being overridden because of the following line in the `app/initializers/ember-simple-auth.js` file:

```javascript
const config   = ENV['ember-simple-auth'] || {};
config.baseURL = ENV.baseURL;
```

This simple patch removes the overriding expression so that the author's `baseURL` can be used.