### PR TITLE
Add fastboot-dist to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 /tests
 /node-tests
 /tmp
+/fastboot-dist
 **/.gitkeep
 .bowerrc
 .editorconfig


### PR DESCRIPTION
This reduces the size of the install by 17MB