### PR TITLE
Upgrade ember-cookies to version 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-import-polyfill": "^0.2.0",
     "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cookies": "^0.0.10",
+    "ember-cookies": "^0.0.11",
     "ember-getowner-polyfill": "^1.1.0",
     "ember-network": "^0.3.0",
     "silent-error": "^1.0.0"


### PR DESCRIPTION
 where deprecation triggered by ember-getowner-polyfill has been fixed