### PR TITLE
Add Before Callbacks to Authenticators

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -60,6 +60,11 @@ export default BaseAuthenticator.extend({
   */
   identificationAttributeName: 'email',
 
+
+  beforeRestore: (data) => { return data; },
+  beforeReject: (data) => { return data; },
+  beforeAuthenticate: (response) => { return response; },
+
   /**
     Restores the session from a session data object; __returns a resolving
     promise when there are non-empty
@@ -79,8 +84,10 @@ export default BaseAuthenticator.extend({
     const identificationAttribute = get(data, identificationAttributeName);
 
     if (!isEmpty(tokenAttribute) && !isEmpty(identificationAttribute)) {
+      data = beforeRestore(data);
       return Promise.resolve(data);
     } else {
+      data = beforeReject(data);
       return Promise.reject();
     }
   },
@@ -111,7 +118,10 @@ export default BaseAuthenticator.extend({
       data[resourceName][identificationAttributeName] = identification;
 
       return this.makeRequest(data).then(
-        (response) => run(null, resolve, response),
+        (response) => {
+          response = beforeAuthenticate(response);
+          run(null, resolve, response);
+        },
         (xhr) => run(null, reject, xhr.responseJSON || xhr.responseText)
       );
     });


### PR DESCRIPTION
While I was programming, I noticed that I wanted to transform some of the data and save it as a record in the data store. To do this, I had to copy the source code and then add then modify the code. It then occurred to me that this project could benefit from having before callbacks.

The purpose of the before callbacks would allow developers to touch the data before a restore, reject, or authentication happens.

I'm just getting started with Ember, so this PR is more of a concept/discussion generator than anything else.