### PR TITLE
Update DataAdapterMixin docs

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -64,8 +64,9 @@ export default Mixin.create({
     specific header name and contents depend on the actual authorizer that is
     used.
 
-    This method applies for Ember Data 2.6 and older. See `headersForRequest`
-    for newer versions of Ember Data.
+    Until [emberjs/rfcs#171](https://github.com/emberjs/rfcs/pull/171)
+    gets resolved, this method will be called for **every** ember-data version.
+    `headersForRequest` *should* replace it after the resolution of the RFC.
 
     @method ajaxOptions
     @protected
@@ -92,8 +93,9 @@ export default Mixin.create({
     Adds request headers containing the authorization data as constructed
     by the {{#crossLink "DataAdapterMixin/authorizer:property"}}{{/crossLink}}.
 
-    This method will only be called in Ember Data 2.7 or greater. Older versions
-    will rely on `ajaxOptions` for request header injection.
+    Until [emberjs/rfcs#171](https://github.com/emberjs/rfcs/pull/171)
+    gets resolved, this method will **not** be used.
+    See `ajaxOptions` instead.
 
     @method headersForRequest
     @protected

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -65,7 +65,9 @@ export default Mixin.create({
     used.
 
     Until [emberjs/rfcs#171](https://github.com/emberjs/rfcs/pull/171)
-    gets resolved, this method will be called for **every** ember-data version.
+    gets resolved and [ds-improved-ajax](https://github.com/emberjs/data/pull/3099)
+    [feature flag](https://github.com/emberjs/data/blob/master/FEATURES.md#feature-flags)
+    is enabled, this method will be called for **every** ember-data version.
     `headersForRequest` *should* replace it after the resolution of the RFC.
 
     @method ajaxOptions
@@ -94,7 +96,9 @@ export default Mixin.create({
     by the {{#crossLink "DataAdapterMixin/authorizer:property"}}{{/crossLink}}.
 
     Until [emberjs/rfcs#171](https://github.com/emberjs/rfcs/pull/171)
-    gets resolved, this method will **not** be used.
+    gets resolved and [ds-improved-ajax](https://github.com/emberjs/data/pull/3099)
+    [feature flag](https://github.com/emberjs/data/blob/master/FEATURES.md#feature-flags)
+    is enabled, this method will **not** be used.
     See `ajaxOptions` instead.
 
     @method headersForRequest


### PR DESCRIPTION
Fix incorrect docs about headersForRequest being used for ember-data versions >= 2.7.
This is on hold until emberjs/rfcs#171 gets resolved

replaces #1297 by @bartocc 