### PR TITLE
Detect version of EmberData to conditionally define ajaxOptions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,11 @@
   "name": "ember-simple-auth",
   "dependencies": {
     "bootstrap": "~3.3.7",
-    "ember": "~2.7.0",
+    "ember": "~2.8.0",
     "mocha": "~2.2.4",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1",
-    "ember-cli-shims": "0.1.1",
+    "ember-cli-shims": "0.1.3",
     "sinonjs": "~1.17.1",
     "base64": "~1.0.0",
     "pretender": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -1,5 +1,6 @@
 /* jshint expr:true */
 import Ember from 'ember';
+import RESTAdapter from 'ember-data/adapters/rest';
 import { it } from 'ember-mocha';
 import { describe, beforeEach } from 'mocha';
 import { expect } from 'chai';
@@ -39,73 +40,77 @@ describe('DataAdapterMixin', () => {
     adapter = Adapter.create({ session: sessionService });
   });
 
-  describe('#ajaxOptions', () => {
-    it('registers a beforeSend hook', () => {
-      adapter.ajaxOptions();
+  const RESTAdapterPrototype = RESTAdapter.proto();
 
-      expect(hash).to.have.ownProperty('beforeSend');
-    });
-
-    it('asserts the presence of authorizer', () => {
-      adapter.set('authorizer', null);
-      expect(function() {
+  if (!RESTAdapterPrototype.headersForRequest) {
+    describe('#ajaxOptions', () => {
+      it('registers a beforeSend hook', () => {
         adapter.ajaxOptions();
-      }).to.throw(/Assertion Failed/);
-    });
 
-    it('preserves an existing beforeSend hook', () => {
-      const existingBeforeSend = sinon.spy();
-      hash.beforeSend = existingBeforeSend;
-      adapter.ajaxOptions();
-      hash.beforeSend();
-
-      expect(existingBeforeSend).to.have.been.called;
-    });
-
-    it('authorizes with the given authorizer', () => {
-      sinon.spy(sessionService, 'authorize');
-      adapter.ajaxOptions();
-      hash.beforeSend();
-
-      expect(sessionService.authorize).to.have.been.calledWith('authorizer:some');
-    });
-
-    describe('the beforeSend hook', () => {
-      let xhr;
-
-      beforeEach(() => {
-        adapter.ajaxOptions();
-        xhr = {
-          setRequestHeader() {}
-        };
-        sinon.spy(xhr, 'setRequestHeader');
+        expect(hash).to.have.ownProperty('beforeSend');
       });
 
-      describe('when the authorizer calls the block', () => {
+      it('asserts the presence of authorizer', () => {
+        adapter.set('authorizer', null);
+        expect(function() {
+          adapter.ajaxOptions();
+        }).to.throw(/Assertion Failed/);
+      });
+
+      it('preserves an existing beforeSend hook', () => {
+        const existingBeforeSend = sinon.spy();
+        hash.beforeSend = existingBeforeSend;
+        adapter.ajaxOptions();
+        hash.beforeSend();
+
+        expect(existingBeforeSend).to.have.been.called;
+      });
+
+      it('authorizes with the given authorizer', () => {
+        sinon.spy(sessionService, 'authorize');
+        adapter.ajaxOptions();
+        hash.beforeSend();
+
+        expect(sessionService.authorize).to.have.been.calledWith('authorizer:some');
+      });
+
+      describe('the beforeSend hook', () => {
+        let xhr;
+
         beforeEach(() => {
-          sinon.stub(sessionService, 'authorize', (authorizer, block) => {
-            block('header', 'value');
+          adapter.ajaxOptions();
+          xhr = {
+            setRequestHeader() {}
+          };
+          sinon.spy(xhr, 'setRequestHeader');
+        });
+
+        describe('when the authorizer calls the block', () => {
+          beforeEach(() => {
+            sinon.stub(sessionService, 'authorize', (authorizer, block) => {
+              block('header', 'value');
+            });
+            hash.beforeSend(xhr);
           });
-          hash.beforeSend(xhr);
+
+          it('adds a request header as given by the authorizer', () => {
+            expect(xhr.setRequestHeader).to.have.been.calledWith('header', 'value');
+          });
         });
 
-        it('adds a request header as given by the authorizer', () => {
-          expect(xhr.setRequestHeader).to.have.been.calledWith('header', 'value');
-        });
-      });
+        describe('when the authorizer does not call the block', () => {
+          beforeEach(() => {
+            sinon.stub(sessionService, 'authorize');
+            hash.beforeSend(xhr);
+          });
 
-      describe('when the authorizer does not call the block', () => {
-        beforeEach(() => {
-          sinon.stub(sessionService, 'authorize');
-          hash.beforeSend(xhr);
-        });
-
-        it('does not add a request header', () => {
-          expect(xhr.setRequestHeader).to.not.have.been.called;
+          it('does not add a request header', () => {
+            expect(xhr.setRequestHeader).to.not.have.been.called;
+          });
         });
       });
     });
-  });
+  }
 
   describe('#headersForRequest', () => {
     it('preserves existing headers by parent adapter', () => {


### PR DESCRIPTION
In Ember-data >= 2.7 there `ajaxOptions` is deprecated in favour of
several more fineGrained methods, one of them being `headersForRequest`.

Ember-Simple-Auth already uses `headersForRequest`, but also for backward
compatibility, continued to define `ajaxOptions` for order versions of ED,
which raises annoying deprecation warnings in newer versions.

This PR makes ESA to conditionally define ajaxOptions ONLY for versions of ED
that do not have the newer API
