### PR TITLE
Provide opt outs for async infinite sync loop

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -73,6 +73,29 @@ export default BaseStore.extend({
   _renewExpirationTimeout: null,
 
   /**
+    The inverval for syncing data in milliseconds. A value of `null` will make
+    the data sync only once and not in a loop with the syncDataInverval
+
+    @property syncDataInterval
+    @type number
+    @default 500
+    @public
+  */
+  _syncDataInterval: 500,
+  syncDataInterval: persistingProperty(),
+
+  /**
+    The inverval for renewing cookie expirationt time in seconds.
+
+    @property renewExpirationTime
+    @type number
+    @default 60
+    @public
+  */
+  _renewExpirationTime: 60,
+  renewExpirationTime: persistingProperty(),
+
+  /**
     The domain to use for the cookie, e.g., "example.com", ".example.com"
     (which includes all subdomains) or "subdomain.example.com". If not
     explicitly set, the cookie domain defaults to the domain the session was
@@ -252,9 +275,9 @@ export default BaseStore.extend({
         this._lastData = data;
         this.trigger('sessionDataUpdated', data);
       }
-      if (!testing) {
+      if (!testing && this.syncDataInterval) {
         cancel(this._syncDataTimeout);
-        this._syncDataTimeout = later(this, this._syncData, 500);
+        this._syncDataTimeout = later(this, this._syncData, this.syncDataInterval);
       }
     });
   },
@@ -270,9 +293,9 @@ export default BaseStore.extend({
   },
 
   _renewExpiration() {
-    if (!testing) {
+    if (!testing && this.renewExpirationTime) {
       cancel(this._renewExpirationTimeout);
-      this._renewExpirationTimeout = later(this, this._renewExpiration, 60000);
+      this._renewExpirationTimeout = later(this, this._renewExpiration, this.renewExpirationTime * 1000);
     }
     if (this.get('_isPageVisible')) {
       return this._renew();


### PR DESCRIPTION
For context, I work with a dev team on http://dailyuv.com
Ember version: 2.8.3 - Fastboot enabled
Ember-simple-auth: 1.1.0 (we did update to 1.2.0 for testing)

We are using fastboot and have been running into many issues with its implementation and support in add-on libraries.

One issue we noticed in our application is that the ember-simple-auth cookie.js file (at https://github.com/simplabs/ember-simple-auth/blob/master/addon/session-stores/cookie.js#L257) creates an infinite loop. For our application it is unnecessary.

So, this Pull Request is meant to provide options for opting out of that infinite loop or to change its interval. Same with the expiration renewal interval. In our testing this does not affect our ability to maintain the current user or with any other functionality.