### PR TITLE
Use proper argument spread to avoid non-transpiled issues

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -1,6 +1,5 @@
 import Mixin from '@ember/object/mixin';
 import { A } from '@ember/array';
-import { bind } from '@ember/runloop';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import { inject } from '@ember/service';
@@ -84,9 +83,7 @@ export default Mixin.create({
       ['authenticationSucceeded', 'sessionAuthenticated'],
       ['invalidationSucceeded', 'sessionInvalidated']
     ]).forEach(([event, method]) => {
-      this.get('session').on(event, bind(this, () => {
-        this[method](...arguments);
-      }));
+      this.get('session').on(event, (...args) => this[method](...args));
     });
   },
 


### PR DESCRIPTION
Based on the arrow function spec, `arguments` is inherited just like `super` and `this`.
This means that the code here is actually spreading the arguments from `_subscribeToSessionEvents` instead of the actual event handler.

This could lead to unexpected results especially since older versions of Babel did not follow spec and allowed use of `...arguments.
As newer versions of Babel follow spec and arrow functions are not transpiled (due to targets), this causes different behavior across transpilation targets.

This PR fixes this.

---

I have also checked and didn't see any other offending `...argument` calls since this is the only one inside of an arrow function.

closes #1638