### PR TITLE
Remove unncessary transition.abort calls on auth mixins

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -79,7 +79,6 @@ export default Mixin.create({
       assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== authenticationRoute);
 
       if (!this.get('_isFastBoot')) {
-        transition.abort();
         this.set('session.attemptedTransition', transition);
       }
 

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -67,14 +67,10 @@ export default Mixin.create({
     @param {Transition} transition The transition that lead to this route
     @public
   */
-  beforeModel(transition) {
+  beforeModel() {
     if (this.get('session').get('isAuthenticated')) {
       let routeIfAlreadyAuthenticated = this.get('routeIfAlreadyAuthenticated');
       assert('The route configured as Configuration.routeIfAlreadyAuthenticated cannot implement the UnauthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== routeIfAlreadyAuthenticated);
-
-      if (!this.get('_isFastBoot')) {
-        transition.abort();
-      }
 
       return this.transitionTo(routeIfAlreadyAuthenticated);
     } else {

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -25,8 +25,7 @@ describe('AuthenticatedRouteMixin', () => {
 
       session = InternalSession.create({ store: EphemeralStore.create() });
       transition = {
-        send() {},
-        abort() {}
+        send() {}
       };
 
       route = Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin, {

--- a/tests/unit/mixins/unauthenticated-route-mixin-test.js
+++ b/tests/unit/mixins/unauthenticated-route-mixin-test.js
@@ -24,8 +24,7 @@ describe('UnauthenticatedRouteMixin', () => {
 
       session    = InternalSession.create({ store: EphemeralStore.create() });
       transition = {
-        send() {},
-        abort() {}
+        send() {}
       };
 
       route = Route.extend(MixinImplementingBeforeModel, UnauthenticatedRouteMixin, {


### PR DESCRIPTION
`transition.abort` were removed on https://github.com/simplabs/ember-simple-auth/pull/992, but were re added with fast boot merge.