### PR TITLE
correctly remove localStorage event handler

### DIFF
--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -46,14 +46,15 @@ export default BaseStore.extend({
   init() {
     this._super(...arguments);
 
+    this._boundHandler = bind(this, this._handleStorageEvent);
     if (!this.get('_isFastBoot')) {
-      window.addEventListener('storage', bind(this, this._handleStorageEvent));
+      window.addEventListener('storage', this._boundHandler);
     }
   },
 
   willDestroy() {
     if (!this.get('_isFastBoot')) {
-      window.removeEventListener('storage', bind(this, this._handleStorageEvent));
+      window.removeEventListener('storage', this._boundHandler);
     }
   },
 


### PR DESCRIPTION
This passes the exact same function to both `window.addEventListener('storage', …` and `window.removeEventListener('storage', …` so that the handler is correctly cleaned up.

closes #1471 