### PR TITLE
Override headersForRequest (with tests)

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -92,7 +92,7 @@ export default Mixin.create({
     Adds request headers containing the authorization data as constructed
     by the {{#crossLink "DataAdapterMixin/authorizer:property"}}{{/crossLink}}.
 
-    This method will only called in Ember Data 2.7 or greater, older versions
+    This method will only be called in Ember Data 2.7 or greater. Older versions
     will rely on `ajaxOptions` for request header injection.
 
     @method handleResponse

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -99,5 +99,16 @@ export default Mixin.create({
       this.get('session').invalidate();
     }
     return this._super(...arguments);
+  },
+
+  headersForRequest() {
+    let headers = this._super(...arguments);
+    const authorizer = this.get('authorizer');
+    headers = Object(headers);
+    this.get('session').authorize(authorizer, (headerName, headerValue) => {
+
+      headers[headerName] = headerValue;
+    });
+    return headers;
   }
 });

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -115,6 +115,26 @@ describe('DataAdapterMixin', () => {
       expect(headers['X-Base-Header']).to.equal('is-still-respected');
     });
 
+    describe('when the base adapter doesn\'t implement headersForRequest', () => {
+      beforeEach(() => {
+        hash = {};
+        sessionService = EmberObject.create({
+          authorize() {},
+          invalidate() {}
+        });
+
+        const Adapter = EmberObject.extend(DataAdapterMixin, {
+          authorizer: 'authorizer:some'
+        });
+        adapter = Adapter.create({ session: sessionService });
+      });
+
+      it('gracefully defaults to empty hash', () => {
+        const headers = adapter.headersForRequest();
+        expect(headers).to.deep.equal({});
+      });
+    });
+
     it('asserts the presence of authorizer', () => {
       adapter.set('authorizer', null);
       expect(function() {

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -158,13 +158,11 @@ describe('DataAdapterMixin', () => {
 
       it('adds a request header as given by the authorizer', () => {
         const headers = adapter.headersForRequest();
-        expect(headers).to.have.ownProperty('X-Authorization-Header');
         expect(headers['X-Authorization-Header']).to.equal('an-auth-value');
       });
 
       it('still returns the base headers', () => {
         const headers = adapter.headersForRequest();
-        expect(headers).to.have.ownProperty('X-Base-Header');
         expect(headers['X-Base-Header']).to.equal('is-still-respected');
       });
     });
@@ -176,14 +174,11 @@ describe('DataAdapterMixin', () => {
 
       it('does not add a request header', () => {
         const headers = adapter.headersForRequest();
-        expect(headers).to.have.ownProperty('X-Base-Header');
         expect(headers).to.not.have.ownProperty('X-Authorization-Header');
-        expect(headers['X-Authorization-Header']).to.not.equal('an-auth-value');
       });
 
       it('still returns the base headers', () => {
         const headers = adapter.headersForRequest();
-        expect(headers).to.have.ownProperty('X-Base-Header');
         expect(headers['X-Base-Header']).to.equal('is-still-respected');
       });
     });


### PR DESCRIPTION
Original work completed by @JeroenvdV in #1009, but now with tests and asserting authorizer presence.

This attempts to fix #1003 so Ember Data 2.7 and greater can send authorization header data when using `DataAdapterMixin`.

@marcoow let me know if this test coverage is sufficient!