### PR TITLE
[BUGFIX] Remove Ember.Logger

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -300,7 +300,7 @@ export default BaseAuthenticator.extend({
           resolve(data);
         });
       }, (xhr, status, error) => {
-        Ember.Logger.warn(`Access token could not be refreshed - server responded with ${error}.`);
+        Ember.warn(`Access token could not be refreshed - server responded with ${error}.`);
         reject();
       });
     });

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -64,9 +64,9 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
           this._busy = false;
           return this._setup(authenticatorFactory, content);
         }, (err) => {
-          Ember.Logger.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
+          Ember.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
           if (err) {
-            Ember.Logger.debug(err);
+            Ember.debug(err);
           }
           this._busy = false;
           return this._clearWithContent(restoredContent).then(reject, reject);
@@ -183,9 +183,9 @@ export default Ember.ObjectProxy.extend(Ember.Evented, {
             this._busy = false;
             this._setup(authenticatorFactory, authenticatedContent, true);
           }, (err) => {
-            Ember.Logger.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
+            Ember.debug(`The authenticator "${authenticatorFactory}" rejected to restore the session - invalidating…`);
             if (err) {
-              Ember.Logger.debug(err);
+              Ember.debug(err);
             }
             this._busy = false;
             this._clearWithContent(content, true);


### PR DESCRIPTION
Ember.Logger is not substituted by noops in production.

More info in emberjs/guides#1467