### PR TITLE
WIP Extend Router DSL  #904

### DIFF
--- a/addon/bootstrap/routing.js
+++ b/addon/bootstrap/routing.js
@@ -1,0 +1,21 @@
+import lookup from '../utils/lookup';
+import { lookupFactory } from '../utils/lookup-factory';
+import { register } from '../utils/register';
+
+function reopenOrRegister(applicationInstance, factoryName, mixin) {
+  const factory = lookup(applicationInstance, factoryName);
+  if (factory) {
+    factory.reopen(mixin);
+  } else {
+    const basicFactory = lookupFactory(applicationInstance, 'route:basic');
+    const routeWithMixin = basicFactory.extend(mixin);
+    register(applicationInstance, factoryName, routeWithMixin);
+  }
+}
+
+export default function(applicationInstance, unauthenticatedRoutes, mixin) {
+  unauthenticatedRoutes.forEach((routeName) => {
+    const factoryName = `route:${routeName}`;
+    reopenOrRegister(applicationInstance, factoryName, mixin);
+  });
+}

--- a/addon/instance-initializers/setup-router.js
+++ b/addon/instance-initializers/setup-router.js
@@ -1,0 +1,21 @@
+import '../router-dsl-ext';
+import bootstrapRouting from '../bootstrap/routing';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+
+export function initialize(applicationInstance) {
+  const router = applicationInstance.get('router');
+  const setupRoutes = function() {
+    const unauthenticatedRoutes = router.router.unauthenticatedRoutes;
+    const hasUnauthenticatedRoutes = !Ember.isEmpty(unauthenticatedRoutes);
+    if (hasUnauthenticatedRoutes) {
+      bootstrapRouting(applicationInstance, unauthenticatedRoutes, UnauthenticatedRouteMixin);
+    }
+    router.off('willTransition', setupRoutes);
+  };
+  router.on('willTransition', setupRoutes);
+}
+
+export default {
+  name: 'setup-router',
+  initialize
+};

--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -1,0 +1,18 @@
+const Router = Ember.Router;
+const proto = Ember.RouterDSL.prototype;
+
+let currentMap = null;
+
+proto.unauthenticatedRoute = function() {
+  this.route.apply(this, arguments);
+  currentMap.push(arguments[0]);
+  console.log('adding new unauthed route');
+};
+
+Router.reopen({
+  _initRouterJs() {
+    currentMap = [];
+    this._super.apply(this, arguments);
+    this.router.unauthenticatedRoutes = currentMap;
+  }
+});

--- a/addon/utils/lookup-factory.js
+++ b/addon/utils/lookup-factory.js
@@ -1,0 +1,11 @@
+export function lookupFactory(applicationInstance, name) {
+  if (applicationInstance && applicationInstance.lookupFactory) {
+    return applicationInstance.lookupFactory(name);
+  } else if (applicationInstance && applicationInstance.application) {
+    return applicationInstance.application.__container__.lookupFactory(name);
+  } else {
+    return applicationInstance.container.lookupFactory(name);
+  }
+}
+
+export default lookupFactory;

--- a/addon/utils/register.js
+++ b/addon/utils/register.js
@@ -1,0 +1,9 @@
+export function register(applicationInstance, name, factory) {
+  if (applicationInstance && applicationInstance.application) {
+    return applicationInstance.application.register(name, factory);
+  } else {
+    return applicationInstance.registry.register(name, factory);
+  }
+}
+
+export default register;

--- a/app/instance-initializers/setup-router.js
+++ b/app/instance-initializers/setup-router.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-simple-auth/instance-initializers/setup-router';

--- a/tests/unit/instance-initializers/setup-router-test.js
+++ b/tests/unit/instance-initializers/setup-router-test.js
@@ -1,0 +1,90 @@
+import Ember from 'ember';
+// import { initialize } from 'dummy/instance-initializers/setup-router';
+// import destroyApp from '../../helpers/destroy-app';
+import { it } from 'ember-mocha';
+import { describe, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('initialize from extending router', () => {
+  let Router;
+
+  beforeEach(() => {
+    // const FakeMixin = Ember.Mixin.create({
+    //   'foo': 'bar'
+    // });
+    //
+    // UnauthenticatedRouteMixin = sinon.stub().returns(FakeMixin);
+
+    // initialize();
+  });
+
+  afterEach(() => {
+    Router = null;
+  });
+
+  it('adds an `unathenticatedRoute` method to router', () => {
+    let unauthenticatedRouteMethod = null;
+    Router = Ember.Router.extend({});
+    Router.map(function() {
+      unauthenticatedRouteMethod = this.unauthenticatedRoute;
+    });
+    let router = Router.create();
+    router._initRouterJs();
+    expect(typeof unauthenticatedRouteMethod).to.eq('function');
+  });
+
+  describe('`unauthenticatedRoute`', () => {
+    it('just calls route', () => {
+      let routeSpy = sinon.spy();
+      Router = Ember.Router.extend({});
+      Router.map(function() {
+        this.route = routeSpy;
+        this.unauthenticatedRoute('test');
+      });
+      let router = Router.create();
+      router._initRouterJs();
+      expect(routeSpy.called).to.eql(true);
+    });
+
+    it('registers all routers', () => {
+      Router = Ember.Router.extend({});
+      Router.map(function() {
+        this.route('test0');
+        this.unauthenticatedRoute('test1');
+        this.unauthenticatedRoute('test2');
+      });
+      let router = Router.create();
+      router._initRouterJs();
+
+      expect(router.router.unauthenticatedRoutes).not.to.include('test0');
+      expect(router.router.unauthenticatedRoutes).to.include('test1');
+      expect(router.router.unauthenticatedRoutes).to.include('test2');
+
+      expect(router.router.recognizer.names).to.have.property('test0');
+      expect(router.router.recognizer.names).to.have.property('test1');
+      expect(router.router.recognizer.names).to.have.property('test2');
+    });
+
+    // it('adds the correct mixin', () => {
+    //   Router = Ember.Router.extend({});
+    //   Router.map(function() {
+    //     this.unauthenticatedRoute('test');
+    //   });
+    //   let router = Router.create();
+    //   router._initRouterJs();
+    //
+    //   const container = {
+    //     lookup() {}
+    //   };
+    //
+    //   container.get = sinon.stub().withArgs('router').returns(router);
+    //
+    //   initialize(container);
+    //   router.trigger('willTransition');
+    //   // lookup route
+    //   // check for mixin
+    //
+    // });
+  });
+});


### PR DESCRIPTION
Opening a WIP PR since this issue had quite a bit of activity today to give some transparency with where things are at.

I'm definitely welcome to suggestions! Here's my current list of questions:
- How should we handle `authenticatedRoute` name conflict?
- How should we bring over the container utilities?
- Any suggestions on tests?

Will make some more progress on this tonight. After we figure out how to handle the name conflict, expanding to handle authenticatedRoute will be easy.
#### There is a name conflict with `authenticatedRoute` via torii

Since torii is currently using `this.unauthenticatedRoute` on Router, we have no way to distinguish whether they want torii or ESA mixins.

Should we somehow namespace our new routes to Ember Simple Auth? (That's why I started with `unauthenticatedRoute`.)
#### Should we combine container utilities into one file?

Several container utilities are needed for registering the mixin on a given route. `addon/utils/lookup.js` is an example of one that ESA already had. Grabbed `register` and `lookup-factory` from troii. Should we consolidate this into one file in ESA, pull out into independent addon, or leave in different files?

`addon/utils/lookup.js`
`addon/utils/register.js` from https://github.com/Vestorly/torii/blob/master/addon/lib/container-utils.js

`addon/utils/lookup-factory.js` from https://github.com/Vestorly/torii/blob/master/addon/lib/container-utils.js
#### Still working on the tests.

Suggestions welcome. I still want to verify that `addon/bootstrap/routing.js` is properly applying a mixin via test. Will probalby break this out into its own unit test.

May rethink some of the tests based off of reading https://github.com/Vestorly/torii/blob/master/tests/acceptance/routing-test.js. (Probably should have done that much earlier)

/cc @mdentremont
