### PR TITLE
Update OAuth2PasswordGrant Authenticator to use Fetch

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -134,12 +134,12 @@ export default BaseAuthenticator.extend({
     This is useful for cases when the backend provides additional context not
     available in the response body.
 
-    @property rejectWithRequest
+    @property rejectWithResponse
     @type Boolean
     @default false
     @public
   */
-  rejectWithRequest: false,
+  rejectWithResponse: false,
 
   /**
     Restores the session from a session data object; __will return a resolving
@@ -209,7 +209,7 @@ export default BaseAuthenticator.extend({
     return new RSVP.Promise((resolve, reject) => {
       const data                = { 'grant_type': 'password', username: identification, password };
       const serverTokenEndpoint = this.get('serverTokenEndpoint');
-      const useRequest = this.get('rejectWithRequest');
+      const useResponse = this.get('rejectWithResponse');
       const scopesString = makeArray(scope).join(' ');
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;
@@ -229,7 +229,7 @@ export default BaseAuthenticator.extend({
           resolve(response);
         });
       }, (response) => {
-        run(null, reject, useRequest ? response : response.responseJSON);
+        run(null, reject, useResponse ? response : response.responseJSON);
       });
     });
   },

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -129,6 +129,19 @@ export default BaseAuthenticator.extend({
 
   /**
     When authentication fails, the rejection callback is provided with the whole
+    XHR object instead of it's response JSON or text.
+    This is useful for cases when the backend provides additional context not
+    available in the response body.
+    @property rejectWithXhr
+    @type Boolean
+    @default false
+    @deprecated
+    @public
+  */
+  rejectWithXhr: computed.deprecatingAlias('rejectWithResponse'),
+
+  /**
+    When authentication fails, the rejection callback is provided with the whole
     fetch response object instead of it's response JSON or text.
 
     This is useful for cases when the backend provides additional context not

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -130,12 +130,14 @@ export default BaseAuthenticator.extend({
   /**
     When authentication fails, the rejection callback is provided with the whole
     XHR object instead of it's response JSON or text.
+
     This is useful for cases when the backend provides additional context not
     available in the response body.
+
     @property rejectWithXhr
     @type Boolean
     @default false
-    @deprecated
+    @deprecated OAuth2PasswordGrantAuthenticator/rejectWithResponse:property
     @public
   */
   rejectWithXhr: computed.deprecatingAlias('rejectWithResponse'),
@@ -296,7 +298,7 @@ export default BaseAuthenticator.extend({
     @param {String} url The request URL
     @param {Object} data The request data
     @param {Object} headers Additional headers to send in request
-    @return {Promise} A promise that resolves into the response object`
+    @return {Promise} A promise that resolves with the response object`
     @protected
   */
   makeRequest(url, data, headers = {}) {

--- a/node-tests/fixtures/app/package/package.json
+++ b/node-tests/fixtures/app/package/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "ember-cli": "*",
-    "ember-simple-auth": "*"
+    "ember-simple-auth": "*",
+    "ember-cli-import-polyfill": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-network": "^0.3.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.5.0",
     "ember-suave": "~4.0.0",
@@ -79,7 +78,9 @@
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "0.0.9",
     "ember-getowner-polyfill": "1.0.1",
-    "silent-error": "^1.0.0"
+    "silent-error": "^1.0.0",
+    "ember-network": "^0.3.0",
+    "ember-cli-import-polyfill": "^0.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-network": "^0.3.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.5.0",
     "ember-suave": "~4.0.0",

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -4,25 +4,30 @@ import Ember from 'ember';
 import { it } from 'ember-mocha';
 import { describe, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import Pretender from 'pretender';
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
 
-const { $: jQuery, run: { next }, tryInvoke } = Ember;
+const { tryInvoke } = Ember;
 
 describe('OAuth2PasswordGrantAuthenticator', () => {
   let authenticator;
   let server;
+  let parsePostData = ((query) => {
+    let result = {};
+    query.split('&').forEach((part) => {
+      let item = part.split('=');
+      result[item[0]] = decodeURIComponent(item[1]);
+    });
+    return result;
+  });
 
   beforeEach(() => {
     authenticator = OAuth2PasswordGrant.create();
     server        = new Pretender();
-    sinon.spy(jQuery, 'ajax');
   });
 
   afterEach(() => {
     tryInvoke(server, 'shutdown');
-    jQuery.ajax.restore();
   });
 
   describe('#restore', () => {
@@ -99,69 +104,58 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
   describe('#authenticate', () => {
     it('sends an AJAX request to the token endpoint', (done) => {
-      authenticator.authenticate('username', 'password');
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0]).to.eql({
-          url:         '/token',
-          type:        'POST',
-          data:        { 'grant_type': 'password', username: 'username', password: 'password' },
-          dataType:    'json',
-          contentType: 'application/x-www-form-urlencoded'
+      server.post('/token', (request) => {
+        let body = parsePostData(request.requestBody);
+        expect(body).to.eql({
+          'grant_type': 'password',
+          'username': 'username',
+          'password': 'password'
         });
         done();
       });
+      
+      authenticator.authenticate('username', 'password');
     });
 
     it('sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
-      authenticator.set('clientId', 'test-client');
-      authenticator.authenticate('username', 'password');
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0]).to.eql({
-          url:         '/token',
-          type:        'POST',
-          data:        { 'grant_type': 'password', username: 'username', password: 'password' },
-          dataType:    'json',
-          contentType: 'application/x-www-form-urlencoded',
-          headers:     { Authorization: 'Basic dGVzdC1jbGllbnQ6' }
-        });
+      server.post('/token', (request) => {
+        expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
         done();
       });
+
+      authenticator.set('clientId', 'test-client');
+      authenticator.authenticate('username', 'password');
     });
 
     it('sends an AJAX request to the token endpoint with customized headers', function(done) {
-      authenticator.authenticate('username', 'password', [], { 'X-Custom-Context': 'foobar' });
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0]).to.eql({
-          url:         '/token',
-          type:        'POST',
-          data:        { 'grant_type': 'password', username: 'username', password: 'password' },
-          dataType:    'json',
-          contentType: 'application/x-www-form-urlencoded',
-          headers:     { 'X-Custom-Context': 'foobar' }
-        });
+      server.post('/token', (request) => {
+        expect(request.requestHeaders['x-custom-context']).to.eql('foobar');
         done();
       });
+
+      authenticator.authenticate('username', 'password', [], { 'X-Custom-Context': 'foobar' });
     });
 
     it('sends a single OAuth scope to the token endpoint', function(done) {
-      authenticator.authenticate('username', 'password', 'public');
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0].data.scope).to.eql('public');
+      server.post('/token', (request) => {
+        let { requestBody } = request;
+        let { scope } = parsePostData(requestBody);
+        expect(scope).to.eql('public');
         done();
       });
+
+      authenticator.authenticate('username', 'password', 'public');
     });
 
     it('sends multiple OAuth scopes to the token endpoint', (done) => {
-      authenticator.authenticate('username', 'password', ['public', 'private']);
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0].data.scope).to.eql('public private');
+      server.post('/token', (request) => {
+        let { requestBody } = request;
+        let { scope } = parsePostData(requestBody);
+        expect(scope).to.eql('public private');
         done();
       });
+
+      authenticator.authenticate('username', 'password', ['public', 'private']);
     });
 
     describe('when the authentication request is successful', () => {
@@ -218,7 +212,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
       describe('when reject with XHR is enabled', () => {
         beforeEach(() => {
-          authenticator.set('rejectWithXhr', true);
+          authenticator.set('rejectWithRequest', true);
         });
 
         it('rejects with xhr object', () => {
@@ -229,7 +223,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
         it('provides access to custom headers', () => {
           return authenticator.authenticate('username', 'password').catch((error) => {
-            expect(error.getResponseHeader('X-Custom-Context')).to.eql('foobar');
+            expect(error.headers.getAll('x-custom-context')[0]).to.eql('foobar');
           });
         });
       });
@@ -252,18 +246,17 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       });
 
       it('sends an AJAX request to the revokation endpoint', (done) => {
-        authenticator.invalidate({ 'access_token': 'access token!' });
-
-        next(() => {
-          expect(jQuery.ajax.getCall(0).args[0]).to.eql({
-            url:         '/revoke',
-            type:        'POST',
-            data:        { 'token_type_hint': 'access_token', token: 'access token!' },
-            dataType:    'json',
-            contentType: 'application/x-www-form-urlencoded'
+        server.post('/revoke', (request) => {
+          let { requestBody } = request;
+          let body = parsePostData(requestBody);
+          expect(body).to.eql({
+            'token_type_hint': 'access_token',
+            'token': 'access token!'
           });
           done();
         });
+
+        authenticator.invalidate({ 'access_token': 'access token!' });
       });
 
       describe('when the revokation request is successful', () => {
@@ -284,18 +277,17 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
       describe('when a refresh token is set', () => {
         it('sends an AJAX request to invalidate the refresh token', (done) => {
-          authenticator.invalidate({ 'access_token': 'access token!', 'refresh_token': 'refresh token!' });
-
-          next(() => {
-            expect(jQuery.ajax.getCall(1).args[0]).to.eql({
-              url:         '/revoke',
-              type:        'POST',
-              data:        { 'token_type_hint': 'refresh_token', token: 'refresh token!' },
-              dataType:    'json',
-              contentType: 'application/x-www-form-urlencoded'
+          server.post('/revoke', (request) => {
+            let { requestBody } = request;
+            let body = parsePostData(requestBody);
+            expect(body).to.eql({
+              'token_type_hint': 'refresh_token',
+              'token': 'refresh token!'
             });
             done();
           });
+
+          authenticator.invalidate({ 'access_token': 'access token!', 'refresh_token': 'refresh token!' });
         });
       });
     });
@@ -316,18 +308,17 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
   // testing private API here ;(
   describe('#_refreshAccessToken', () => {
     it('sends an AJAX request to the token endpoint', (done) => {
-      authenticator._refreshAccessToken(12345, 'refresh token!');
-
-      next(() => {
-        expect(jQuery.ajax.getCall(0).args[0]).to.eql({
-          url:         '/token',
-          type:        'POST',
-          data:        { 'grant_type': 'refresh_token', 'refresh_token': 'refresh token!' },
-          dataType:    'json',
-          contentType: 'application/x-www-form-urlencoded'
+      server.post('/token', (request) => {
+        let { requestBody } = request;
+        let body = parsePostData(requestBody);
+        expect(body).to.eql({
+          'grant_type': 'refresh_token',
+          'refresh_token': 'refresh token!'
         });
         done();
       });
+
+      authenticator._refreshAccessToken(12345, 'refresh token!');
     });
 
     describe('when the refresh request is successful', () => {

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -113,7 +113,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         });
         done();
       });
-      
+
       authenticator.authenticate('username', 'password');
     });
 
@@ -212,7 +212,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
       describe('when reject with XHR is enabled', () => {
         beforeEach(() => {
-          authenticator.set('rejectWithRequest', true);
+          authenticator.set('rejectWithResponse', true);
         });
 
         it('rejects with xhr object', () => {


### PR DESCRIPTION
**This is a replacement for @bakerac4's PR #1060 that I messed up when trying to rebase his branch 😊**

This PR implements the updates to the oauth2 password grant authenticator that allow it to work in Fastboot per #1049

Notable Changes

I created 'rejectWithResponse' to replace 'rejectWithXhr'
I added a deprecatingAlias pointing to rejectWithResponse for rejectWithXhr
I had to include ember-cli-import-polyfill as a dependency, otherwise ember-network fails to be included