### PR TITLE
Cookie store `_secureCookies`: use correct protocol property in FastBoot mode

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -108,10 +108,10 @@ export default BaseStore.extend({
 
   _secureCookies: computed(function() {
     if (this.get('_fastboot.isFastBoot')) {
-      return this.get('_fastboot.request.host').indexOf('https:') === 0;
-    } else {
-      return window.location.protocol === 'https:';
+      return this.get('_fastboot.request.protocol') === 'https';
     }
+
+    return window.location.protocol === 'https:';
   }).volatile(),
 
   _syncDataTimeout: null,


### PR DESCRIPTION
According to [the guide](https://ember-fastboot.com/docs/user-guide), the `host` property only contains the host. For protocol, the `protocol` property should be used and it contains protocol name without the colon.

This edit also prevents a crash if the property is nully for [some reason](https://github.com/robwebdev/ember-cli-staticboot).