### PR TITLE
Optionally send custom headers in authentication call

### DIFF
--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -130,6 +130,22 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       });
     });
 
+    it('sends an AJAX request to the token endpoint with customized headers', function(done) {
+      authenticator.authenticate('username', 'password', [], { 'X-Custom-Context': 'foobar' });
+
+      next(() => {
+        expect(jQuery.ajax.getCall(0).args[0]).to.eql({
+          url:         '/token',
+          type:        'POST',
+          data:        { 'grant_type': 'password', username: 'username', password: 'password' },
+          dataType:    'json',
+          contentType: 'application/x-www-form-urlencoded',
+          headers:     { 'X-Custom-Context': 'foobar' }
+        });
+        done();
+      });
+    });
+
     it('sends a single OAuth scope to the token endpoint', function(done) {
       authenticator.authenticate('username', 'password', 'public');
 


### PR DESCRIPTION
Complex systems that offer Two Factor Authentication with their OAuth 2.0 implementation need to send additional context via the HTTP headers. This pattern has been observed in the wild by such systems such as GitHub. Because of the restrictions of OAuth 2.0 RFC, only headers can be used for additional context, not request/response bodies.

This could be seen as a counterpart to #1012, where using both features allow bi-directional context enabling 2FA, brute force lockouts, etc.

* * *

An different approach that functions the same would be

```js
authenticator.set('headers', { foo: 'bar' });
authenticator.authenticate('username', 'password');
```

Which is consistent with `clientId` but I feel like my approach may be more intuitive for the user.