### PR TITLE
Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,18 @@ addons:
 env:
   secure: IVCX1o8nMAKAKxj2cXE6a2A8xmnt3Gj72ocyjT1vhZutEJ1z7wu3Xl/r6Q0fhlaux3+ZNz/KV6Lax6NW8KgC/Wo1+B5SF2RWMLGX+exglf5zUXT3wzaOq8LcEyQ7SGfsuovHa8ij3dMM4UWjl5lE3cM1M1KjxlekniUF9nFxZd4=
   matrix:
-    - SCRIPT=test:all
+    - SCRIPT="test:one ember-1.12"
+    - SCRIPT="test:one ember-1.13"
+    - SCRIPT="test:one ember-2.0"
+    - SCRIPT="test:one ember-lts-2.4"
+    - SCRIPT="test:one ember-lts-2.8"
+    - SCRIPT="test:one ember-lts-2.12"
+    - SCRIPT="test:one ember-lts-2.16"
+    - SCRIPT="test:one ember-lts-2.18"
+    - SCRIPT="test:one ember-3.0"
+    - SCRIPT="test:one ember-release"
+    - SCRIPT="test:one ember-beta"
+    - SCRIPT="test:one ember-canary"
     - SCRIPT=test:fastboot
     - SCRIPT=test:node
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -150,6 +150,22 @@ module.exports = function() {
           },
         },
         {
+          name: 'ember-3.0',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.0.0',
+              'ember-source': '~3.0.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           bower: {
             dependencies: {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
+    "test:one": "ember try:one",
     "test:fastboot": "ember fastboot:test",
     "test:node": "mocha node-tests --recursive"
   },


### PR DESCRIPTION
This adds Ember 3.0 to the test scenarios and runs the tests in parallel instead of one after the other which should hopefully help getting the build times down 🙏 

Another advantage of this is that if any of the scenarios fail, we don't have to re-run **all** scenarios and wait for ca. 20min but can re-run only that **one** scenario wich is much faster of course.