### PR TITLE
Update docs to show baseURL is internal

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -30,13 +30,14 @@ const DEFAULTS = {
 export default {
   /**
     The base URL of the application as configured in `config/environment.js`.
+    This is an internal property and should not be configured manually.
 
     @property baseURL
     @readOnly
     @static
     @type String
     @default ''
-    @public
+    @protected
   */
   baseURL: DEFAULTS.baseURL,
 


### PR DESCRIPTION
As discussed in #955, baseURL is an internal config parameter. Therefore, the documentation should be updated to reflect this.