### PR TITLE
Exclude /fastboot-tests from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,9 @@
 /node-tests
 /tmp
 /fastboot-dist
+/fastboot-tests
+/docs
+/guides
 **/.gitkeep
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Don't know about `/tests`, they seem to be included intentionally?

Also was unsure about `docs`, `guides` and `server`, which are all published, does that make sense?