### PR TITLE
Re-export authorizers and authenticators

### DIFF
--- a/app/authenticators/devise.js
+++ b/app/authenticators/devise.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authenticators/devise';

--- a/app/authenticators/oauth2-password-grant.js
+++ b/app/authenticators/oauth2-password-grant.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authenticators/oauth2-password-grant';

--- a/app/authenticators/test.js
+++ b/app/authenticators/test.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authenticators/test';

--- a/app/authenticators/torii.js
+++ b/app/authenticators/torii.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authenticators/torii';

--- a/app/authorizers/devise.js
+++ b/app/authorizers/devise.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authorizers/devise';

--- a/app/authorizers/oauth2-bearer.js
+++ b/app/authorizers/oauth2-bearer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-auth/authorizers/oauth2-bearer';


### PR DESCRIPTION
Create app re-exports of the authorizers and authenticators so that they can be used directly without extension. Base versions were omitted because they should not be used directly. Session stores were omitted because there should only be one, which is already implemented.

There will need to be documentation changes to communicate this effectively. I will wait until the other pending documentation PRs are merged and you indicate that this is a change you want before doing that.