### PR TITLE
Typo in docs comment for headersForRequest

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -95,7 +95,7 @@ export default Mixin.create({
     This method will only be called in Ember Data 2.7 or greater. Older versions
     will rely on `ajaxOptions` for request header injection.
 
-    @method handleResponse
+    @method headersForRequest
     @protected
    */
   headersForRequest() {


### PR DESCRIPTION
This PR fixes a docs typo, completing the Mixin's method list.