### PR TITLE
Fix issue where store is emptied on page refresh

### DIFF
--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -158,7 +158,10 @@ export default ObjectProxy.extend(Evented, {
   setUnknownProperty(key, value) {
     assert('"authenticated" is a reserved key used by Ember Simple Auth!', key !== 'authenticated');
     let result = this._super(key, value);
-    this._updateStore();
+    if (this.content) {
+      // only update the store if there's content
+      this._updateStore();
+    }
     return result;
   },
 

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -158,8 +158,7 @@ export default ObjectProxy.extend(Evented, {
   setUnknownProperty(key, value) {
     assert('"authenticated" is a reserved key used by Ember Simple Auth!', key !== 'authenticated');
     let result = this._super(key, value);
-    if (this.content) {
-      // only update the store if there's content
+    if (!(/^_/).test(key)) {
       this._updateStore();
     }
     return result;

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -511,15 +511,31 @@ describe('InternalSession', () => {
 
   describe("when the session's content changes", function() {
     describe('when a single property is set', function() {
-      beforeEach(function() {
-        session.set('some', 'property');
+      describe('when the property is private (starts with an "_")', function() {
+        beforeEach(function() {
+          session.set('_some', 'property');
+        });
+
+        it('does not persist its content in the store', function() {
+          return store.restore().then((properties) => {
+            delete properties.authenticator;
+
+            expect(properties).to.eql({});
+          });
+        });
       });
 
-      it('persists its content in the store', function() {
-        return store.restore().then((properties) => {
-          delete properties.authenticator;
+      describe('when the property is not private (does not start with an "_")', function() {
+        beforeEach(function() {
+          session.set('some', 'property');
+        });
 
-          expect(properties).to.eql({ some: 'property', authenticated: {} });
+        it('persists its content in the store', function() {
+          return store.restore().then((properties) => {
+            delete properties.authenticator;
+
+            expect(properties).to.eql({ some: 'property', authenticated: {} });
+          });
         });
       });
     });
@@ -527,14 +543,14 @@ describe('InternalSession', () => {
     describe('when multiple properties are set at once', function() {
       beforeEach(function() {
         session.set('some', 'property');
-        session.setProperties({ multiple: 'properties' });
+        session.setProperties({ another: 'property', multiple: 'properties' });
       });
 
       it('persists its content in the store', function() {
         return store.restore().then((properties) => {
           delete properties.authenticator;
 
-          expect(properties).to.eql({ some: 'property', multiple: 'properties', authenticated: {} });
+          expect(properties).to.eql({ some: 'property', another: 'property', multiple: 'properties', authenticated: {} });
         });
       });
     });


### PR DESCRIPTION
Related #990 #1090.

Early in the initialization of this object, `setUnknownProperty` gets called with `__OWNER__` and `__NAME_KEY__` (system properties?). This happens before `this.content` is present. The side effect is that `null` is persisted, which trashes the data within our store. This fix checks to make sure `this.content` exists before persisting. 

Related discussion #990, #1090