### PR TITLE
Add Ember import to torii authenticator

### DIFF
--- a/blueprints/authenticator/index.js
+++ b/blueprints/authenticator/index.js
@@ -15,7 +15,7 @@ module.exports = {
 
     if (baseClass === 'torii') {
       return {
-        imports: 'import Torii from \'ember-simple-auth/authenticators/torii\';',
+        imports: 'import Ember from \'ember\';' + EOL + 'import Torii from \'ember-simple-auth/authenticators/torii\';',
         baseClass: 'Torii',
         body: EOL + '  torii: Ember.inject.service(\'torii\')'
       };

--- a/node-tests/blueprints/authenticator-test.js
+++ b/node-tests/blueprints/authenticator-test.js
@@ -14,7 +14,8 @@ describe('Acceptance: ember generate and destroy authenticator', function() {
   it('generates a torii authenticator', function() {
     return emberNew().then(() => generateAndDestroy(['authenticator', 'application', '--base-class=torii'], (file) => {
       expect(file('app/authenticators/application.js')).to.contain('\
-import Torii from \'ember-simple-auth/authenticators/torii\';' + EOL + '\
+import Ember from \'ember\';' + EOL +
+'import Torii from \'ember-simple-auth/authenticators/torii\';' + EOL + '\
 ' + EOL + '\
 export default Torii.extend({' + EOL + '\
   torii: Ember.inject.service(\'torii\')' + EOL + '\


### PR DESCRIPTION
A jshint/eslint error was thrown after generating an authenticator that extends the torii one:

> ember g authenticator github-auth-code --base-class=torii

This PR adds the missing line.