### PR TITLE
Disable 'sessionDataUpdated' trigger if window is active for IE

### DIFF
--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -83,7 +83,7 @@ export default BaseStore.extend({
 
   _bindToStorageEvents() {
     jQuery(window).bind('storage', (e) => {
-      if (e.originalEvent.key === this.key) {
+      if (e.originalEvent.key === this.key && (document.visibilityState typeof undefined || document.visibilityState === 'hidden')) {
         this.restore().then((data) => {
           if (!objectsAreEqual(data, this._lastData)) {
             this._lastData = data;

--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -83,7 +83,7 @@ export default BaseStore.extend({
 
   _bindToStorageEvents() {
     jQuery(window).bind('storage', (e) => {
-      if (e.originalEvent.key === this.key && (document.visibilityState typeof undefined || document.visibilityState === 'hidden')) {
+      if (e.originalEvent.key === this.key && (typeof document.hidden === "undefined" || document.hidden)) {
         this.restore().then((data) => {
           if (!objectsAreEqual(data, this._lastData)) {
             this._lastData = data;


### PR DESCRIPTION
According to the spec the `storage-event` should only be fired **for other** tabs and windows, see https://html.spec.whatwg.org/multipage/webstorage.html#the-localstorage-attribute.

However, IE does fail to do so: https://connect.microsoft.com/IE/feedback/details/798684/ie-localstorage-event-misfired. To bring this behaviour to IE we can emulate it by using the `document.visibilityState`. Pity enough this works only for IE10 en IE11, so older versions of Internet Explorer still suffer the extra unneeded session-data update.