### PR TITLE
Switch from ember-network to ember-fetch

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import BaseAuthenticator from './base';
-import fetch from 'ember-network/fetch';
+import fetch from 'fetch';
 
 const { RSVP: { Promise }, isEmpty, run, assign: emberAssign, merge, computed } = Ember;
 const assign = emberAssign || merge;
@@ -177,7 +177,7 @@ export default BaseAuthenticator.extend({
 
   /**
     Makes a request to the Devise server using
-    [ember-network/fetch](https://github.com/tomdale/ember-network#fetch).
+    [ember-fetch](https://github.com/stefanpenner/ember-fetch).
 
     @method makeRequest
     @param {Object} data The request data

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import BaseAuthenticator from './base';
-import fetch from 'ember-network/fetch';
+import fetch from 'fetch';
 
 const {
   RSVP,

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.0.13",
+    "ember-fetch": "^1.4.2",
     "ember-getowner-polyfill": "^1.1.0",
-    "ember-network": "^0.3.0",
     "silent-error": "^1.0.0"
   },
   "devDependencies": {

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -220,7 +220,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
         it('provides access to custom headers', function() {
           return authenticator.authenticate('username', 'password').catch((error) => {
-            expect(error.headers.getAll('x-custom-context')[0]).to.eql('foobar');
+            expect(error.headers.get('x-custom-context')).to.eql('foobar');
           });
         });
       });


### PR DESCRIPTION
ember-fetch is being more actively maintained and is more up-to-date with the fetch spec.

See discussion in https://github.com/tomdale/ember-network/issues/17 and https://github.com/stefanpenner/ember-fetch/issues/21

The one change I made in the tests is because `headers.getAll` was [removed from the current WHATWG standard](https://www.fxsitecompat.com/en-CA/docs/2016/headers-getall-has-been-removed-in-favour-of-get-now-returning-all-values/), so ember-fetch doesn't implement it.