### PR TITLE
Override headersForRequest, fixes #1003

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -99,5 +99,16 @@ export default Mixin.create({
       this.get('session').invalidate();
     }
     return this._super(...arguments);
+  },
+
+  headersForRequest() {
+    let headers = this._super(...arguments);
+    const authorizer = this.get('authorizer');
+    headers = Object(headers);
+    this.get('session').authorize(authorizer, (headerName, headerValue) => {
+
+      headers[headerName] = headerValue;
+    });
+    return headers;
   }
 });


### PR DESCRIPTION
This fixes issue #1003 which is caused by changes in emberjs/data#3099, whereby the authorization headers are no longer when using Ember Data 2.7 because header constructing code is moved to a separate method.