### PR TITLE
Add rejectWithXhr to optionally reject with XHR vs response body

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -62,6 +62,20 @@ export default BaseAuthenticator.extend({
   identificationAttributeName: 'email',
 
   /**
+    When authentication fails, the rejection callback is provided with the whole
+    XHR object instead of it's response JSON or text.
+
+    This is useful for cases when the backend provides additional context not
+    available in the response body.
+
+    @property rejectWithXhr
+    @type Boolean
+    @default false
+    @public
+  */
+  rejectWithXhr: false,
+
+  /**
     Restores the session from a session data object; __returns a resolving
     promise when there are non-empty
     {{#crossLink "DeviseAuthenticator/tokenAttributeName:property"}}token{{/crossLink}}
@@ -98,6 +112,7 @@ export default BaseAuthenticator.extend({
   */
   authenticate(identification, password) {
     return new Promise((resolve, reject) => {
+      const useXhr = this.get('rejectWithXhr');
       const { resourceName, identificationAttributeName, tokenAttributeName } = this.getProperties('resourceName', 'identificationAttributeName', 'tokenAttributeName');
       const data         = {};
       data[resourceName] = { password };
@@ -113,7 +128,7 @@ export default BaseAuthenticator.extend({
             run(null, reject, `Check that server response includes ${tokenAttributeName} and ${identificationAttributeName}`);
           }
         },
-        (xhr) => run(null, reject, xhr.responseJSON || xhr.responseText)
+        (xhr) => run(null, reject, useXhr ? xhr : (xhr.responseJSON || xhr.responseText))
       );
     });
   },

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -126,6 +126,20 @@ export default BaseAuthenticator.extend({
   }),
 
   /**
+    When authentication fails, the rejection callback is provided with the whole
+    XHR object instead of it's response JSON or text.
+
+    This is useful for cases when the backend provides additional context not
+    available in the response body.
+
+    @property rejectWithXhr
+    @type Boolean
+    @default false
+    @public
+  */
+  rejectWithXhr: false,
+
+  /**
     Restores the session from a session data object; __will return a resolving
     promise when there is a non-empty `access_token` in the session data__ and
     a rejecting promise otherwise.
@@ -192,6 +206,7 @@ export default BaseAuthenticator.extend({
     return new RSVP.Promise((resolve, reject) => {
       const data                = { 'grant_type': 'password', username: identification, password };
       const serverTokenEndpoint = this.get('serverTokenEndpoint');
+      const useXhr = this.get('rejectWithXhr');
       const scopesString = makeArray(scope).join(' ');
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;
@@ -211,7 +226,7 @@ export default BaseAuthenticator.extend({
           resolve(response);
         });
       }, (xhr) => {
-        run(null, reject, xhr.responseJSON || xhr.responseText);
+        run(null, reject, useXhr ? xhr : (xhr.responseJSON || xhr.responseText));
       });
     });
   },

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -190,13 +190,31 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
     describe('when the authentication request fails', () => {
       beforeEach(() => {
-        server.post('/token', () => [400, { 'Content-Type': 'application/json' }, '{ "error": "invalid_grant" }']);
+        server.post('/token', () => [400, { 'Content-Type': 'application/json', 'X-Custom-Context': 'foobar' }, '{ "error": "invalid_grant" }']);
       });
 
       it('rejects with the correct error', (done) => {
         authenticator.authenticate('username', 'password').catch((error) => {
           expect(error).to.eql({ error: 'invalid_grant' });
           done();
+        });
+      });
+
+      describe('when reject with XHR is enabled', () => {
+        beforeEach(() => {
+          authenticator.set('rejectWithXhr', true);
+        });
+
+        it('rejects with xhr object', () => {
+          return authenticator.authenticate('username', 'password').catch((error) => {
+            expect(error.responseJSON).to.eql({ error: 'invalid_grant' });
+          });
+        });
+
+        it('provides access to custom headers', () => {
+          return authenticator.authenticate('username', 'password').catch((error) => {
+            expect(error.getResponseHeader('X-Custom-Context')).to.eql('foobar');
+          });
         });
       });
     });


### PR DESCRIPTION
Allows ember apps using ember-simple-auth to receive the whole XHR object if the backend fails, instead of the response body, if they so choose.

In the case of OAuth 2.0 backends, it's been a pattern in the wild to use X- headers to send context as to why a grant has failed. Examples include API throttling, brute force lockouts, and [OTP/two-factor authentication](https://developer.github.com/v3/auth/#working-with-two-factor-authentication) information.

Selfishly, I require this change so my application can be notified when the API has locked out an account due to suspicious activity via an X- header.

The decision to expose it as an option was chosen so backwards compatibility is maintained and keeps the addon simple for those who need not be concerned with complex backends.