### PR TITLE
cleanup session stores tests

### DIFF
--- a/tests/unit/session-stores/cookie-test.js
+++ b/tests/unit/session-stores/cookie-test.js
@@ -1,4 +1,4 @@
-import { describe, beforeEach, afterEach } from 'mocha';
+import { describe, beforeEach } from 'mocha';
 import sinon from 'sinon';
 import Cookie from 'ember-simple-auth/session-stores/cookie';
 import itBehavesLikeAStore from './shared/store-behavior';
@@ -16,10 +16,6 @@ describe('CookieStore', () => {
 
   beforeEach(function() {
     store = createCookieStore(FakeCookieService.create());
-  });
-
-  afterEach(function() {
-    store.clear();
   });
 
   itBehavesLikeAStore({

--- a/tests/unit/session-stores/ephemeral-test.js
+++ b/tests/unit/session-stores/ephemeral-test.js
@@ -1,17 +1,11 @@
-import { describe, beforeEach } from 'mocha';
+import { describe } from 'mocha';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 import itBehavesLikeAStore from './shared/store-behavior';
 
-describe('EphemeralStore', () => {
-  let store;
-
-  beforeEach(function() {
-    store = Ephemeral.create();
-  });
-
+describe('EphemeralStore', function() {
   itBehavesLikeAStore({
     store() {
-      return store;
+      return Ephemeral.create();
     }
   });
 });

--- a/tests/unit/session-stores/local-storage-test.js
+++ b/tests/unit/session-stores/local-storage-test.js
@@ -1,23 +1,13 @@
-import { describe, beforeEach, afterEach } from 'mocha';
+import { describe } from 'mocha';
 import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
 import itBehavesLikeAStore from './shared/store-behavior';
 
-describe('LocalStorageStore', () => {
-  let store;
-
-  beforeEach(function() {
-    store = LocalStorage.create({
-      _isFastBoot: false
-    });
-  });
-
-  afterEach(function() {
-    store.clear();
-  });
-
+describe('LocalStorageStore', function() {
   itBehavesLikeAStore({
     store() {
-      return store;
+      return LocalStorage.create({
+        _isFastBoot: false
+      });
     }
   });
 });

--- a/tests/unit/session-stores/session-storage-test.js
+++ b/tests/unit/session-stores/session-storage-test.js
@@ -1,23 +1,13 @@
-import { describe, beforeEach, afterEach } from 'mocha';
+import { describe } from 'mocha';
 import SessionStorage from 'ember-simple-auth/session-stores/session-storage';
 import itBehavesLikeAStore from './shared/store-behavior';
 
-describe('SessionStorageStore', () => {
-  let store;
-
-  beforeEach(function() {
-    store = SessionStorage.create({
-      _isFastBoot: false
-    });
-  });
-
-  afterEach(function() {
-    store.clear();
-  });
-
+describe('SessionStorageStore', function() {
   itBehavesLikeAStore({
     store() {
-      return store;
+      return SessionStorage.create({
+        _isFastBoot: false
+      });
     }
   });
 });

--- a/tests/unit/session-stores/shared/store-behavior.js
+++ b/tests/unit/session-stores/shared/store-behavior.js
@@ -15,6 +15,11 @@ export default function(options) {
     store = options.store();
   });
 
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  afterEach(function() {
+    store.clear();
+  });
+
   describe('#persist', function() {
     it('persists an object', function() {
       return store.persist({ key: 'value' }).then(() => {


### PR DESCRIPTION
This cleans up the session store tests a bit by removing unused code and making sure the shared behaviors use a fresh store instance for each example.