### PR TITLE
Revert "New Module Imports" in "app" folder

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,4 +1,6 @@
-import Route from '@ember/routing/route';
+import Ember from 'ember';
+
+const { Route } = Ember;
 
 // Ensure the application route exists for ember-simple-auth's `setup-session-restoration` initializer
 export default Route.extend();


### PR DESCRIPTION
proper solution is to just reexport stuff in the `app` folder and have the real code in the `addon` folder, but reverting that part should be enough for now.