### PR TITLE
Remove setOwner() calls

### DIFF
--- a/tests/helpers/create-with-container.js
+++ b/tests/helpers/create-with-container.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { setOwner } = Ember;
+
+export default function createWithContainer(Constructor, options, container) {
+  if (setOwner) {
+    let instance = Constructor.create(options);
+    setOwner(instance, container);
+    return instance;
+  } else {
+    options.container = container;
+    return Constructor.create(options);
+  }
+}

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -7,7 +7,9 @@ import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import Authenticator from 'ember-simple-auth/authenticators/base';
 
-const { RSVP, K, run: { next }, setOwner } = Ember;
+import createWithContainer from '../helpers/create-with-container';
+
+const { RSVP, K, run: { next } } = Ember;
 
 describe('InternalSession', () => {
   let session;
@@ -19,8 +21,7 @@ describe('InternalSession', () => {
     container     = { lookup() {} };
     store         = EphemeralStore.create();
     authenticator = Authenticator.create();
-    session       = InternalSession.create({ store });
-    setOwner(session, container);
+    session       = createWithContainer(InternalSession, { store }, container);
     sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
   });
 

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -7,7 +7,9 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 
-const { Route, run: { next }, setOwner } = Ember;
+import createWithContainer from '../../helpers/create-with-container';
+
+const { Route, run: { next } } = Ember;
 
 describe('ApplicationRouteMixin', () => {
   let session;
@@ -27,13 +29,9 @@ describe('ApplicationRouteMixin', () => {
 
     containerMock.lookup.withArgs('service:cookies').returns(cookiesMock);
 
-    route = Route.extend(ApplicationRouteMixin, {
+    route = createWithContainer(Route.extend(ApplicationRouteMixin, {
       transitionTo() {}
-    }).create({
-      session
-    });
-
-    setOwner(route, containerMock);
+    }), { session }, containerMock);
   });
 
   describe('mapping of service events to route methods', () => {

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -8,7 +8,9 @@ import InternalSession from 'ember-simple-auth/internal-session';
 import Configuration from 'ember-simple-auth/configuration';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 
-const { Mixin, RSVP, Route, setOwner } = Ember;
+import createWithContainer from '../../helpers/create-with-container';
+
+const { Mixin, RSVP, Route } = Ember;
 
 describe('AuthenticatedRouteMixin', () => {
   let route;
@@ -46,14 +48,12 @@ describe('AuthenticatedRouteMixin', () => {
       containerMock.lookup.withArgs('service:cookies').returns(cookiesMock);
       containerMock.lookup.withArgs('service:fastboot').returns(fastbootMock);
 
-      route = Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin, {
+      route = createWithContainer(Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin, {
         // pretend this is never FastBoot
         _isFastBoot: false,
         // replace actual transitionTo as the router isn't set up etc.
         transitionTo() {}
-      }).create({ session });
-
-      setOwner(route, containerMock);
+      }), { session }, containerMock);
 
       sinon.spy(transition, 'send');
       sinon.spy(route, 'transitionTo');

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -5,7 +5,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import Session from 'ember-simple-auth/services/session';
 
-const { ObjectProxy, Evented, run: { next }, set, setOwner } = Ember;
+import createWithContainer from '../../helpers/create-with-container';
+
+const { ObjectProxy, Evented, run: { next }, set } = Ember;
 
 describe('SessionService', () => {
   let sessionService;
@@ -23,8 +25,7 @@ describe('SessionService', () => {
     let stub = sinon.stub(container, 'lookup');
     stub.withArgs('authorizer').returns(authorizer);
     stub.withArgs('bad-authorizer').returns(undefined);
-    sessionService = Session.create({ session });
-    setOwner(sessionService, container);
+    sessionService = createWithContainer(Session, { session }, container);
   });
 
   it('forwards the "authenticationSucceeded" event from the session', (done) => {


### PR DESCRIPTION
`setOwner()` is not polyfilled by ember-getowner-polyfill and fails on older Ember versions. Using `setOwner()` in the tests was introduced by https://github.com/simplabs/ember-simple-auth/pull/1124, which should have failed CI, but apparently went through for some unknown reason (possibly a caching issue or some transitive dependency constraint on the polyfill?).

This is needed until https://github.com/rwjblue/ember-getowner-polyfill/pull/14 lands.