### PR TITLE
Documentation: compatible with the ember-network (Fetch API) used

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -66,7 +66,8 @@ export default BaseAuthenticator.extend({
 
   /**
     When authentication fails, the rejection callback is provided with the whole
-    XHR object instead of it's response JSON or text.
+    Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
+    instead of its responseJSON or responseText.
 
     This is useful for cases when the backend provides additional context not
     available in the response body.
@@ -81,7 +82,8 @@ export default BaseAuthenticator.extend({
 
   /**
     When authentication fails, the rejection callback is provided with the whole
-    fetch response object instead of it's response JSON or text.
+    Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
+    instead of its responseJSON or responseText.
 
     This is useful for cases when the backend provides additional context not
     available in the response body.
@@ -170,7 +172,8 @@ export default BaseAuthenticator.extend({
   },
 
   /**
-    Makes a request to the devise server.
+    Makes a request to the Devise server using
+    [ember-network/fetch](https://github.com/tomdale/ember-network#fetch).
 
     @method makeRequest
     @param {Object} data The request data

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -129,7 +129,8 @@ export default BaseAuthenticator.extend({
 
   /**
     When authentication fails, the rejection callback is provided with the whole
-    XHR object instead of it's response JSON or text.
+    Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
+    instead of its responseJSON or responseText.
 
     This is useful for cases when the backend provides additional context not
     available in the response body.
@@ -144,7 +145,8 @@ export default BaseAuthenticator.extend({
 
   /**
     When authentication fails, the rejection callback is provided with the whole
-    fetch response object instead of it's response JSON or text.
+    Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
+    instead of its responseJSON or responseText.
 
     This is useful for cases when the backend provides additional context not
     available in the response body.
@@ -298,7 +300,7 @@ export default BaseAuthenticator.extend({
     @param {String} url The request URL
     @param {Object} data The request data
     @param {Object} headers Additional headers to send in request
-    @return {Promise} A promise that resolves with the response object`
+    @return {Promise} A promise that resolves with the response object
     @protected
   */
   makeRequest(url, data, headers = {}) {


### PR DESCRIPTION
This PR changes docstrings to:

  - spell out `responseJSON` and `responseText` in the documentation comments
  - link to Fetch API spec and ember-network repository
  - remove two it's/its typos