### PR TITLE
Add the GitHub guide to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ authorization mechanisms__.
 **Other Guides**
 
 * [Managing a current User](guides/managing-current-user.md)
+* [GitHub authorization with torii](guides/auth-torii-with-github.md)
 
 **Other Resources**
 


### PR DESCRIPTION
I realized that a link was missing in the "Other Guides" section.