### PR TITLE
Improve OAuth2 implicit grant authenticator documentation

### DIFF
--- a/addon/authenticators/oauth2-implicit-grant.js
+++ b/addon/authenticators/oauth2-implicit-grant.js
@@ -11,6 +11,10 @@ const {
  ([RFC 6749](http://tools.ietf.org/html/rfc6749)), specifically the _"Implicit
  Grant Type"_.
 
+ Use {{#crossLink "OAuth2ImplicitGrantCallbackMixin"}}{{/crossLink}} in your
+ OAuth 2.0 redirect route to parse authentication parameters from location
+ hash string into an object.
+
  @class OAuth2ImplicitGrantAuthenticator
  @module ember-simple-auth/authenticators/oauth2-implicit-grant
  @extends BaseAuthenticator

--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -5,7 +5,7 @@ const { inject: { service }, Mixin, computed, getOwner } = Ember;
 /**
   __This mixin is used in the callback route when using OAuth 2.0 Implicit
   Grant authentication.__ It implements the
-  {{#chrossLink "OAuth2ImplicitGrantCallbackRouteMixin/activate:method"}}{{/crossLink}}
+  {{#crossLink "OAuth2ImplicitGrantCallbackMixin/activate:method"}}{{/crossLink}}
   method that retrieves and processes authentication parameters, such as
   `access_token`, from the hash parameters provided in the callback URL by
   the authentication server. The parameters are then passed to the


### PR DESCRIPTION
This PR adds a hint about `OAuth2ImplicitGrantCallbackMixin` to the `OAuth2ImplicitGrantAuthenticator` documentation: to suggest built-in location string parsing.

Also it fixes a typo.

This is continuation of https://github.com/simplabs/ember-simple-auth/pull/1353