### PR TITLE
Upgrade to ember-cookies 0.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-file-creator": "^1.1.1",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-is-package-missing": "^1.0.0",
-    "ember-cookies": "^0.0.12",
+    "ember-cookies": "^0.0.13",
     "ember-getowner-polyfill": "^1.1.0",
     "ember-network": "^0.3.0",
     "silent-error": "^1.0.0"


### PR DESCRIPTION
Our app is currently getting conflicting versions of `ember-getowner-polyfill`. This is fixed in 0.0.13. Thanks!