### PR TITLE
don't return transitionTo from beforeModel

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -93,7 +93,7 @@ export default Mixin.create({
         this.set('session.attemptedTransition', transition);
       }
 
-      return this.transitionTo(authenticationRoute);
+      this.transitionTo(authenticationRoute);
     } else {
       return this._super(...arguments);
     }

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -72,7 +72,7 @@ export default Mixin.create({
       let routeIfAlreadyAuthenticated = this.get('routeIfAlreadyAuthenticated');
       assert('The route configured as Configuration.routeIfAlreadyAuthenticated cannot implement the UnauthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== routeIfAlreadyAuthenticated);
 
-      return this.transitionTo(routeIfAlreadyAuthenticated);
+      this.transitionTo(routeIfAlreadyAuthenticated);
     } else {
       return this._super(...arguments);
     }


### PR DESCRIPTION
This removes unnecessary `return`s from the `AuthenticatedRouteMixin` and `UnauthenticatedRouteMixin` mixins - there's basically no difference between `return this.transitionTo(…` and `this.transitionTo(…` in `beforeModel` anyway and the code currently is a bit confusing actually.

closes #1238 