### PR TITLE
Update README link for Pre-1.0 Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ authorization mechanisms__.
 
 **Other Resources**
 
-* [Upgrading from Pre-1.0 versions](http://log.simplabs.com/post/131698328145/updating-to-ember-simple-auth-10)
+* [Upgrading from Pre-1.0 versions](https://simplabs.com/blog/2015/11/27/updating-to-ember-simple-auth-1.0.html)
 * [API Documentation](http://ember-simple-auth.com/api/)
 
 ## What does it do?


### PR DESCRIPTION
Change `Upgrading from Pre-1.0 versions` to point to https://simplabs.com/blog/2015/11/27/updating-to-ember-simple-auth-1.0.html.

The current link doesn't seem to link to correct post.
