### PR TITLE
Added argument passing to invalidate method

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -51,7 +51,7 @@ export default ObjectProxy.extend(Evented, {
     assert('Session#invalidate requires the session to be authenticated!', this.get('isAuthenticated'));
 
     let authenticator = this._lookupAuthenticator(this.authenticator);
-    return authenticator.invalidate(this.content.authenticated).then(() => {
+    return authenticator.invalidate(this.content.authenticated, ...arguments).then(() => {
       authenticator.off('sessionDataUpdated');
       this._busy = false;
       return this._clear(true);

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: 'simplabs/configs/ember-mocha',
+  extends: 'simplabs/configs/ember-mocha'
 };

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -386,12 +386,20 @@ describe('InternalSession', () => {
     });
 
     describe('when the authenticator resolves invalidation with params', () => {
-      it('when some data is sent with invalidate', () => {
-        let invalidateSession = sinon.spy(authenticator, 'invalidate');
+      var spy;
+
+      beforeEach(() => {
+        spy = sinon.spy(authenticator, 'invalidate');
+      });
+
+      it('passes the params on to the authenticators invalidate method', () => {
         let param = { some: 'random data' };
         session.invalidate(param);
-        invalidateSession.restore();
-        sinon.assert.calledWith(invalidateSession, session.get('authenticated'), param);
+        expect(authenticator.invalidate).to.have.been.calledWith(session.get('authenticated'), param);
+      });
+
+      afterEach(() => {
+        spy.restore();
       });
     });
 

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -391,7 +391,7 @@ describe('InternalSession', () => {
         let param = { some: 'random data' };
         session.invalidate(param);
         invalidateSession.restore();
-        sinon.assert.calledWith(invalidateSession, session.get('authenticated') , param);
+        sinon.assert.calledWith(invalidateSession, session.get('authenticated'), param);
       });
     });
 

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -386,7 +386,7 @@ describe('InternalSession', () => {
     });
 
     describe('when the authenticator resolves invalidation with params', () => {
-      var spy;
+      let spy;
 
       beforeEach(() => {
         spy = sinon.spy(authenticator, 'invalidate');

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -385,7 +385,17 @@ describe('InternalSession', () => {
       return session.authenticate('authenticator');
     });
 
-    describe('when the authenticator resolves invaldiation', () => {
+    describe('when the authenticator resolves invalidation with params', () => {
+      it('when some data is sent with invalidate', () => {
+        let invalidateSession = sinon.spy(authenticator, 'invalidate');
+        let param = { some: 'random data' };
+        session.invalidate(param);
+        invalidateSession.restore();
+        sinon.assert.calledWith(invalidateSession, session.get('authenticated') , param);
+      });
+    });
+
+    describe('when the authenticator resolves invalidation', () => {
       beforeEach(() => {
         sinon.stub(authenticator, 'invalidate').returns(RSVP.resolve());
       });

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -385,7 +385,7 @@ describe('InternalSession', () => {
       return session.authenticate('authenticator');
     });
 
-    describe('when the authenticator resolves invalidation with params', () => {
+    describe('when invalidate gets called with additional params', () => {
       let spy;
 
       beforeEach(() => {


### PR DESCRIPTION
I saw, that the authenticate method passes the arguments into the authenticator. But the invalidate method does not do that. So I simply added the arguments into the method call to enable the same behaviour as seen in the authenticate method.