### PR TITLE
fix link to upgrade-to-1.0 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ember install ember-simple-auth
 ```
 
 ### Upgrading from ember-cli-simple-auth / pre-1.0 release?
-The 1.0 release of ember-simple-auth introduced a lot of breaking changes, but thankfully [the upgrade path isn't too hard](http://log.simplabs.com/post/131698328145/updating-to-ember-simple-auth-10).
+The 1.0 release of ember-simple-auth introduced a lot of breaking changes, but thankfully [the upgrade path isn't too hard](https://simplabs.com/blog/2015/11/27/updating-to-ember-simple-auth-1.0.html).
 
 ## Walkthrough
 


### PR DESCRIPTION
The link in the ToC was correct but we were still linking to the old domain from the text.