### PR TITLE
Cleanup transition usage in authenticated and unauthenticated route mixins

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -56,9 +56,8 @@ export default Ember.Mixin.create({
     if (!this.get('session.isAuthenticated')) {
       Ember.assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== Configuration.authenticationRoute);
 
-      transition.abort();
       this.set('session.attemptedTransition', transition);
-      this.transitionTo(Configuration.authenticationRoute);
+      return this.transitionTo(Configuration.authenticationRoute);
     } else {
       return this._super(...arguments);
     }

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -47,11 +47,10 @@ export default Ember.Mixin.create({
     @param {Transition} transition The transition that lead to this route
     @public
   */
-  beforeModel(transition) {
+  beforeModel() {
     if (this.get('session').get('isAuthenticated')) {
-      transition.abort();
       Ember.assert('The route configured as Configuration.routeIfAlreadyAuthenticated cannot implement the UnauthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== Configuration.routeIfAlreadyAuthenticated);
-      this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
+      return this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
     } else {
       return this._super(...arguments);
     }

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -28,12 +28,10 @@ describe('AuthenticatedRouteMixin', () => {
 
       session = InternalSession.create({ store: EphemeralStore.create() });
       transition = {
-        abort() {},
         send() {}
       };
 
       route = Route.create({ session });
-      sinon.spy(transition, 'abort');
       sinon.spy(transition, 'send');
       sinon.spy(route, 'transitionTo');
     });
@@ -49,12 +47,6 @@ describe('AuthenticatedRouteMixin', () => {
         });
       });
 
-      it('does not abort the transition', () => {
-        route.beforeModel(transition);
-
-        expect(transition.abort).to.not.have.been.called;
-      });
-
       it('does not transition to the authentication route', () => {
         route.beforeModel(transition);
 
@@ -65,12 +57,6 @@ describe('AuthenticatedRouteMixin', () => {
     describe('if the session is not authenticated', () => {
       it('does not return the upstream promise', () => {
         expect(route.beforeModel(transition)).to.be.undefined;
-      });
-
-      it('aborts the transition', () => {
-        route.beforeModel(transition);
-
-        expect(transition.abort).to.have.been.called;
       });
 
       it('transitions to the authentication route', () => {

--- a/tests/unit/mixins/unauthenticated-route-mixin-test.js
+++ b/tests/unit/mixins/unauthenticated-route-mixin-test.js
@@ -28,24 +28,16 @@ describe('UnauthenticatedRouteMixin', () => {
 
       session    = InternalSession.create({ store: EphemeralStore.create() });
       transition = {
-        abort() {},
         send() {}
       };
 
       route = Route.create({ session });
-      sinon.spy(transition, 'abort');
       sinon.spy(route, 'transitionTo');
     });
 
     describe('if the session is authenticated', () => {
       beforeEach(() => {
         session.set('isAuthenticated', true);
-      });
-
-      it('aborts the transition', () => {
-        route.beforeModel(transition);
-
-        expect(transition.abort).to.have.been.called;
       });
 
       it('transitions to routeIfAlreadyAuthenticated', () => {
@@ -60,12 +52,6 @@ describe('UnauthenticatedRouteMixin', () => {
     });
 
     describe('if the session is not authenticated', () => {
-      it('does not abort the transition', () => {
-        route.beforeModel(transition);
-
-        expect(transition.abort).to.not.have.been.called;
-      });
-
       it('does not call route transitionTo', () => {
         route.beforeModel(transition);
 


### PR DESCRIPTION
no issue
- fixes potential test timing issue
- removes unecessary abort call

@marcoow This became necessary as I was working on some ember-simple-auth refactoring for Ghost. In this particular use case, a parent route implemented the unauthenticated route mixin, and in the tests there was several checks to ensure each child route was redirected correctly (see the tests [here](https://github.com/TryGhost/Ghost-Admin/blob/master/tests/acceptance/setup-test.js#L26-L46))

Basically what was happening is the `transition.abort()` call in the unauthenticated route mixin was causing the transition to abort, which then allowed the `andThen` method in the tests to run, before the second transition was started. This only occurred when more than one `visit`/`andThen` combination was used in the same `it` block.

iirc, `transitionTo` calls `abort` internally, so those calls in each mixin were unnecessary. (see [here](https://gist.github.com/machty/5723945#abort-and-retry-transitions))