### PR TITLE
WIP: Add a DeviseTokenAuth authenticator/authorizer

### DIFF
--- a/addon/authenticators/devise-token-auth.js
+++ b/addon/authenticators/devise-token-auth.js
@@ -1,0 +1,116 @@
+import Ember from 'ember';
+import DeviseAuthenticator from './devise';
+
+const { RSVP, assert, getProperties, Array: { isEvery }, isPresent, run } = Ember;
+
+/**
+  Authenticator that works with the Ruby gem
+  [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth).
+  
+  Read more about the [Token Header format](https://github.com/lynndylanhurley/devise_token_auth#token-header-format).
+
+  @class DeviseTokenAuthAuthenticator
+  @module ember-simple-auth/authenticators/devise-token-auth
+  @extends DeviseAuthenticator
+  @public
+*/
+export default DeviseAuthenticator.extend({
+  /**
+    The attribute in the session data that represents the authentication
+    token.
+
+    @property tokenAttributeName
+    @type String
+    @default 'accessToken'
+    @public
+  */
+  tokenAttributeName: 'accessToken',
+  
+  /**
+    The attribute in the session data that represents the authenticating
+    user's identity.
+
+    @property identificationAttributeName
+    @type String
+    @default 'email'
+    @public
+  */
+  identificationAttributeName: 'email',
+
+  /**
+    The endpoint on the server that the authentication request is sent to.
+
+    @property serverTokenEndpoint
+    @type String
+    @default null
+    @public
+  */
+  serverTokenEndpoint: null,
+  
+  /**
+    The devise resource name. __This will be used in the request and also be
+    expected in the server's response.__
+
+    @property resourceName
+    @type String
+    @default 'user'
+    @public
+  */
+  resourceName: 'user',
+
+  /**
+    Asserts that required attributes `resourceName` and `serverTokenEndpoint`
+    are set.
+
+    @method init
+    @public
+  */
+  init() {
+    this._super(...arguments);
+    assert('`resourceName` or `serverTokenEndpoint` missing',
+      isEvery([this.get('resourceName'), this.get('serverTokenEndpoint')], isPresent)
+    );
+  },
+
+  /**
+    Authenticates the session with the specified `identification` and
+    `password`; the credentials are `POST`ed to the
+    {{#crossLink "DeviseAuthenticator/serverTokenEndpoint:property"}}server{{/crossLink}}.
+    If the credentials are valid the server will respond with a
+    {{#crossLink "DeviseAuthenticator/tokenAttributeName:property"}}token{{/crossLink}}
+    and
+    {{#crossLink "DeviseAuthenticator/identificationAttributeName:property"}}identification{{/crossLink}}.
+    __If the credentials are valid and authentication succeeds, a promise that
+    resolves with the server's response is returned__, otherwise a promise that
+    rejects with the server error is returned.
+
+    @method authenticate
+    @param {String} identification The user's identification
+    @param {String} password The user's password
+    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+    @public
+  */
+  authenticate(identification, password) {
+    return new RSVP.Promise((resolve, reject) => {
+        const data = { password };
+        data[this.get('identificationAttributeName')] = identification;
+        return this.makeRequest(data)
+          .then((response, _, xhr) => {
+            let responseData = response.data;
+            responseData.accessToken = xhr.getResponseHeader('access-token');
+            responseData.client = xhr.getResponseHeader('client');
+            run(null, resolve, responseData);
+          })
+          .fail((xhr) => {
+            console.error(xhr.responseJSON || xhr.responseText);
+            run(null, reject, xhr.responseJSON || xhr.responseText);
+          });
+      }
+    );
+  },
+  
+  _validate(data) {
+    const { accessToken, uid, client } = getProperties(data, 'accessToken', 'uid', 'client');
+    return isEvery([accessToken, uid, client], isPresent);
+  }
+});

--- a/addon/authenticators/devise-token-auth.js
+++ b/addon/authenticators/devise-token-auth.js
@@ -5,9 +5,8 @@ const { RSVP, assert, getProperties, Array: { isEvery }, isPresent, run } = Embe
 
 /**
   Authenticator that works with the Ruby gem
-  [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth).
-  
-  Read more about the [Token Header format](https://github.com/lynndylanhurley/devise_token_auth#token-header-format).
+  [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth)
+  which does token-based authentication. Read more about the [Token Header format](https://github.com/lynndylanhurley/devise_token_auth#token-header-format).
 
   @class DeviseTokenAuthAuthenticator
   @module ember-simple-auth/authenticators/devise-token-auth
@@ -25,7 +24,7 @@ export default DeviseAuthenticator.extend({
     @public
   */
   tokenAttributeName: 'accessToken',
-  
+
   /**
     The attribute in the session data that represents the authenticating
     user's identity.
@@ -46,7 +45,7 @@ export default DeviseAuthenticator.extend({
     @public
   */
   serverTokenEndpoint: null,
-  
+
   /**
     The devise resource name. __This will be used in the request and also be
     expected in the server's response.__
@@ -108,7 +107,7 @@ export default DeviseAuthenticator.extend({
       }
     );
   },
-  
+
   _validate(data) {
     const { accessToken, uid, client } = getProperties(data, 'accessToken', 'uid', 'client');
     return isEvery([accessToken, uid, client], isPresent);

--- a/addon/authenticators/devise-token-auth.js
+++ b/addon/authenticators/devise-token-auth.js
@@ -94,6 +94,6 @@ export default DeviseAuthenticator.extend({
   _validate(data) {
     const resourceName = this.get('resourceName');
     const _data = data[resourceName] ? data[resourceName] : data;
-    !isEmpty(_data.client) && this._super(...arguments);
+    return !isEmpty(_data.client) && this._super(...arguments);
   }
 });

--- a/addon/authorizers/devise-token-auth.js
+++ b/addon/authorizers/devise-token-auth.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import DeviseAuthorizer from './devise';
+
+const { getProperties, Array: { isEvery }, isPresent } = Ember;
+
+/**
+  Authorizer that works with the Ruby gem
+  [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth).
+
+  @class DeviseTokenAuthAuthorizer
+  @module ember-simple-auth/authorizers/devise-token-auth
+  @extends DeviseAuthorizer
+  @public
+*/
+export default DeviseAuthorizer.extend({
+  /**
+   Includes the user's token (see
+   {{#crossLink "DeviseAuthenticator/tokenAttributeName:property"}}{{/crossLink}})
+   and identification (see
+   {{#crossLink "DeviseAuthenticator/identificationAttributeName:property"}}{{/crossLink}})
+   in the `Authorization` header.
+   @method authorize
+   @param {Object} data The data that the session currently holds
+   @param {Function} block(headers) The callback to call with the authorization data;
+   will receive the header names and header contents as an Object
+   @public
+   */
+  authorize(data, block) {
+    const { client, accessToken, uid } = getProperties(data, 'client', 'accessToken', 'uid');
+    if (isEvery([client, accessToken, uid], isPresent)) {
+      const authorizationHeaders = {
+        client,
+        uid,
+        'access-token': accessToken
+      };
+      block(authorizationHeaders);
+    }
+  }
+});

--- a/addon/mixins/devise-token-auth-data-adapter-mixin.js
+++ b/addon/mixins/devise-token-auth-data-adapter-mixin.js
@@ -1,0 +1,102 @@
+import Ember from 'ember';
+
+const { inject: { service }, Mixin, assert, isPresent } = Ember;
+
+export default Mixin.create({
+
+  /**
+    The session service.
+    @property session
+    @readOnly
+    @type SessionService
+    @public
+   */
+  session: service('session'),
+
+  /**
+    The authorizer that is used to authorize API requests. The authorizer has
+    to call the authorization callback (see
+    {{#crossLink "BaseAuthorizer/authorize:method"}}{{/crossLink}}) with header
+    name and header content arguments. __This property must be overridden in
+    adapters using this mixin.__
+    @property authorizer
+    @type String
+    @default null
+    @public
+   */
+  authorizer: null,
+
+  /**
+    Defines a `beforeSend` hook (see http://api.jquery.com/jQuery.ajax/) that
+    injects a request header containing the authorization data as constructed
+    by the {{#crossLink "DataAdapterMixin/authorizer:property"}}{{/crossLink}}
+    (see {{#crossLink "SessionService/authorize:method"}}{{/crossLink}}). The
+      specific header name and contents depend on the actual auhorizer that is
+        used.
+    @method ajaxOptions
+    @protected
+  */
+  ajaxOptions() {
+    const authorizer = this.get('authorizer');
+    assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", isPresent(authorizer));
+
+    let hash = this._super(...arguments);
+    let { beforeSend } = hash;
+
+    hash.beforeSend = (xhr) => {
+      this.get('session').authorize(authorizer, (authHeaders) => {
+        for (let headerName in authHeaders) {
+          if (authHeaders.hasOwnProperty(headerName)) {
+            xhr.setRequestHeader(headerName, authHeaders[headerName]);
+          }
+        }
+      });
+      if (beforeSend) {
+        return beforeSend(xhr);
+      }
+    };
+    return hash;
+  },
+
+  /**
+    Adds request headers containing the authorization data as constructed
+    by the {{#crossLink "DataAdapterMixin/authorizer:property"}}{{/crossLink}}.
+
+    This method will only be called in Ember Data 2.7 or greater. Older versions
+    will rely on `ajaxOptions` for request header injection.
+
+    @method headersForRequest
+    @protected
+   */
+  headersForRequest() {
+    const authorizer = this.get('authorizer');
+    assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", isPresent(authorizer));
+
+    let headers = this._super(...arguments);
+    headers = Object(headers);
+    this.get('session').authorize(authorizer, (authHeaders) => {
+      for (let headerName in authHeaders) {
+        if (authHeaders.hasOwnProperty(headerName)) {
+          headers[headerName] = authHeaders[headerName];
+        }
+      }
+    });
+    return headers;
+  },
+
+  /**
+    This method is called for every response that the adapter receives from the
+    API. If the response has a 401 status code it invalidates the session (see
+    {{#crossLink "SessionService/invalidate:method"}}{{/crossLink}}).
+
+    @method handleResponse
+    @param {Number} status The response status as received from the API
+    @protected
+  */
+  handleResponse(status) {
+    if (status === 401 && this.get('session.isAuthenticated')) {
+      this.get('session').invalidate();
+    }
+    return this._super(...arguments);
+  }
+});


### PR DESCRIPTION
This WIP PR adds a new Authenticator and Authorizer for use with the Ruby gem [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth).

It is an extraction from working code [at eCraft](https://github.com/ecraft/).

## Checklist

- [x] Write API documentation, introducing devise_token_auth
- [ ] Write tests
- [x] DeviseAuthenticator - accommodate #1118
- [ ] Accommodate the Mixin, presented as a new file `addon/mixins/devise-token-auth-data-adapter-mixin.js` here
- [ ] ajaxOptions to be compatible with ember-network/fetch

## Questions

- [ ] Can we deprecate the Devise authenticator, authorizer? The proposed backend patch which comes linked in  the DeviseAuthorizer API docs is from 2013.
- [ ] devise_token_auth gem has a setting for using Legacy-style Devise (non-Bearer Token authentication) [README link to section where this is explained](https://github.com/lynndylanhurley/devise_token_auth/blob/master/README.md#configuration-cont) - I should investigate that to see if that could be a way to get the Devise parts EmberSimpleAuth to _have_ a backend done