### PR TITLE
Fix tests

### DIFF
--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -787,7 +787,7 @@ describe('InternalSession', () => {
   });
 
   it('does not share the content object between multiple instances', function() {
-    let session2 = InternalSession.create({ store, container });
+    let session2 = createWithContainer(InternalSession, { store }, container);
 
     expect(session2.get('content')).to.not.equal(session.get('content'));
   });


### PR DESCRIPTION
This fixes the tests, specifically undefined is not an object (evaluating '_emberUtils.getOwner(this).__container__'), see https://travis-ci.org/simplabs/ember-simple-auth/builds/227956938.