### PR TITLE
add ability to send client_id via authorization header or in POST body

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -336,7 +336,7 @@ export default BaseAuthenticator.extend({
 
     const clientIdHeader = this.get('_clientIdHeader');
     if (this.get('enableLegacyClientIdentification') && !isEmpty(clientIdHeader)) {
-      deprecate('Ember Simple Auth: sending client_id as authoriation header is no longer ' +
+      deprecate('Ember Simple Auth: sending client_id in the Authorization header is no longer ' +
         'supported, please set enableLegacyClientIdentification property to false',
         false,
         { id: `ember-simple-auth.oauth2-password-grant.makeRequest`, until: '2.0.0' });

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -338,7 +338,7 @@ export default BaseAuthenticator.extend({
     if (this.get('enableLegacyClientIdentification') && !isEmpty(clientIdHeader)) {
       deprecate('Ember Simple Auth: sending client_id as authoriation header is no longer ' +
         'supported, please set enableLegacyClientIdentification property to false',
-        false, 
+        false,
         { id: `ember-simple-auth.oauth2-password-grant.makeRequest`, until: '2.0.0' });
       merge(options.headers, clientIdHeader);
     }

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -336,10 +336,12 @@ export default BaseAuthenticator.extend({
 
     const clientIdHeader = this.get('_clientIdHeader');
     if (this.get('enableLegacyClientIdentification') && !isEmpty(clientIdHeader)) {
-      deprecate('Ember Simple Auth: sending client_id in the Authorization header is no longer ' +
+      deprecate(
+        'Ember Simple Auth: sending client_id in the Authorization header is no longer ' +
         'supported, please set enableLegacyClientIdentification property to false',
         false,
-        { id: `ember-simple-auth.oauth2-password-grant.makeRequest`, until: '2.0.0' });
+        { id: `ember-simple-auth.oauth2-password-grant.makeRequest`, until: '2.0.0' }
+      );
       merge(options.headers, clientIdHeader);
     }
     return new RSVP.Promise((resolve, reject) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -337,10 +337,9 @@ export default BaseAuthenticator.extend({
     const clientIdHeader = this.get('_clientIdHeader');
     if (this.get('enableLegacyClientIdentification') && !isEmpty(clientIdHeader)) {
       deprecate('Ember Simple Auth: sending client_id as authoriation header is no longer ' +
-        'supported, please set enableLegacyClientIdentification property to false', {
-          id: `ember-simple-auth.oauth2-password-grant.makeRequest`,
-          until: '2.0.0'
-        });
+        'supported, please set enableLegacyClientIdentification property to false',
+        false, 
+        { id: `ember-simple-auth.oauth2-password-grant.makeRequest`, until: '2.0.0' });
       merge(options.headers, clientIdHeader);
     }
     return new RSVP.Promise((resolve, reject) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -55,6 +55,18 @@ export default BaseAuthenticator.extend({
   clientId: null,
 
   /**
+    If `true`, the client_id (if present) will be sent in the `Authorization`
+    header with an empty client_secret. If `false`, the client_id will be sent
+    in the request body.
+
+    @property enableClientAuth
+    @type Boolean
+    @default true
+    @public
+  */
+  enableClientAuth: true,
+
+  /**
     The endpoint on the server that authentication and token refresh requests
     are sent to.
 
@@ -232,6 +244,9 @@ export default BaseAuthenticator.extend({
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;
       }
+      if (!this.get('enableClientAuth') && !isEmpty('clientId')) {
+        data['client_id'] = this.get('clientId');
+      }
       this.makeRequest(serverTokenEndpoint, data, headers).then((response) => {
         run(() => {
           if (!this._validate(response)) {
@@ -318,7 +333,7 @@ export default BaseAuthenticator.extend({
     };
 
     const clientIdHeader = this.get('_clientIdHeader');
-    if (!isEmpty(clientIdHeader)) {
+    if (this.get('enableClientAuth') && !isEmpty(clientIdHeader)) {
       merge(options.headers, clientIdHeader);
     }
     return new RSVP.Promise((resolve, reject) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -241,11 +241,12 @@ export default BaseAuthenticator.extend({
       const serverTokenEndpoint = this.get('serverTokenEndpoint');
       const useResponse = this.get('rejectWithResponse');
       const scopesString = makeArray(scope).join(' ');
+      const clientId = this.get('clientId');
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;
       }
-      if (!this.get('enableClientAuth') && !isEmpty('clientId')) {
-        data['client_id'] = this.get('clientId');
+      if (!this.get('enableClientAuth') && !isEmpty(clientId)) {
+        data['client_id'] = clientId;
       }
       this.makeRequest(serverTokenEndpoint, data, headers).then((response) => {
         run(() => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -9,6 +9,7 @@ import {
   merge,
   assign as emberAssign
 } from '@ember/polyfills';
+import { deprecate } from '@ember/application/deprecations';
 import Ember from 'ember';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
@@ -59,12 +60,12 @@ export default BaseAuthenticator.extend({
     header with an empty client_secret. If `false`, the client_id will be sent
     in the request body.
 
-    @property enableClientAuth
+    @property enableLegacyClientIdentification
     @type Boolean
     @default true
     @public
   */
-  enableClientAuth: true,
+  enableLegacyClientIdentification: true,
 
   /**
     The endpoint on the server that authentication and token refresh requests
@@ -245,7 +246,7 @@ export default BaseAuthenticator.extend({
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;
       }
-      if (!this.get('enableClientAuth') && !isEmpty(clientId)) {
+      if (!this.get('enableLegacyClientIdentification') && !isEmpty(clientId)) {
         data['client_id'] = clientId;
       }
       this.makeRequest(serverTokenEndpoint, data, headers).then((response) => {
@@ -334,7 +335,12 @@ export default BaseAuthenticator.extend({
     };
 
     const clientIdHeader = this.get('_clientIdHeader');
-    if (this.get('enableClientAuth') && !isEmpty(clientIdHeader)) {
+    if (this.get('enableLegacyClientIdentification') && !isEmpty(clientIdHeader)) {
+      deprecate('Ember Simple Auth: sending client_id as authoriation header is no longer ' +
+        'supported, please set enableLegacyClientIdentification property to false', {
+          id: `ember-simple-auth.oauth2-password-grant.makeRequest`,
+          until: '2.0.0'
+        });
       merge(options.headers, clientIdHeader);
     }
     return new RSVP.Promise((resolve, reject) => {

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -127,6 +127,34 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       authenticator.authenticate('username', 'password');
     });
 
+    it('sends an AJAX request to the token endpoint without client_id Basic Auth header when enableClientAuth is false', function(done) {
+      server.post('/token', (request) => {
+        expect(request.requestHeaders.hasOwnProperty('authorization')).to.eql(false);
+        done();
+      });
+
+      authenticator.set('clientId', 'test-client');
+      authenticator.set('enableClientAuth', false);
+      authenticator.authenticate('username', 'password');
+    });
+
+    it('sends an AJAX request to the token endpoint with client_id in POST body when enableClientAuth is false', function(done) {
+      server.post('/token', (request) => {
+        let body = parsePostData(request.requestBody);
+        expect(body).to.eql({
+          'grant_type': 'password',
+          'username': 'username',
+          'password': 'password',
+          'client_id': 'test-client'
+        });
+        done();
+      });
+
+      authenticator.set('clientId', 'test-client');
+      authenticator.set('enableClientAuth', false);
+      authenticator.authenticate('username', 'password');
+    });
+
     it('sends an AJAX request to the token endpoint with customized headers', function(done) {
       server.post('/token', (request) => {
         expect(request.requestHeaders['x-custom-context']).to.eql('foobar');

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -127,18 +127,18 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       authenticator.authenticate('username', 'password');
     });
 
-    it('sends an AJAX request to the token endpoint without client_id Basic Auth header when enableClientAuth is false', function(done) {
+    it('sends an AJAX request to the token endpoint without client_id Basic Auth header when enableLegacyClientIdentification is false', function(done) {
       server.post('/token', (request) => {
         expect(request.requestHeaders.hasOwnProperty('authorization')).to.eql(false);
         done();
       });
 
       authenticator.set('clientId', 'test-client');
-      authenticator.set('enableClientAuth', false);
+      authenticator.set('enableLegacyClientIdentification', false);
       authenticator.authenticate('username', 'password');
     });
 
-    it('sends an AJAX request to the token endpoint with client_id in POST body when enableClientAuth is false', function(done) {
+    it('sends an AJAX request to the token endpoint with client_id in POST body when enableLegacyClientIdentification is false', function(done) {
       server.post('/token', (request) => {
         let body = parsePostData(request.requestBody);
         expect(body).to.eql({
@@ -151,7 +151,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       });
 
       authenticator.set('clientId', 'test-client');
-      authenticator.set('enableClientAuth', false);
+      authenticator.set('enableLegacyClientIdentification', false);
       authenticator.authenticate('username', 'password');
     });
 

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -129,7 +129,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
     it('sends an AJAX request to the token endpoint without client_id Basic Auth header when enableLegacyClientIdentification is false', function(done) {
       server.post('/token', (request) => {
-        expect(request.requestHeaders.hasOwnProperty('authorization')).to.eql(false);
+        expect(request.requestHeaders.hasOwnProperty('authorization')).to.be.false;
         done();
       });
 


### PR DESCRIPTION
The way that were sending a client_id currently (in an authorization header with an empty password) explicitly implies that we're doing client authentication.

The OAuth2 spec outlines that we can't do client authentication from a user-agent based client.
https://tools.ietf.org/html/rfc6749#page-16

This PR adds an attribute (enableClientAuth) that will send the client_id in the POST body instead of in the authorization header if it's set to false.

In my mind, the default should be false, but for now it's set to true for backwards compatibility.