### PR TITLE
Fixing deprecation warnings for Ember 2.5.0

### DIFF
--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = Ember.assign({}, config.APP);
+  attributes = Ember.assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
We are having some Deprecation warnings with Ember 2.5.0 for those lines with Ember.merge...
Usage of `Ember.merge` is deprecated, use `Ember.assign` instead. [deprecation id: ember-metal.merge] See http://emberjs.com/deprecations/v2.x/#toc_ember-merge for more details.