### PR TITLE
Fix JSON parsing exception in password grant authentication response

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -248,7 +248,7 @@ export default BaseAuthenticator.extend({
           resolve(response);
         });
       }, (response) => {
-        run(null, reject, useResponse ? response : response.responseJSON);
+        run(null, reject, useResponse ? response : (response.responseJSON || response.responseText));
       });
     });
   },
@@ -325,12 +325,17 @@ export default BaseAuthenticator.extend({
     return new RSVP.Promise((resolve, reject) => {
       fetch(url, options).then((response) => {
         response.text().then((text) => {
-          let json = text ? JSON.parse(text) : {};
+          try {
+            response.responseJSON = text ? JSON.parse(text) : {};
+          } catch (SyntaxError) {
+            response.responseText = text;
+            reject(response);
+          }
+
           if (!response.ok) {
-            response.responseJSON = json;
             reject(response);
           } else {
-            resolve(json);
+            resolve(response.responseJSON);
           }
         });
       }).catch(reject);

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -184,12 +184,22 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         });
       });
 
-      describe('when the server returns incomplete data', function() {
-        it('fails when no access_token is present', function() {
+      describe('when the server response is missing access_token', function() {
+        it('fails with a string describing the issue', function() {
           server.post('/token', () => [200, { 'Content-Type': 'application/json' }, '{}']);
 
           return authenticator.authenticate('username', 'password').catch((error) => {
             expect(error).to.eql('access_token is missing in server response');
+          });
+        });
+      });
+
+      describe('but the response is not valid JSON', function() {
+        it('fails with the string of the response', function() {
+          server.post('/token', () => [200, { 'Content-Type': 'text/plain' }, 'Something went wrong']);
+
+          return authenticator.authenticate('username', 'password').catch((error) => {
+            expect(error).to.eql('Something went wrong');
           });
         });
       });


### PR DESCRIPTION
When the server responds with something unexpected, the authenticator was failing with an exception and actually rejecting with `null` if `rejectWithResponse` was disabled (the terrible default).

With this change, if the body cannot be parsed as JSON, it's stored as `responseText` in the response object. With `rejectWithResponse` disabled, the rejection contains the text of the response. With `rejectWithResponse` enabled, the response object in the rejection contains `responseText` and `responseJSON` is left undefined.

Failure to parse the response as JSON is also considered a failure, and the promise will be rejected in that case as well, containing the body of the server response. I don't love this behavior, but since `rejectWithResponse` is false by default, this seems to be the only way to be consistent. If `rejectWithResponse` is true, the response of course contains more detail.

This solves #1443 and #1439.