### PR TITLE
add empty "ember-simple-auth! instance initializer

### DIFF
--- a/app/instance-initializers/ember-simple-auth.js
+++ b/app/instance-initializers/ember-simple-auth.js
@@ -1,0 +1,8 @@
+// This is only needed for backwards compatibility and will be removed in the
+// next major release of ember-simple-auth. Unfortunately, there is no way to
+// deprecate this without hooking into Ember's internals…
+export default {
+  name: 'ember-simple-auth',
+
+  initialize() {}
+};


### PR DESCRIPTION
#1547 removed the `ember-simple-auth` instance initializer but that is actually a breaking change as applications might depend on the existence of that initializer, e.g.

```js
export default {
  name  : 'segment',
  after : 'ember-simple-auth',
  initialize
};
```

### TODO

- [ ] figure out how we can only show a deprecation when any instance initializer in the application has a `after: 'ember-simple-auth'` or `before: 'ember-simple-auth'` but not if that's not the case.

closes #1564 