### PR TITLE
Improve implicit grant authenticator to accept hash as string

### DIFF
--- a/addon/authenticators/oauth2-implicit-grant.js
+++ b/addon/authenticators/oauth2-implicit-grant.js
@@ -47,11 +47,13 @@ export default BaseAuthenticator.extend({
    (see https://tools.ietf.org/html/rfc6749#section-4.2.2.1).
 
    @method authenticate
-   @param {Object} hash The location hash
+   @param {Object} hash The location hash: object or a string
    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
    @public
    */
   authenticate(hash) {
+    hash = typeof hash === 'string' ? this._parseLocationHash(hash) : hash;
+
     return new RSVP.Promise((resolve, reject) => {
       if (hash.error) {
         reject(hash.error);
@@ -81,5 +83,18 @@ export default BaseAuthenticator.extend({
     return !isEmpty(data) &&
       !isEmpty(data.access_token);
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+  },
+
+  _parseLocationHash(hash) {
+    if (hash.length < 1) {
+      return {};
+    }
+
+    const hashString = hash.charAt(0) === '#' ? hash.substr(1) : hash;
+
+    return hashString
+      .split('&')
+      .map(el => el.split('='))
+      .reduce((pre, cur) => { pre[cur[0]] = cur[1]; return pre; }, {});
   }
 });

--- a/tests/unit/authenticators/oauth2-implicit-grant-test.js
+++ b/tests/unit/authenticators/oauth2-implicit-grant-test.js
@@ -12,6 +12,8 @@ describe('OAuth2ImplicitGrantAuthenticator', () => {
     'access_token': 'secret-token'
   };
 
+  let dataString = 'access_token=secret-token';
+
   beforeEach(function() {
     authenticator = OAuth2ImplicitGrant.create();
   });
@@ -55,6 +57,20 @@ describe('OAuth2ImplicitGrantAuthenticator', () => {
       it('rejects with that error', function() {
         return authenticator.authenticate({ error: 'access_denied' }).catch((_err) => {
           expect(_err).to.eql('access_denied');
+        });
+      });
+    });
+
+    describe('when the data is passed in as a string', function() {
+      it('parses the data into object', function() {
+        return authenticator.authenticate(dataString).then((_data) => {
+          expect(_data).to.eql(data);
+        });
+      });
+
+      it('ignores the # character', function() {
+        return authenticator.authenticate(`#${dataString}`).then((_data) => {
+          expect(_data).to.eql(data);
         });
       });
     });


### PR DESCRIPTION
OAuth2ImplicitGrantAuthenticator now accepts the location hash
either as an object or as a string.

When the string is passed in:

- The leading "#" character is removed if present.
- The string is parsed into an object.
- The rest of the flow works normally.

## Explanation

**TL;DR:** `authenticate` call will now accept either an object with access_token or a string with access_token encoded as GET parameters, which will definitely make my life easier - as a user if this library.

I'm building an Ember application that does not have its own backend, it only uses the external API and authenticates to that API via OAuth2, using "implicit grant" strategy.

The typical OAuth2 workflow uses token authentication, which goes like this (roughly):

1. Client app redirects user to the auth provider.
1. Auth provider redirects the user back with `authentication_code`.
1. Client app passes the received `authentication_code` to its backend.
1. Backend makes an API call to auth provider to exchange the `authentication_code` for `authentication_token`.
1. Backend stores the auth token and uses it for subsequent external API calls.

Since my app does not have a backend, there is no need to exchange `authentication_code` for the `authentication_token`, instead I can get the `authentication_token` from auth provider directly, so I use "implicit grant" strategy. However, in it the `authentication_token` is returned as a "location hash" parameter, which you can get by calling `window.location.hash`. This returns a string, which you're responsible for parsing. **Now the implicit grant authenticator will do it for you.**
