### PR TITLE
deprecate DeviseAuthenticator.rejectWithXhr

### DIFF
--- a/tests/unit/authenticators/devise-test.js
+++ b/tests/unit/authenticators/devise-test.js
@@ -103,9 +103,9 @@ describe('DeviseAuthenticator', () => {
         });
       });
 
-      describe('when reject with XHR is enabled', () => {
+      describe('when reject with response is enabled', () => {
         beforeEach(() => {
-          authenticator.set('rejectWithXhr', true);
+          authenticator.set('rejectWithResponse', true);
         });
 
         it('rejects with the response', () => {

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -209,7 +209,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         });
       });
 
-      describe('when reject with XHR is enabled', () => {
+      describe('when reject with response is enabled', () => {
         beforeEach(() => {
           authenticator.set('rejectWithResponse', true);
         });


### PR DESCRIPTION
This deprecates `DeviseAuthenticator.rejectWithXhr` in favor of `DeviseAuthenticator.rejectWithResponse`.

Closes #1117 

@stevenwu: can you review?