### PR TITLE
deprecate baseURL config setting

### DIFF
--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,9 +1,9 @@
+import { A } from '@ember/array';
 import { getWithDefault } from '@ember/object';
-import { typeOf } from '@ember/utils';
 import { deprecate } from '@ember/application/deprecations';
 
 const DEFAULTS = {
-  baseURL:                     '',
+  rootURL:                     '',
   authenticationRoute:         'login',
   routeAfterAuthentication:    'index',
   routeIfAlreadyAuthenticated: 'index'
@@ -19,6 +19,18 @@ const DEFAULTS = {
 */
 export default {
   /**
+    The root URL of the application as configured in `config/environment.js`.
+
+    @property rootURL
+    @readOnly
+    @static
+    @type String
+    @default ''
+    @public
+  */
+  rootURL: DEFAULTS.rootURL,
+
+  /**
     The base URL of the application as configured in `config/environment.js`.
 
     @property baseURL
@@ -28,7 +40,13 @@ export default {
     @default ''
     @public
   */
-  baseURL: DEFAULTS.baseURL,
+  get baseURL() {
+    deprecate('The baseURL property should no longer be used. Instead, use rootURL.', false, {
+      id: `ember-simple-auth.configuration.base-url`,
+      until: '2.0.0'
+    });
+    return this.rootURL;
+  },
 
   /**
     The route to transition to for authentication. The
@@ -75,17 +93,15 @@ export default {
   routeIfAlreadyAuthenticated: DEFAULTS.routeIfAlreadyAuthenticated,
 
   load(config) {
-    for (let property in this) {
-      if (this.hasOwnProperty(property) && typeOf(this[property]) !== 'function') {
-        if (['authenticationRoute', 'routeAfterAuthentication', 'routeIfAlreadyAuthenticated'].indexOf(property) >= 0 && DEFAULTS[property] !== this[property]) {
-          deprecate(`Ember Simple Auth: ${property} should no longer be overridden in the configuration. Instead, override the ${property} property in the route.`, false, {
-            id: `ember-simple-auth.configuration.routes`,
-            until: '2.0.0'
-          });
-        }
-
-        this[property] = getWithDefault(config, property, DEFAULTS[property]);
+    A(['rootURL', 'authenticationRoute', 'routeAfterAuthentication', 'routeIfAlreadyAuthenticated']).forEach((property) => {
+      if (['authenticationRoute', 'routeAfterAuthentication', 'routeIfAlreadyAuthenticated'].indexOf(property) >= 0 && DEFAULTS[property] !== this[property]) {
+        deprecate(`Ember Simple Auth: ${property} should no longer be overridden in the configuration. Instead, override the ${property} property in the route.`, false, {
+          id: `ember-simple-auth.configuration.routes`,
+          until: '2.0.0'
+        });
       }
-    }
+
+      this[property] = getWithDefault(config, property, DEFAULTS[property]);
+    });
   }
 };

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -139,9 +139,9 @@ export default Mixin.create({
   sessionInvalidated() {
     if (!Ember.testing) {
       if (this.get('_isFastBoot')) {
-        this.transitionTo(Configuration.baseURL);
+        this.transitionTo(Configuration.rootURL);
       } else {
-        window.location.replace(Configuration.baseURL);
+        window.location.replace(Configuration.rootURL);
       }
     }
   }

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -9,7 +9,7 @@ export default {
 
   initialize(registry) {
     const config = ENV['ember-simple-auth'] || {};
-    config.baseURL = ENV.rootURL || ENV.baseURL;
+    config.rootURL = ENV.rootURL || ENV.baseURL;
     Configuration.load(config);
 
     setupSession(registry);

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -1,17 +1,42 @@
 import { describe, afterEach, it } from 'mocha';
 import { expect } from 'chai';
 import Configuration from 'ember-simple-auth/configuration';
+import { registerDeprecationHandler } from '@ember/debug';
 
 describe('Configuration', () => {
   afterEach(function() {
     Configuration.load({});
   });
 
-  describe('baseURL', function() {
+  describe('rootURL', function() {
     it('defaults to ""', function() {
       Configuration.load({});
 
-      expect(Configuration.baseURL).to.eql('');
+      expect(Configuration.rootURL).to.eql('');
+    });
+  });
+
+  describe('baseURL', function() {
+    it('is an alias to rootURL', function() {
+      Configuration.load({ rootURL: '/rootURL' });
+
+      expect(Configuration.baseURL).to.eql('/rootURL');
+    });
+
+    it('is deprecated', function() {
+      let warnings;
+      registerDeprecationHandler((message, options, next) => {
+        // in case a deprecation is issued before a test is started
+        if (!warnings) {
+          warnings = [];
+        }
+
+        warnings.push(message);
+        next(message, options);
+      });
+      Configuration.baseURL;
+
+      expect(warnings[0]).to.eq('The baseURL property should no longer be used. Instead, use rootURL.');
     });
   });
 
@@ -34,10 +59,10 @@ describe('Configuration', () => {
   });
 
   describe('.load', function() {
-    it('sets baseURL correctly', function() {
-      Configuration.load({ baseURL: '/baseURL' });
+    it('sets rootURL correctly', function() {
+      Configuration.load({ rootURL: '/rootURL' });
 
-      expect(Configuration.baseURL).to.eql('/baseURL');
+      expect(Configuration.rootURL).to.eql('/rootURL');
     });
 
     it('sets authenticationRoute correctly', function() {


### PR DESCRIPTION
The property still being called `baseURL` (like the deprecated Ember CLI config setting) confuses people. This introduces a new property `rootURL` that's in line with the Ember CLI setting and deprecates `baseURL`.

closes #1596 