### PR TITLE
reject _refreshAccessToken with response

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -371,7 +371,7 @@ export default BaseAuthenticator.extend({
         });
       }, (response) => {
         warn(`Access token could not be refreshed - server responded with ${response.responseJSON}.`, false, { id: 'ember-simple-auth.failedOAuth2TokenRefresh' });
-        reject();
+        reject(response);
       });
     });
   },


### PR DESCRIPTION
_refreshAccessToken rejection should return something. Then you can implement your own actions for situations when refresh is rejected due lack of internet connectivity or when refresh is rejected by server answering error (ie. token expired).

I really cannot see any reason why response shouldn't be returned by reject :)