### PR TITLE
Make sure rootUrl is handled correctly

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -4,7 +4,8 @@ import config from './config/environment';
 const { Router: EmberRouter } = Ember;
 
 const Router = EmberRouter.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {


### PR DESCRIPTION
This makes sure we're correctly dealing with the recent deprecation of `baseURL`. I think what we need to do is:
- [ ] Make sure read-only properties are correctly document as being read-only. As the generated docs data will contain a `readonly` flag with no value for properties documented with `@readOnly` (`"readonly": ""`) [this line in the docs template](https://github.com/simplabs/ember-simple-auth/blob/master/docs/theme/partials/props.handlebars#L14) is never true. What we need to do here is to check if the var is defined instead of checking if it has a value (if that's possible with Handlebars)
- [ ] [We're currently reading the default value for `Configuration.baseURL` from the configuration's `baseURL`](https://github.com/simplabs/ember-simple-auth/blob/master/app/initializers/ember-simple-auth.js#L11) which will be empty when people switch to `rootURL`. We should instead try `rootURL` first and if that's empty, try `baseURL` (`config.baseURL = ENV.rootURL || ENV.baseURL;`).
- [ ] we should raise a deprecation when the configuration's `baseURL` property is read so we can make it private in ESA 2.0.
