### PR TITLE
session-stores/cookie: Inline `_warn()` method

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -125,7 +125,7 @@ export default BaseStore.extend({
     if (isNone(value)) {
       this.get('_cookies').clear(`${this.get('cookieName')}-expiration_time`);
     } else if (value < 90) {
-      this._warn('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).', false, { id: 'ember-simple-auth.cookieExpirationTime' });
+      warn('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).', false, { id: 'ember-simple-auth.cookieExpirationTime' });
     }
   }),
 
@@ -293,8 +293,4 @@ export default BaseStore.extend({
       this._write(data, expiration);
     }
   },
-
-  _warn() {
-    warn(...arguments);
-  }
 });

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^2.0.0",
     "ember-data": "^2.14.4",
+    "ember-debug-handlers-polyfill": "^1.1.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-fastboot-addon-tests": "^0.4.0",

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { next, run } from '@ember/runloop';
 import {
   describe,
@@ -8,7 +9,6 @@ import {
 import { expect } from 'chai';
 import sinon from 'sinon';
 import FakeCookieService from '../../../helpers/fake-cookie-service';
-import CookieSessionStore from 'ember-simple-auth/session-stores/cookie';
 
 export default function(options) {
   let store;
@@ -39,11 +39,12 @@ export default function(options) {
 
   describe('#persist', function() {
     beforeEach(function() {
-      sinon.spy(CookieSessionStore.prototype, '_warn');
+      sinon.spy(Ember, 'warn');
     });
 
     afterEach(function() {
-      CookieSessionStore.prototype._warn.restore();
+      // eslint-disable-next-line ember/local-modules
+      Ember.warn.restore();
     });
 
     it('respects the configured cookieName', function() {
@@ -103,7 +104,7 @@ export default function(options) {
           cookieExpirationTime: 60
         });
 
-        expect(CookieSessionStore.prototype._warn).to.have.been.calledWith('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).');
+        expect(Ember.warn).to.have.been.calledWith('The recommended minimum value for `cookieExpirationTime` is 90 seconds. If your value is less than that, the cookie may expire before its expiration time is extended (expiration time is extended every 60 seconds).');
 
         done();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,6 +2883,10 @@ ember-data@^2.14.4:
     silent-error "^1.0.0"
     testem "1.15.0"
 
+ember-debug-handlers-polyfill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.0.tgz#c293cf10e3a3872d9ee97799a7be4cfe599d359e"
+
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.2.tgz#261cccaf6bf8fbb1836be7bdfe4278f9ab92b873"


### PR DESCRIPTION
`warn(...arguments)` unfortunately can't be used like this at the moment since `...arguments` won't be transpiled properly.

see https://github.com/chadhietala/babel-plugin-debug-macros/issues/47

Obviously it would be best if this issue was fixed in `babel-plugin-debug-macros` directly, but until then we should avoid using rest/spread with the `warn()` macro.

Resolves https://github.com/simplabs/ember-simple-auth/issues/1496