### PR TITLE
Improve current-user service guides

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -50,7 +50,14 @@ export default Component.extend({
 
 In this example, the service does not need to know the ID of the current user
 as it uses a dedicated endpoint instead that will always respond with the user
-belonging to the authorization token in the request:
+belonging to the authorization token in the request.
+
+Note: Using `store.queryRecord` is the correct way to query for a record when id is
+unknown. Ember data expects the returned model to have the same id, as otherwise an
+unused empty record with `id` of `me` is in the store.
+
+We can override the adapter to generate `api/users/me` when `store.queryRecord` is
+invoked with a query param where the `me` param is present.
 
 ```js
 // app/services/current-user.js
@@ -64,10 +71,24 @@ export default Ember.Service.extend({
 
   load() {
     if (this.get('session.isAuthenticated')) {
-      return this.get('store').find('user', 'me').then((user) => {
+      return this.get('store').queryRecord('user', { me: true }).then((user) => {
         this.set('user', user);
       });
     }
+  }
+});
+
+// app/adapters/user.js
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  urlForQueryRecord(query) {
+    if (query.me) {
+      delete query.me;
+      return `${this._super(...arguments)}/me`;
+    }
+
+    return this._super(...arguments);
   }
 });
 ```
@@ -89,17 +110,14 @@ export default Ember.Service.extend({
   store: service(),
 
   load() {
-    return new RSVP.Promise((resolve, reject) => {
-      let userId = this.get('session.data.authenticated.user_id');
-      if (!isEmpty(userId)) {
-        this.get('store').find('user', userId).then((user) => {
-          this.set('user', user);
-          resolve();
-        }, reject);
-      } else {
-        resolve();
-      }
-    });
+    let userId = this.get('session.data.authenticated.user_id');
+    if (!isEmpty(userId)) {
+      return this.get('store').findRecord('user', userId).then((user) => {
+        this.set('user', user);
+      });
+    } else {
+      return Ember.RSVP.resolve();
+    }
   }
 });
 ```


### PR DESCRIPTION
This PR aims to improve `current-user` service guides a bit, including the case when using a dedicated endpoint but including the actual current using id in the response instead of a special value (e.g.: me).

The newly added section explains why using EmberData's`find` method with id `me` and returning an actual id in the response is a problem. For more information, please check: https://github.com/emberjs/data/issues/4414.

It also closes a stalled issue and PR:
https://github.com/simplabs/ember-simple-auth/issues/1064
https://github.com/simplabs/ember-simple-auth/pull/1065