### PR TITLE
Ensure correct root url handling

### DIFF
--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -8,7 +8,7 @@ export default {
   name:       'ember-simple-auth',
   initialize: function(registry) {
     const config   = ENV['ember-simple-auth'] || {};
-    config.baseURL = ENV.baseURL;
+    config.baseURL = ENV.rootURL || ENV.baseURL;
     Configuration.load(config);
 
     setupSession(registry);

--- a/docs/theme/helpers/helpers.js
+++ b/docs/theme/helpers/helpers.js
@@ -1,0 +1,9 @@
+module.exports = {
+  exists: function(variable, options) {
+    if (typeof variable !== 'undefined') {
+      return options.fn(this);
+    } else if (options.inverse) {
+      return options.inverse(this);
+    }
+  }
+};

--- a/docs/theme/partials/props.handlebars
+++ b/docs/theme/partials/props.handlebars
@@ -11,9 +11,9 @@
     {{#if access}}
       <span class="label label-access-{{access}} pull-right">{{access}}</span>
     {{/if}}
-    {{#if readOnly}}
+    {{#exists readonly}}
       <span class="label label-warning pull-right">readonly</span>
-    {{/if}}
+    {{/exists}}
     <h3 class="panel-title signature">
       <strong class="name">`{{name}}`</strong>: <code>{{#crossLink type}}{{/crossLink}}</code>
     </h3>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -42,7 +42,8 @@ module.exports = function(defaults) {
       quiet:       true,
       parseOnly:   false,
       lint:        false,
-      themedir:    'docs/theme'
+      themedir:    'docs/theme',
+      helpers:     ['docs/theme/helpers/helpers.js']
     }
   });
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -4,7 +4,8 @@ import config from './config/environment';
 const { Router: EmberRouter } = Ember;
 
 const Router = EmberRouter.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {


### PR DESCRIPTION
- [x] Updates docs to show readonly even if its an empty string.
- [x] Read the default value for config.baseURL from rootURL first, then baseURL as a back.
- [x] Raises deprecation error when running config.get('baseURL').
~~ - [ ] Update tests in https://github.com/simplabs/ember-simple-auth/blob/master/tests/unit/configuration-test.js~~

Replaces #1051 

Closes #1048 
