### PR TITLE
ember-try: Use `useYarn` flag

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   command: 'yarn test',
   scenarios: [
     {


### PR DESCRIPTION
Otherwise `ember-try` (or rather `node_modules`) can end up in an inconsistent state.