### PR TITLE
[Fastboot] Remove inject of cookies in initializer; Bump ember-cookies; Add fastboot host whitelist

### DIFF
--- a/addon/initializers/setup-session.js
+++ b/addon/initializers/setup-session.js
@@ -14,6 +14,5 @@ export default function setupSession(registry) {
     registry.register(store, Ephemeral);
   }
 
-  inject(registry, store, 'cookies', 'service:cookies');
   inject(registry, 'session:main', 'store', store);
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cookies": "0.0.7",
+    "ember-cookies": "0.0.9",
     "ember-getowner-polyfill": "1.0.1",
     "silent-error": "^1.0.0"
   },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -34,7 +34,12 @@ module.exports = function(environment) {
       }
     },
 
-    apiHost: 'http://localhost:4200'
+    apiHost: 'http://localhost:4200',
+
+    fastboot: {
+      hostWhitelist:[/^localhost:\d+$/]
+    },
+
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
- As per comment in the old [PR of fastboot](https://github.com/simplabs/ember-simple-auth/pull/964/files#r60259386), remove the inject of cookies service from the initializer. Not needed anymore.

- Bump ember-cookies to make the dummy app work. 
- Add fastboot host whitelist to dummy app.