### PR TITLE
Improved current-user and it's loading

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -74,6 +74,8 @@ export default Ember.Service.extend({
       return this.get('store').queryRecord('user', { me: true }).then((user) => {
         this.set('user', user);
       });
+    } else {
+      return Ember.RSVP.resolve();
     }
   }
 });
@@ -150,11 +152,11 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
 
   sessionAuthenticated() {
     this._super(...arguments);
-    this._loadCurrentUser().catch(() => this.get('session').invalidate());
+    this._loadCurrentUser();
   },
 
   _loadCurrentUser() {
-    return this.get('currentUser').load();
+    return this.get('currentUser').load().catch(() => this.get('session').invalidate());
   }
 });
 ```

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -12,10 +12,10 @@ export default Route.extend(ApplicationRouteMixin, {
 
   sessionAuthenticated() {
     this._super(...arguments);
-    this._loadCurrentUser().catch(() => this.get('session').invalidate());
+    this._loadCurrentUser();
   },
 
   _loadCurrentUser() {
-    return this.get('sessionAccount').loadCurrentUser();
+    return this.get('sessionAccount').loadCurrentUser().catch(() => this.get('session').invalidate());
   }
 });


### PR DESCRIPTION
- `api/users/me` version of `currentUser` returns a promise even if session is invalid, so we can always call `get('currentUser').load().catch( () => this.get('session').invalidate() )`
- In `currentUser` loading we need to invalidate session if `currentUser` fails. The scenarios is that we had valid session so ESA did `restore` therefore `beforeModel` is called (and no `sessionAuthenticated`), but in this case it's possible that backend no longer considers the session valid, and it manifests as an error for `currentUser`, we need to invalidate session in this case too.