### PR TITLE
ignore store events while the session is busy

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -13,37 +13,45 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
   init() {
     this._super(...arguments);
     this.set('content', { authenticated: {} });
+    this._busy = false;
     this._bindToStoreEvents();
   },
 
   authenticate(authenticatorFactory, ...args) {
+    this._busy = true;
     Ember.assert(`Session#authenticate requires the authenticator to be specified, was "${authenticatorFactory}"!`, !isEmpty(authenticatorFactory));
     const authenticator = this._lookupAuthenticator(authenticatorFactory);
     Ember.assert(`No authenticator for factory "${authenticatorFactory}" could be found!`, !isNone(authenticator));
 
     return authenticator.authenticate(...args).then((content) => {
+      this._busy = false;
       return this._setup(authenticatorFactory, content, true);
     }, (error) => {
       const rejectWithError = () => RSVP.Promise.reject(error);
 
+      this._busy = false;
       return this._clear().then(rejectWithError, rejectWithError);
     });
   },
 
   invalidate() {
+    this._busy = true;
     Ember.assert('Session#invalidate requires the session to be authenticated!', this.get('isAuthenticated'));
 
     let authenticator = this._lookupAuthenticator(this.authenticator);
     return authenticator.invalidate(this.content.authenticated).then(() => {
       authenticator.off('sessionDataUpdated');
+      this._busy = false;
       return this._clear(true);
     }, (error) => {
       this.trigger('sessionInvalidationFailed', error);
+      this._busy = false;
       return RSVP.Promise.reject(error);
     });
   },
 
   restore() {
+    this._busy = true;
     const reject = () => RSVP.Promise.reject();
 
     return this._callStoreAsync('restore').then((restoredContent) => {
@@ -53,19 +61,23 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
         const authenticator = this._lookupAuthenticator(authenticatorFactory);
         return authenticator.restore(restoredContent.authenticated).then((content) => {
           this.set('content', restoredContent);
+          this._busy = false;
           return this._setup(authenticatorFactory, content);
         }, (err) => {
           Ember.Logger.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
           if (err) {
             Ember.Logger.debug(err);
           }
+          this._busy = false;
           return this._clearWithContent(restoredContent).then(reject, reject);
         });
       } else {
         delete (restoredContent || {}).authenticated;
+        this._busy = false;
         return this._clearWithContent(restoredContent).then(reject, reject);
       }
     }, () => {
+      this._busy = false;
       return this._clear().then(reject, reject);
     });
   },
@@ -160,22 +172,28 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
 
   _bindToStoreEvents() {
     this.store.on('sessionDataUpdated', (content) => {
-      let { authenticator: authenticatorFactory } = (content.authenticated || {});
-      if (!!authenticatorFactory) {
-        delete content.authenticated.authenticator;
-        const authenticator = this._lookupAuthenticator(authenticatorFactory);
-        authenticator.restore(content.authenticated).then((authenticatedContent) => {
-          this.set('content', content);
-          this._setup(authenticatorFactory, authenticatedContent, true);
-        }, (err) => {
-          Ember.Logger.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
-          if (err) {
-            Ember.Logger.debug(err);
-          }
+      if (!this._busy) {
+        this._busy = true;
+        let { authenticator: authenticatorFactory } = (content.authenticated || {});
+        if (!!authenticatorFactory) {
+          delete content.authenticated.authenticator;
+          const authenticator = this._lookupAuthenticator(authenticatorFactory);
+          authenticator.restore(content.authenticated).then((authenticatedContent) => {
+            this.set('content', content);
+            this._busy = false;
+            this._setup(authenticatorFactory, authenticatedContent, true);
+          }, (err) => {
+            Ember.Logger.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
+            if (err) {
+              Ember.Logger.debug(err);
+            }
+            this._busy = false;
+            this._clearWithContent(content, true);
+          });
+        } else {
+          this._busy = false;
           this._clearWithContent(content, true);
-        });
-      } else {
-        this._clearWithContent(content, true);
+        }
       }
     });
   },


### PR DESCRIPTION
This modifies handling of session store events so that these events will be ignored if the session is currently busy restoring, authenticating or processing another session store event.

While the implementation isn't great obviously, this is simply a temporary solution until #916 gets done with the 1.2 release.

This closes #959 