### PR TITLE
YUIDoc configuration and npm script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "ember server",
     "test": "ember try:each",
     "nodetest": "node node-tests/nodetest-runner.js",
-    "fastboot-nodetest": "node node-tests/fastboot-runner.js"
+    "fastboot-nodetest": "node node-tests/fastboot-runner.js",
+    "yuidoc": "ember ember-cli-yuidoc"
   },
   "repository": "https://github.com/simplabs/ember-simple-auth",
   "engines": {
@@ -47,6 +48,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-yuidoc": "0.8.7",
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -6,13 +6,11 @@
     "paths": [
       "addon"
     ],
-    "external": [
-
-    ],
+    "external": [],
     "themedir": "docs/theme",
     "helpers": ["docs/theme/helpers/helpers.js"],
     "exclude": "vendor",
-    "outdir": "output",
+    "outdir": "../docs",
     "linkNatives": false,
     "quiet": true,
     "parseOnly": false,

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,16 +1,21 @@
 {
   "name": "ember-simple-auth",
+  "description": "A lightweight library for implementing authentication/authorization with Ember.js applications.",
+  "version": "1.1.0",
   "options": {
     "paths": [
       "addon"
     ],
+    "external": [
+
+    ],
+    "themedir": "docs/theme",
+    "helpers": ["docs/theme/helpers/helpers.js"],
     "exclude": "vendor",
-    "outdir": "../docs",
-    "yuidoc": {
-      "linkNatives": true,
-      "quiet": true,
-      "parseOnly": true,
-      "lint": false
-    }
+    "outdir": "output",
+    "linkNatives": false,
+    "quiet": true,
+    "parseOnly": false,
+    "lint": false
   }
 }


### PR DESCRIPTION
Ember-simple-auth has a theme and helpers for YUIDoc but it's not added as a dependency nor does it contain the correct config for YUIDoc. This PR fixes the mentioned issues.

- Add YUIDoc as a dev-dependency
- Update the YUIDoc config
- Add a NPM command to run `ember-cli-yuidoc`

ping @olleolleolle 