### PR TITLE
Removes unused ember-getowner-polyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-import-polyfill": "^0.2.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.0.11",
     "ember-getowner-polyfill": "^1.1.0",


### PR DESCRIPTION
ember-getowner-polyfill is no longer used in ESA and triggers a deprecation warning in latest releases of Ember.
