### PR TITLE
fix secure token for zeit.co

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   chrome: stable
 
 env:
+  secure: IVCX1o8nMAKAKxj2cXE6a2A8xmnt3Gj72ocyjT1vhZutEJ1z7wu3Xl/r6Q0fhlaux3+ZNz/KV6Lax6NW8KgC/Wo1+B5SF2RWMLGX+exglf5zUXT3wzaOq8LcEyQ7SGfsuovHa8ij3dMM4UWjl5lE3cM1M1KjxlekniUF9nFxZd4=
   matrix:
     - SCRIPT=test:all
     - SCRIPT=test:fastboot
@@ -49,7 +50,3 @@ notifications:
   slack:
     rooms:
       secure: OOKD4ZksqzEBW/A3WRuOToODIxnDITqx+Esu7tdmmYPuQlMYgx4SUHv8j9OM9/ScFJiseeVGSkl45vJrHLLIITX9XSjO1RgiGZgw2heVujmGpF6CZNqvT6GsQuKIvMzmwF7IxuHdfV45Csr9Ou/Fg74TszR/4S2h4SOI4zhLg7A=
-
-env:
-  now:
-    secure: CTqDGGwSMS1j96bnoCldK/QDiLaPR2xwhSjZtmSM2/jBOrkh7uTh9HIw14dIpEXg4hKVvPBrZQ2igDsT+qktXzzrai7NO2cl8C0CfLRBSSZhDGlTb0IbcoREU6UORRHX6PwfwpMpIobvh1MRDSuOYaDh1jnTI3BKqwro3uhMO7g=


### PR DESCRIPTION
This fixes the way we define the secure token for zeit.co in the `.travis.yml` - see broken build here: https://travis-ci.org/simplabs/ember-simple-auth/builds/257805306