### PR TITLE
Test for session service data being set with Ember.set

### DIFF
--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -100,6 +100,12 @@ describe('SessionService', () => {
       expect(session.content).to.eql({ some: { other: 'data' } });
     });
 
+    it('can be set with Ember.set', () => {
+      Ember.set(sessionService, 'data.emberSet', 'ember-set-data');
+
+      expect(session.content).to.eql({ emberSet: 'ember-set-data' });
+    });
+
     it('is read-only', () => {
       expect(() => {
         sessionService.set('data', false);


### PR DESCRIPTION
In reference to issue #926.

In looking into #926, I found that this seems to be working as expected.  I wanted to verify it so I have added a test to make sure that this is working properly going forward.