### PR TITLE
Bugfix: Don't try to bind arrow functions

### DIFF
--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -84,9 +84,9 @@ export default Mixin.create({
       ['authenticationSucceeded', 'sessionAuthenticated'],
       ['invalidationSucceeded', 'sessionInvalidated']
     ]).forEach(([event, method]) => {
-      this.get('session').on(event, bind(this, () => {
-        this[method](...arguments);
-      }));
+      this.get('session').on(event, (...args) => {
+        this[method](...args);
+      });
     });
   },
 


### PR DESCRIPTION
Arrow functions have neiter a `this` that could be bound nor their own `arguments` object.

Replaces #1638