### PR TITLE
require sudo for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:


### PR DESCRIPTION
see https://github.com/simplabs/ember-cookies/pull/150, https://github.com/travis-ci/travis-ci/issues/8836

This is not great but as far as I know the only way to get builds with Headless Chrome working again currently…