### PR TITLE
Fix SyntaxError from `ember build`

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -5,7 +5,7 @@ import { later, cancel, scheduleOnce, next } from '@ember/runloop';
 import { isPresent, typeOf, isEmpty } from '@ember/utils';
 import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
-import { warn } from '@ember/debug';
+import { warn as debugWarn } from '@ember/debug';
 import Ember from 'ember';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
@@ -293,6 +293,6 @@ export default BaseStore.extend({
   },
 
   _warn() {
-    warn(...arguments);
+    debugWarn(...arguments);
   }
 });


### PR DESCRIPTION
Fixes #1443.

The issue here is that `warn` is an [ember-cli-babel](https://github.com/chadhietala/babel-plugin-debug-macros#warn-macro-expansion) macro. The function that was imported had the same name. By renaming the local function, the macro no longer affects the function call.