### PR TITLE
simplify import code

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,6 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
-    // see: https://github.com/ember-cli/ember-cli/issues/3718
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
-
     app.import('vendor/ember-simple-auth/register-version.js');
   }
 };


### PR DESCRIPTION
As we now use ember-cli-import-polyfill as a dependency we don't need the code in `index.js` anymore that deals with the dependency-of-a-dependency situation anymore.