### PR TITLE
Restore cookieExpirationTime from cookie value

### DIFF
--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -133,6 +133,11 @@ export default Base.extend({
       const options = this.getProperties('cookieDomain', 'cookieName', 'cookieExpirationTime', 'cookiePath');
       options._fastboot = this.get('_fastboot');
       options._cookies = this.get('_cookies');
+
+      let expirationCookieName = `${this.get('cookieName')}-expiration_time`;
+      let expirationTime = parseInt(options._cookies.read(expirationCookieName), 10);
+      this.set('cookieExpirationTime', expirationTime);
+
       store = this._createStore(Cookie, options);
     }
     this.set('_store', store);
@@ -140,12 +145,6 @@ export default Base.extend({
 
   _createStore(storeType, options) {
     const store = storeType.create(options);
-
-    if (!this.get('_isLocalStorageAvailable')) {
-      let expirationCookieName = `${this.get('cookieName')}-expiration_time`;
-      let expirationTime = parseInt(options._cookies.read(expirationCookieName), 10);
-      this.set('cookieExpirationTime', expirationTime);
-    }
 
     store.on('sessionDataUpdated', (data) => {
       this.trigger('sessionDataUpdated', data);

--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -134,11 +134,8 @@ export default Base.extend({
       options._fastboot = this.get('_fastboot');
       options._cookies = this.get('_cookies');
 
-      let expirationCookieName = `${this.get('cookieName')}-expiration_time`;
-      let expirationTime = parseInt(options._cookies.read(expirationCookieName), 10);
-      this.set('cookieExpirationTime', expirationTime);
-
       store = this._createStore(Cookie, options);
+      this.set('cookieExpirationTime', store.get('cookieExpirationTime'));
     }
     this.set('_store', store);
   },

--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -141,6 +141,12 @@ export default Base.extend({
   _createStore(storeType, options) {
     const store = storeType.create(options);
 
+    if (!this.get('_isLocalStorageAvailable')) {
+      let expirationCookieName = `${this.get('cookieName')}-expiration_time`;
+      let expirationTime = parseInt(options._cookies.read(expirationCookieName), 10);
+      this.set('cookieExpirationTime', expirationTime);
+    }
+
     store.on('sessionDataUpdated', (data) => {
       this.trigger('sessionDataUpdated', data);
     });

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -159,9 +159,9 @@ export default BaseStore.extend({
   init() {
     this._super(...arguments);
 
-    if (!this.get('cookieExpirationTime')) {
-      let cachedExpirationTime = parseInt(this._read(`${this.get('cookieName')}-expiration_time`), 10);
-      this.set('cookieExpirationTime', cachedExpirationTime);
+    let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
+    if (cachedExpirationTime) {
+      this.set('cookieExpirationTime', parseInt(cachedExpirationTime, 10));
     }
 
     if (!this.get('_fastboot.isFastBoot')) {

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -159,6 +159,11 @@ export default BaseStore.extend({
   init() {
     this._super(...arguments);
 
+    if (!this.get('cookieExpirationTime')) {
+      let cachedExpirationTime = parseInt(this._read(`${this.get('cookieName')}-expiration_time`), 10);
+      this.set('cookieExpirationTime', cachedExpirationTime);
+    }
+
     if (!this.get('_fastboot.isFastBoot')) {
       next(() => {
         this._syncData().then(() => {

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -293,4 +293,21 @@ export default function(options) {
       });
     });
   });
+
+  describe('#init', function() {
+    let cookieName = 'ember_simple_auth-session-expiration_time';
+    let expirationTime = 60 * 60 * 24;
+    beforeEach(function() {
+      cookieService.write(cookieName, expirationTime);
+      store = createStore(cookieService);
+    });
+
+    afterEach(function() {
+      cookieService.clear(cookieName);
+    });
+
+    it('restores expiration time from cookie', function() {
+      expect(store.get('cookieExpirationTime')).to.equal(expirationTime);
+    });
+  });
 }


### PR DESCRIPTION
When `AdaptiveStore` is using a `CookieStore`, the cookie values (name, domain, path) are only accessible through `AdaptiveStore._cookies`. I don't think they are restored, so `proxyToInternalStore` cannot access them. Do they need to be set in `init` as well?

/cc @marcoow 