### PR TITLE
Add explanatory comment to application route

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,3 +1,4 @@
 import Ember from 'ember';
 
+// Ensure the application route exists for ember-simple-auth's `setup-session-restoration` initializer
 export default Ember.Route.extend();


### PR DESCRIPTION
The setup-session-restoration initializer needs the application route to be explicitly defined in the consuming app, so simple auth must ship with `app/routes/application.js` in case the consuming app hasn't defined their own. However, if the consuming app has another addon that similarly provides an application route via `app/routes/application.js`, simple auth may override that addon's file with it's own empty version, depending on the load order.

This is easily fixed by specifying an explicit load order (i.e. `after: 'ember-simple-auth'`). However, because the contents of simple auth's `app/routes/application.js` are completely generic, and Ember's build process merges this file into the app folder without retaining source information, it's difficult to know from the consuming app's perspective that simple-auth is the addon providing this generic file (and therefore the `after` option needs to specify "ember-simple-auth").

This adds an explanatory comment, hopefully making it a bit clearer in case anyone (_cough_ me five minutes ago _cough_) is trying to figure out where this empty application route file is coming from.