### PR TITLE
Clear cached time when setting expiration to null

### DIFF
--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -1,6 +1,5 @@
 /* global localStorage */
 import { computed } from '@ember/object';
-
 import { inject as service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import Base from 'ember-simple-auth/session-stores/base';
@@ -142,7 +141,8 @@ export default Base.extend({
   },
 
   _createStore(storeType, options) {
-    const store = storeType.create(options);
+    let owner = getOwner(this);
+    const store = storeType.create(owner.ownerInjection(), options);
 
     store.on('sessionDataUpdated', (data) => {
       this.trigger('sessionDataUpdated', data);

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -120,7 +120,13 @@ export default BaseStore.extend({
   */
   _cookieExpirationTime: null,
   cookieExpirationTime: persistingProperty(function(key, value) {
-    if (value < 90) {
+    // When nulling expiry time on purpose, we need to clear the cached value.
+    // Otherwise, `_calculateExpirationTime` will reuse it.
+    if (this.get('_cookies') && value === null) {
+      this.get('_cookies').clear(`${this.get('cookieName')}-expiration_time`);
+    }
+
+    if (value < 90 && value !== null) {
       this._warn('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).', false, { id: 'ember-simple-auth.cookieExpirationTime' });
     }
   }),

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -2,7 +2,7 @@ import RSVP from 'rsvp';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { later, cancel, scheduleOnce, next } from '@ember/runloop';
-import { isPresent, typeOf, isEmpty } from '@ember/utils';
+import { isPresent, typeOf, isEmpty, isNone } from '@ember/utils';
 import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
 import { warn } from '@ember/debug';
@@ -122,7 +122,7 @@ export default BaseStore.extend({
   cookieExpirationTime: persistingProperty(function(key, value) {
     // When nulling expiry time on purpose, we need to clear the cached value.
     // Otherwise, `_calculateExpirationTime` will reuse it.
-    if (value === null) {
+    if (isNone(value)) {
       this.get('_cookies').clear(`${this.get('cookieName')}-expiration_time`);
     } else if (value < 90) {
       this._warn('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).', false, { id: 'ember-simple-auth.cookieExpirationTime' });

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -122,11 +122,9 @@ export default BaseStore.extend({
   cookieExpirationTime: persistingProperty(function(key, value) {
     // When nulling expiry time on purpose, we need to clear the cached value.
     // Otherwise, `_calculateExpirationTime` will reuse it.
-    if (this.get('_cookies') && value === null) {
+    if (value === null) {
       this.get('_cookies').clear(`${this.get('cookieName')}-expiration_time`);
-    }
-
-    if (value < 90 && value !== null) {
+    } else if (value < 90) {
       this._warn('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).', false, { id: 'ember-simple-auth.cookieExpirationTime' });
     }
   }),

--- a/tests/helpers/create-adaptive-store.js
+++ b/tests/helpers/create-adaptive-store.js
@@ -1,21 +1,25 @@
 import Adaptive from 'ember-simple-auth/session-stores/adaptive';
 import createCookieStore from './create-cookie-store';
+import { merge, assign as emberAssign } from '@ember/polyfills';
 
-export default function createAdaptiveStore(cookiesService, options = {}) {
-  options._cookies = cookiesService;
-  options._fastboot = { isFastBoot: false };
-  options._isLocalStorageAvailable = false;
-  options._isFastboot = false;
+const assign = emberAssign || merge;
 
-  let cookieStore = createCookieStore(cookiesService, options);
+export default function createAdaptiveStore(
+  cookiesService,
+  options = {},
+  props = {}
+) {
+  let cookieStore = createCookieStore(
+    cookiesService,
+    assign({}, options, { _isFastboot: false })
+  );
+  props._createStore = function() {
+    cookieStore.on('sessionDataUpdated', data => {
+      this.trigger('sessionDataUpdated', data);
+    });
 
-  return Adaptive.extend({
-    _createStore() {
-      cookieStore.on('sessionDataUpdated', (data) => {
-        this.trigger('sessionDataUpdated', data);
-      });
+    return cookieStore;
+  };
 
-      return cookieStore;
-    }
-  }).create(options);
+  return Adaptive.extend(props).create(options);
 }

--- a/tests/helpers/create-adaptive-store.js
+++ b/tests/helpers/create-adaptive-store.js
@@ -5,6 +5,7 @@ export default function createAdaptiveStore(cookiesService, options = {}) {
   options._cookies = cookiesService;
   options._fastboot = { isFastBoot: false };
   options._isLocalStorageAvailable = false;
+  options._isFastboot = false;
 
   let cookieStore = createCookieStore(cookiesService, options);
 

--- a/tests/helpers/create-adaptive-store.js
+++ b/tests/helpers/create-adaptive-store.js
@@ -1,0 +1,20 @@
+import Adaptive from 'ember-simple-auth/session-stores/adaptive';
+import createCookieStore from './create-cookie-store';
+
+export default function createAdaptiveStore(cookiesService, options = {}) {
+  options._cookies = cookiesService;
+  options._fastboot = { isFastBoot: false };
+  options._isLocalStorageAvailable = false;
+
+  let cookieStore = createCookieStore(cookiesService, options);
+
+  return Adaptive.extend({
+    _createStore() {
+      cookieStore.on('sessionDataUpdated', (data) => {
+        this.trigger('sessionDataUpdated', data);
+      });
+
+      return cookieStore;
+    }
+  }).create(options);
+}

--- a/tests/helpers/create-cookie-store.js
+++ b/tests/helpers/create-cookie-store.js
@@ -1,0 +1,7 @@
+import Cookie from 'ember-simple-auth/session-stores/cookie';
+
+export default function createCookieStore(cookiesService, options = {}) {
+  options._cookies = cookiesService;
+  options._fastboot = { isFastBoot: false };
+  return Cookie.create(options);
+}

--- a/tests/unit/session-stores/adaptive-test.js
+++ b/tests/unit/session-stores/adaptive-test.js
@@ -1,4 +1,3 @@
-import { merge, assign as emberAssign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 import {
   describe,
@@ -9,12 +8,11 @@ import {
 import { expect } from 'chai';
 import sinon from 'sinon';
 import Adaptive from 'ember-simple-auth/session-stores/adaptive';
+import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import createAdaptiveStore from '../../helpers/create-adaptive-store';
-
-const assign = emberAssign || merge;
 
 describe('AdaptiveStore', () => {
   let store;
@@ -27,7 +25,7 @@ describe('AdaptiveStore', () => {
     beforeEach(function() {
       store = Adaptive.extend({
         _createStore(storeType, options) {
-          return this._super(storeType, assign(options, { _isFastBoot: false }));
+          return LocalStorage.create({ _isFastBoot: false }, options);
         }
       }).create({
         _isLocalStorageAvailable: true

--- a/tests/unit/session-stores/adaptive-test.js
+++ b/tests/unit/session-stores/adaptive-test.js
@@ -47,7 +47,10 @@ describe('AdaptiveStore', () => {
       cookieService = FakeCookieService.create();
       sinon.spy(cookieService, 'read');
       sinon.spy(cookieService, 'write');
-      store = createAdaptiveStore(cookieService);
+      store = createAdaptiveStore(cookieService, {
+        _isLocal: false,
+        _cookies: cookieService,
+      });
     });
 
     itBehavesLikeAStore({
@@ -57,8 +60,12 @@ describe('AdaptiveStore', () => {
     });
 
     itBehavesLikeACookieStore({
-      createStore(cookieService, options) {
-        return createAdaptiveStore(cookieService, options);
+      createStore(cookieService, options = {}) {
+        options._isLocalStorageAvailable = false;
+        return createAdaptiveStore(cookieService, options, {
+          _cookies: cookieService,
+          _fastboot: { isFastBoot: false },
+        });
       },
       renew(store, data) {
         return store.get('_store')._renew(data);

--- a/tests/unit/session-stores/adaptive-test.js
+++ b/tests/unit/session-stores/adaptive-test.js
@@ -12,6 +12,7 @@ import Adaptive from 'ember-simple-auth/session-stores/adaptive';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
+import createAdaptiveStore from '../../helpers/create-adaptive-store';
 
 const assign = emberAssign || merge;
 
@@ -46,14 +47,7 @@ describe('AdaptiveStore', () => {
       cookieService = FakeCookieService.create();
       sinon.spy(cookieService, 'read');
       sinon.spy(cookieService, 'write');
-      store = Adaptive.extend({
-        _createStore(storeType, options) {
-          return this._super(storeType, assign({}, options, { _isFastBoot: false }));
-        }
-      }).create({
-        _isLocalStorageAvailable: false,
-        _cookies: cookieService
-      });
+      store = createAdaptiveStore(cookieService);
     });
 
     itBehavesLikeAStore({
@@ -63,15 +57,8 @@ describe('AdaptiveStore', () => {
     });
 
     itBehavesLikeACookieStore({
-      createStore(cookieService, options = {}) {
-        options._isLocalStorageAvailable = false;
-        return Adaptive.extend({
-          _cookies: cookieService,
-          _fastboot: { isFastBoot: false },
-          _createStore(storeType, options) {
-            return this._super(storeType, assign({}, options, { _isFastBoot: false }));
-          }
-        }).create(options);
+      createStore(cookieService, options) {
+        return createAdaptiveStore(cookieService, options);
       },
       renew(store, data) {
         return store.get('_store')._renew(data);

--- a/tests/unit/session-stores/cookie-test.js
+++ b/tests/unit/session-stores/cookie-test.js
@@ -1,15 +1,9 @@
 import { describe, beforeEach } from 'mocha';
 import sinon from 'sinon';
-import Cookie from 'ember-simple-auth/session-stores/cookie';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
-
-function createCookieStore(cookiesService, options = {}) {
-  options._cookies = cookiesService;
-  options._fastboot = { isFastBoot: false };
-  return Cookie.create(options);
-}
+import createCookieStore from '../../helpers/create-cookie-store';
 
 describe('CookieStore', () => {
   let store;

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -285,12 +285,11 @@ export default function(options) {
     });
 
     it('clears cached expiration times when setting expiration to null', function() {
-      let defaultName = 'ember_simple_auth-session';
       run(() => {
         store.set('cookieExpirationTime', null);
       });
 
-      expect(cookieService.clear).to.have.been.calledWith(`${defaultName}-expiration_time`);
+      expect(cookieService.clear).to.have.been.calledWith(`session-foo-expiration_time`);
     });
 
     it('only rewrites the cookie once per run loop when multiple properties are changed', function(done) {

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -284,6 +284,15 @@ export default function(options) {
       );
     });
 
+    it('clears cached expiration times when setting expiration to null', function() {
+      let defaultName = 'ember_simple_auth-session';
+      run(() => {
+        store.set('cookieExpirationTime', null);
+      });
+
+      expect(cookieService.clear).to.have.been.calledWith(`${defaultName}-expiration_time`);
+    });
+
     it('only rewrites the cookie once per run loop when multiple properties are changed', function(done) {
       run(() => {
         store.set('cookieName', 'session-bar');


### PR DESCRIPTION
@marcoow the issue is that `calculateExpirationTime` always uses the cached expiration time if there is one. 

I've decided to clear the cache when user nulls expiration time, however we get `Error: Assertion Failed: Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`. Thoughts?

#854