### PR TITLE
Fix [ember-debug.deprecate-options-missing] on rejectWithXhr deprecationAlias

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -78,7 +78,10 @@ export default BaseAuthenticator.extend({
     @deprecated DeviseAuthenticator/rejectWithResponse:property
     @public
   */
-  rejectWithXhr: computed.deprecatingAlias('rejectWithResponse'),
+  rejectWithXhr: computed.deprecatingAlias('rejectWithResponse', {
+    id: `ember-simple-auth.authenticator.reject-with-xhr`,
+    until: '2.0.0'
+  }),
 
   /**
     When authentication fails, the rejection callback is provided with the whole

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -141,7 +141,10 @@ export default BaseAuthenticator.extend({
     @deprecated OAuth2PasswordGrantAuthenticator/rejectWithResponse:property
     @public
   */
-  rejectWithXhr: computed.deprecatingAlias('rejectWithResponse'),
+  rejectWithXhr: computed.deprecatingAlias('rejectWithResponse', {
+    id: `ember-simple-auth.authenticator.reject-with-xhr`,
+    until: '2.0.0'
+  }),
 
   /**
     When authentication fails, the rejection callback is provided with the whole


### PR DESCRIPTION
Trivial, but the deprecation of `rejectWithXhr` in #1118 itself caused a deprecation error in the console. This fixes that.

Before: 
![image](https://cloud.githubusercontent.com/assets/3239830/21730218/9a832bba-d403-11e6-9f2a-9fbf20b5d5f8.png)

After:
![image](https://cloud.githubusercontent.com/assets/3239830/21730232/a46c889c-d403-11e6-99c4-25803cf49320.png)
