### PR TITLE
Tweak authorizer deprecation example to be closer to original behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,11 +535,15 @@ Examples:
 
 ```js
 // OAuth 2
+import { isPresent } from '@ember/utils';
+
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   session: service('session'), 
   authorize(xhr) {
     let { access_token } = this.get('session.data.authenticated');
-    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`);
+    if (isPresent(access_token)) {
+      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`);
+    }
   }
 });
 


### PR DESCRIPTION
Authorizers would previosuly omit the authorization header if no token was available. The original example in the readme caused some issues in certain apps that relied on this behavior.