### PR TITLE
FastBoot dependency whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,21 @@ import CookieStore from 'ember-simple-auth/session-stores/cookie';
 export default CookieStore.extend();
 ```
 
+If you are using the
+[`OAuth2PasswordGrantAuthenticator`](http://ember-simple-auth.com/api/classes/OAuth2PasswordGrantAuthenticator.html),
+or
+[`DeviseAuthenticator`](http://ember-simple-auth.com/api/classes/DeviseAuthenticator.html),
+you must add `node-fetch` to your list of FastBoot whitelisted dependencies
+in `package.json`:
+
+```json
+{
+  "fastbootDependencies": [
+    "node-fetch"
+  ]
+}
+```
+
 ## Testing
 
 Ember Simple Auth comes with a __set of test helpers that can be used in


### PR DESCRIPTION
#### Adds node-fetch to fastbootDependencies
~~This PR fixes Ember Simple Auth from breaking in Fastboot when using the OAuth2PasswordGrant authenticator, as referenced in [#1138](https://github.com/simplabs/ember-simple-auth/issues/1138#issuecomment-283318213). The fix is to simply add node-fetch to the addon's whitelisted `fastbootDependencies`.~~

```json
"ember-addon": {
  "configPath": "tests/dummy/config",
  "fastbootDependencies": {
    "node-fetch"
  }
}
```

See below for updated PR info.