### PR TITLE
Torii restore generic data

### DIFF
--- a/addon/authenticators/torii.js
+++ b/addon/authenticators/torii.js
@@ -1,6 +1,7 @@
 import RSVP from 'rsvp';
 import { assert } from '@ember/debug';
 import { isPresent, isEmpty } from '@ember/utils';
+import { assign as emberAssign } from '@ember/polyfills';
 import BaseAuthenticator from './base';
 
 /**
@@ -58,9 +59,9 @@ export default BaseAuthenticator.extend({
     if (!isEmpty(data.provider)) {
       const { provider } = data;
 
-      return this.get('torii').fetch(data.provider, data).then((data) => {
-        this._authenticateWithProvider(provider, data);
-        return data;
+      return this.get('torii').fetch(data.provider, data).then((fetchedData) => {
+        this._authenticateWithProvider(provider, fetchedData);
+        return emberAssign(data, fetchedData);
       }, () => delete this._provider);
     } else {
       delete this._provider;

--- a/tests/unit/authenticators/torii-test.js
+++ b/tests/unit/authenticators/torii-test.js
@@ -40,9 +40,9 @@ describe('ToriiAuthenticator', () => {
           sinon.stub(torii, 'fetch').returns(RSVP.resolve({ some: 'other data' }));
         });
 
-        it('returns a promise that resolves with the session data', function() {
-          return authenticator.restore({ some: 'data', provider: 'provider' }).then((data) => {
-            expect(data).to.eql({ some: 'other data', provider: 'provider' });
+        it('returns a promise that resolves with the session data merged with the data fetched from torri', function() {
+          return authenticator.restore({ some: 'data', provider: 'provider', another: 'prop' }).then((data) => {
+            expect(data).to.eql({ some: 'other data', provider: 'provider', another: 'prop' });
           });
         });
       });


### PR DESCRIPTION
I think I've found a small bug in `authenticator:torii`. It seems that on `restore`, session data (possibly resolved by extra functionality in `authenticate`) is being clobbered by the data returned from `this.get('torii').fetch()`.

I've updated a test with some generic data to demonstrate a failing result and including a fix that simply merges the `sessionData` passed into `restore` with the data returned from the `.fetch()` call.

Let me know if I'm missing something here, or if you'd like anything changed/updated.
