### PR TITLE
Change jQuery 'bind' to 'on' to support jQuery >= 3

### DIFF
--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -95,7 +95,7 @@ export default BaseStore.extend({
   },
 
   _bindToStorageEvents() {
-    jQuery(window).bind('storage', (e) => {
+    jQuery(window).on('storage', (e) => {
       if (e.originalEvent.key === this.key) {
         this.restore().then((data) => {
           if (!objectsAreEqual(data, this._lastData)) {


### PR DESCRIPTION
As of jQuery 3.0, .bind() has been deprecated. This PR replaces the 'bind' call in the local storage store with it's successor 'on'. For more info check the [jQuery docs](http://api.jquery.com/bind/).