### PR TITLE
[WIP] ApplicationRoute - mixin de-entanglement

### DIFF
--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -1,21 +1,23 @@
 import Route from '@ember/routing/route';
 import { next } from '@ember/runloop';
-import { describe, beforeEach, it } from 'mocha';
+import { describe, beforeEach, afterEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
-
 import createWithContainer from '../../helpers/create-with-container';
+import EmberObject from '@ember/object';
 
 describe('ApplicationRouteMixin', () => {
   let session;
   let route;
   let cookiesMock;
   let containerMock;
-
+  let routerMock;
+  let sinon;
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     session = InternalSession.create({ store: EphemeralStore.create() });
     cookiesMock = {
       read: sinon.stub(),
@@ -24,12 +26,18 @@ describe('ApplicationRouteMixin', () => {
     containerMock = {
       lookup: sinon.stub()
     };
-
+    routerMock = createWithContainer(EmberObject.extend({
+      transitionTo() {}
+    }), {}, containerMock);
     containerMock.lookup.withArgs('service:cookies').returns(cookiesMock);
-
+    containerMock.lookup.withArgs('service:session').returns(session);
+    containerMock.lookup.withArgs('router:main').returns(routerMock);
     route = createWithContainer(Route.extend(ApplicationRouteMixin, {
       transitionTo() {}
     }), { session }, containerMock);
+  });
+  afterEach(() => {
+    sinon.restore();
   });
 
   describe('mapping of service events to route methods', function() {


### PR DESCRIPTION
This is a super-rough hack that I'll refine later on, but I wanted to leave it here for the purposes of discussion. 

By refactoring two functions out of the mixin, I'm now able to do the `ApplicationRouteMixin`'s job on a service or any other ember singleton.

## TODO:
- [ ] Figure out intuitive function names
- [ ] Break these two top-level functions out into a single `./utils/___`
- [ ] Docs
- [ ] Tests for non-mixin use