### PR TITLE
add missing needs

### DIFF
--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('ApplicationRoute', function() {
   setupTest('route:application', {
-    needs: ['service:session', 'router:main']
+    needs: ['service:session', 'router:main', 'service:session-account']
   });
 
   it('is still testable when using the ApplicationRouteMixin', function() {

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('LoginRoute', function() {
   setupTest('route:login', {
-    needs: ['router:main']
+    needs: ['router:main', 'service:session']
   });
 
   it('is still testable when using the UnauthenticatedRouteMixin', function() {

--- a/tests/unit/routes/protected-test.js
+++ b/tests/unit/routes/protected-test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('ProtectedRoute', function() {
   setupTest('route:protected', {
-    needs: ['router:main']
+    needs: ['router:main', 'service:session']
   });
 
   it('is still testable when using the AuthenticatedRouteMixin', function() {


### PR DESCRIPTION
Apparently all injected services must be available when a new instance of the class they are injected into is created. This wasn't actually asserted pre Ember 2.12 though…

See https://github.com/emberjs/ember.js/pull/5162, https://github.com/emberjs/ember.js/pull/4861 for details.

Thanks @rwjblue for the heads up on this!