### PR TITLE
Restore Node 0.12 compatibility

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
+
 module.exports = {
   scenarios: [
     {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,7 @@
-/* eslint-env node */
 'use strict';
+
+/* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
 
 module.exports = function(/* environment, appConfig */) {
   return { };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,25 +1,27 @@
-/* eslint-env node */
 'use strict';
 
-const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-const Yuidoc = require('broccoli-yuidoc');
-const version = require('git-repo-version')();
+/* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
 
-let sourceTrees = [];
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+var Yuidoc = require('broccoli-yuidoc');
+var version = require('git-repo-version')();
+
+var sourceTrees = [];
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
+  var app = new EmberAddon(defaults, {
     storeConfigInMeta: true,
   });
 
   app.import('bower_components/bootstrap/dist/css/bootstrap.css');
 
-  const yuidocTree = new Yuidoc(['addon', 'app'], {
+  var yuidocTree = new Yuidoc(['addon', 'app'], {
     destDir: 'docs',
     yuidoc: {
       project: {
         name: 'The Ember Simple Auth API',
-        version,
+        version: version,
       },
       linkNatives: false,
       quiet: true,

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-/* eslint-env node */
 'use strict';
+
+/* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
 
 module.exports = {
   name: 'ember-simple-auth',
 
-  included(app) {
+  included: function(app) {
     this._super.included.apply(this, arguments);
 
     // see: https://github.com/ember-cli/ember-cli/issues/3718

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
+
 module.exports = {
   'framework': 'mocha',
   'test_page': 'tests/index.html?hidepassed',

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,10 +1,12 @@
-/* eslint-env node */
 'use strict';
 
+/* eslint-env node */
+/* eslint-disable no-var, object-shorthand */
+
 module.exports = function(environment) {
-  let ENV = {
+  var ENV = {
     modulePrefix: 'dummy',
-    environment,
+    environment: environment,
     rootURL: '/',
     locationType: 'auto',
     EmberENV: {


### PR DESCRIPTION
Resolves #1204 

our `ember test` will not run on Node 0.12 though, unless the `ember-cli-eslint` and `ember-cli-fastboot` deps are removed from `package.json`