### PR TITLE
[BUGFIX]: Subscribing to session events in activate, not init

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -74,7 +74,7 @@ export default Mixin.create({
     return Configuration.routeAfterAuthentication;
   }),
 
-  init() {
+  activate() {
     this._super(...arguments);
     this._subscribeToSessionEvents();
   },

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -36,6 +36,7 @@ describe('ApplicationRouteMixin', () => {
     beforeEach(function() {
       sinon.spy(route, 'sessionAuthenticated');
       sinon.spy(route, 'sessionInvalidated');
+      route.activate();
     });
 
     it("maps the services's 'authenticationSucceeded' event into a method call", function(done) {


### PR DESCRIPTION
Closes https://github.com/simplabs/ember-simple-auth/issues/1539

**/cc** @marcoow  @0xadada 

I applied the fix to my addon and it worked :+1: 
https://github.com/alexander-alvarez/ember-cli-qunit-service-registering/compare/test-case-failing

Let me know if there are other test cases we can introduce into this repository