### PR TITLE
[FEATURE] Introduce 'setupSessionTest' test-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ case, helpers can be imported from the `ember-simple-auth` addon namespace.
 
 ```js
 // tests/acceptance/…
-import { currentSession, authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
+import { currentSession, authenticateSession, invalidateSession, setupSessionTest} from 'ember-simple-auth/test-support';
 ```
 
 The new-style helpers have the following function signatures:
@@ -667,6 +667,7 @@ The new-style helpers have the following function signatures:
   the optional `sessionData` argument can be used to mock an authenticator
   response (e.g. a token or user).
 * `invalidateSession()` invalidates the session asynchronously.
+* `setupSessionTest(hooks)` prepares the test context to use sessions.
 
 New tests using the async `authenticateSession` helper will look like this:
 
@@ -686,6 +687,28 @@ module('Acceptance | super secret url', function(hooks) {
     });
     await visit('/super-secret-url');
     assert.equal(currentURL(), '/super-secret-url', 'user is on super-secret-url');
+  });
+});
+```
+
+If you want to leverage the test helpers outside of ApplicationTests, use the provided `setupSessionTest` function.
+```js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from 'ember-test-helpers';
+import { authenticateSession , setupSessionTest} from 'ember-simple-auth/test-support';
+
+module('my-component test', function(hooks) {
+  setupRenderingTest(hooks); // could also be `setupTest`
+  setupSessionTest(hooks);
+
+  test('my-component shows logged in text', async function(assert) {
+    await authenticateSession({
+      userId: 1,
+      otherData: 'some-data'
+    });
+    await render('{{my-component}}');
+    assert.equal(this.element.innerHTML, 'User 1 is logged in', 'user is logged in');
   });
 });
 ```

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -2,6 +2,8 @@ import { get } from '@ember/object';
 import { getContext, settled } from '@ember/test-helpers';
 import Promise from 'rsvp';
 import Test from 'ember-simple-auth/authenticators/test';
+import setupSession from 'ember-simple-auth/initializers/setup-session';
+import setupSessionService from 'ember-simple-auth/initializers/setup-session-service';
 
 const SESSION_SERVICE_KEY = 'service:session';
 const TEST_CONTAINER_KEY = 'authenticator:test';
@@ -24,7 +26,10 @@ function ensureAuthenticator(owner) {
 export function authenticateSession(sessionData) {
   const { owner } = getContext();
   const session = owner.lookup(SESSION_SERVICE_KEY);
-  owner.setupRouter(); // router must initialize fully before authentication
+  // router must initialize fully before authentication in application tests cases
+  if (owner.setupRouter) {
+    owner.setupRouter();
+  }
   ensureAuthenticator(owner);
   return session.authenticate(TEST_CONTAINER_KEY, sessionData).then(() => {
     return settled();
@@ -58,4 +63,17 @@ export function invalidateSession() {
     }
   })
     .then(() => settled());
+}
+
+/**
+ * Runs the session initializers to setup a session test.
+ * This is useful for using sessions in non ApplicationTest contexts.
+ *
+ * @public
+ */
+export function setupSessionTest(hooks) {
+  hooks.beforeEach(function() {
+    setupSession(this.owner);
+    setupSessionService(this.owner);
+  });
 }


### PR DESCRIPTION
In response to https://github.com/simplabs/ember-simple-auth/issues/1543, this PR improves `authenticateSession` so it can be used outside of `ApplicationTest` contexts.

Also adds a new `setupSessionTest` helper, so that we can use all helpers in any context that has a properly setup owner (e.g. `setupTest`, `setupRenderingTest`), not just `ApplicationTests`.
