### PR TITLE
fix deprecated import of getOwner

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   RSVP,
@@ -12,7 +11,8 @@ const {
   assert,
   deprecate,
   set,
-  debug
+  debug,
+  getOwner
 } = Ember;
 const assign = emberAssign || merge;
 

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import Configuration from './../configuration';
 
-const { inject, Mixin, A, run: { bind }, testing, computed } = Ember;
+const { inject, Mixin, A, run: { bind }, testing, computed, getOwner } = Ember;
 
 /**
   The mixin for the application route; __defines methods that are called when

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import Configuration from './../configuration';
 
-const { inject: { service }, Mixin, assert, computed } = Ember;
+const { inject: { service }, Mixin, assert, computed, getOwner } = Ember;
 
 /**
   __This mixin is used to make routes accessible only if the session is

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import Configuration from './../configuration';
 
-const { inject: { service }, Mixin, assert, computed } = Ember;
+const { inject: { service }, Mixin, assert, computed, getOwner } = Ember;
 
 /**
   __This mixin is used to make routes accessible only if the session is

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const SESSION_DATA_KEY_PREFIX = /^data\./;
 
-const { computed, A, Service, Evented }  = Ember;
+const { computed, A, Service, Evented, getOwner }  = Ember;
 
 /**
   __The session service provides access to the current session as well as

--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -1,11 +1,10 @@
 /* global localStorage */
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import Base from 'ember-simple-auth/session-stores/base';
 import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
 import Cookie from 'ember-simple-auth/session-stores/cookie';
 
-const { computed, inject: { service } } = Ember;
+const { computed, inject: { service }, getOwner } = Ember;
 
 const LOCAL_STORAGE_TEST_KEY = '_ember_simple_auth_test_key';
 

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
-import getOwner from 'ember-getowner-polyfill';
 
-const { RSVP, computed, inject: { service }, run: { next, cancel, later, scheduleOnce }, isEmpty, typeOf, testing, isPresent, K, A } = Ember;
+const { RSVP, computed, inject: { service }, run: { next, cancel, later, scheduleOnce }, isEmpty, typeOf, testing, isPresent, K, A, getOwner } = Ember;
 
 const persistingProperty = function(beforeSet = K) {
   return computed({

--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -1,10 +1,9 @@
 /* global localStorage */
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 
-const { RSVP, $: jQuery, computed } = Ember;
+const { RSVP, $: jQuery, computed, getOwner } = Ember;
 
 /**
   Session store that persists data in the browser's `localStorage`.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ember-cli-import-polyfill": "^0.2.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.0.10",
-    "ember-getowner-polyfill": "^1.0.1",
+    "ember-getowner-polyfill": "^1.1.0",
     "ember-network": "^0.3.0",
     "silent-error": "^1.0.0"
   },

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -7,7 +7,7 @@ import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import Authenticator from 'ember-simple-auth/authenticators/base';
 
-const { RSVP, K, run: { next } } = Ember;
+const { RSVP, K, run: { next }, setOwner } = Ember;
 
 describe('InternalSession', () => {
   let session;
@@ -19,7 +19,8 @@ describe('InternalSession', () => {
     container     = { lookup() {} };
     store         = EphemeralStore.create();
     authenticator = Authenticator.create();
-    session       = InternalSession.create({ store, container });
+    session       = InternalSession.create({ store });
+    setOwner(session, container);
     sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
   });
 

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import Session from 'ember-simple-auth/services/session';
 
-const { ObjectProxy, Evented, run: { next }, set } = Ember;
+const { ObjectProxy, Evented, run: { next }, set, setOwner } = Ember;
 
 describe('SessionService', () => {
   let sessionService;
@@ -21,7 +21,8 @@ describe('SessionService', () => {
     };
     let container = { lookup() {} };
     sinon.stub(container, 'lookup').withArgs('authorizer').returns(authorizer);
-    sessionService = Session.create({ container, session });
+    sessionService = Session.create({ session });
+    setOwner(sessionService, container);
   });
 
   it('forwards the "authenticationSucceeded" event from the session', (done) => {


### PR DESCRIPTION
Should fix the second deprecation in #1122

Not sure if using setOwner this way in the tests is the right way though.
At least for the SessionService, maybe using the [setupTest thing](https://github.com/emberjs/ember-mocha#setup-tests) from is the way to go, but I guess it implies a bigger refactor

I just realize that it would be breaking change...