### PR TITLE
move fastboot CP into util

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -6,6 +6,7 @@ import { getOwner } from '@ember/application';
 import { inject } from '@ember/service';
 import Ember from 'ember';
 import Configuration from './../configuration';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   The mixin for the application route, __defining methods that are called when
@@ -56,11 +57,7 @@ export default Mixin.create({
   */
   session: inject('session'),
 
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   /**
     The route to transition to after successful authentication.

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -4,6 +4,7 @@ import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import Configuration from './../configuration';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   __This mixin is used to make routes accessible only if the session is
@@ -35,11 +36,7 @@ export default Mixin.create({
   */
   session: service('session'),
 
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   /**
     The route to transition to for authentication. The

--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
-import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   __This mixin is used in the callback route when using OAuth 2.0 Implicit
@@ -76,11 +75,7 @@ export default Mixin.create({
     });
   },
 
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   _windowLocationHash() {
     // we wrap this so we can stub it with sinon

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -2,8 +2,8 @@ import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
 import Configuration from './../configuration';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   __This mixin is used to make routes accessible only if the session is
@@ -36,11 +36,7 @@ export default Mixin.create({
   */
   session: service('session'),
 
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   /**
     The route to transition to if a route that implements the

--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -1,11 +1,10 @@
 /* global localStorage */
 import RSVP from 'rsvp';
 
-import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
 import { bind } from '@ember/runloop';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   Session store that persists data in the browser's `localStorage`.
@@ -27,11 +26,7 @@ import objectsAreEqual from '../utils/objects-are-equal';
   @public
 */
 export default BaseStore.extend({
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   /**
     The `localStorage` key the store persists data in.

--- a/addon/session-stores/session-storage.js
+++ b/addon/session-stores/session-storage.js
@@ -1,11 +1,10 @@
 /* global sessionStorage */
 import RSVP from 'rsvp';
 
-import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
 import { bind } from '@ember/runloop';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 /**
   Session store that persists data in the browser's `sessionStorage`.
@@ -23,11 +22,7 @@ import objectsAreEqual from '../utils/objects-are-equal';
   @public
 */
 export default BaseStore.extend({
-  _isFastBoot: computed(function() {
-    const fastboot = getOwner(this).lookup('service:fastboot');
-
-    return fastboot ? fastboot.get('isFastBoot') : false;
-  }),
+  _isFastBoot: isFastBoot(),
 
   /**
     The `sessionStorage` key the store persists data in.

--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -1,0 +1,13 @@
+import { computed } from '@ember/object';
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+
+export default function isFastBoot() {
+  return computed(function() {
+    const container = getOwner(this);
+    assert('You may only use isFastBoot() on a container-aware object', container && typeof container.lookup === 'function');
+
+    const fastboot = container.lookup('service:fastboot');
+    return fastboot ? fastboot.get('isFastBoot') : false;
+  });
+}


### PR DESCRIPTION
I was having a look at what I could do to help with #1619. I don't really get the full scope of how we could move away from mixins, but I did notice that `isFastBoot` method was repeated 5 times, so I moved it to a util function.