### PR TITLE
Authenticated route: allow easier use w/o mixin

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -4,7 +4,33 @@ import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import Configuration from './../configuration';
-import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
+import isFastBootCPM, { isFastBoot } from '../utils/is-fastboot';
+
+/**
+ * If the user is unauthenticated, invoke `callback`
+ *
+ * @param {ApplicationInstance} owner The ApplicationInstance that owns the service (and possibly fastboot and cookie) service(s)
+ * @param {Transition} transition Transition for the user's original navigation
+ * @param {(...args: []any) => any} callback Callback that will be invoked if the user is unauthenticated
+ */
+function runIfUnauthenticated(owner, transition, callback) {
+  const isFb = isFastBoot(owner);
+  const sessionSvc = owner.lookup('service:session');
+  if (!sessionSvc.get('isAuthenticated')) {
+    if (isFb) {
+      const fastboot = owner.lookup('service:fastboot');
+      const cookies = owner.lookup('service:cookies');
+      cookies.write('ember_simple_auth-redirectTarget', transition.intent.url, {
+        path: '/',
+        secure: fastboot.get('request.protocol') === 'https'
+      });
+    } else {
+      sessionSvc.set('attemptedTransition', transition);
+    }
+    callback();
+    return true;
+  }
+}
 
 /**
   __This mixin is used to make routes accessible only if the session is
@@ -36,7 +62,7 @@ export default Mixin.create({
   */
   session: service('session'),
 
-  _isFastBoot: isFastBoot(),
+  _isFastBoot: isFastBootCPM(),
 
   /**
     The route to transition to for authentication. The
@@ -76,21 +102,10 @@ export default Mixin.create({
     @public
   */
   beforeModel(transition) {
-    if (!this.get('session.isAuthenticated')) {
-      if (this.get('_isFastBoot')) {
-        const fastboot = getOwner(this).lookup('service:fastboot');
-        const cookies = getOwner(this).lookup('service:cookies');
-
-        cookies.write('ember_simple_auth-redirectTarget', transition.intent.url, {
-          path: '/',
-          secure: fastboot.get('request.protocol') === 'https'
-        });
-      } else {
-        this.set('session.attemptedTransition', transition);
-      }
-
+    const didRedirect = runIfUnauthenticated(getOwner(this), transition, () => {
       this.triggerAuthentication();
-    } else {
+    });
+    if (!didRedirect) {
       return this._super(...arguments);
     }
   },

--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -1,13 +1,27 @@
+/* eslint-disable no-unused-vars */
+// @ts-check
 import { computed } from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
+import ApplicationInstance from '@ember/application/instance';
 
-export default function isFastBoot() {
+/**
+ * @return {ComputedProperty<boolean>}
+ */
+export default function isFastBootCPM() {
   return computed(function() {
-    const container = getOwner(this);
-    assert('You may only use isFastBoot() on a container-aware object', container && typeof container.lookup === 'function');
-
-    const fastboot = container.lookup('service:fastboot');
-    return fastboot ? fastboot.get('isFastBoot') : false;
+    return isFastBoot(getOwner(this));
   });
+}
+
+/**
+ *
+ * @param {ApplicationInstance} owner
+ * @return {boolean}
+ */
+export function isFastBoot(owner) {
+  assert('You may only use isFastBoot() on a container-aware object', owner && typeof owner.lookup === 'function');
+  const fastboot = owner.lookup('service:fastboot');
+  return fastboot ? fastboot.get('isFastBoot') : false;
 }

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -46,10 +46,10 @@ describe('AuthenticatedRouteMixin', () => {
 
       containerMock.lookup.withArgs('service:cookies').returns(cookiesMock);
       containerMock.lookup.withArgs('service:fastboot').returns(fastbootMock);
+      containerMock.lookup.withArgs('service:session').returns(session);
 
       route = createWithContainer(Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin, {
         // pretend this is never FastBoot
-        _isFastBoot: false,
         // replace actual transitionTo as the router isn't set up etc.
         transitionTo() {}
       }), { session }, containerMock);
@@ -91,12 +91,9 @@ describe('AuthenticatedRouteMixin', () => {
 
       it('sets the redirectTarget cookie in fastboot', function() {
         fastbootMock.get.withArgs('request.protocol').returns('https');
+        fastbootMock.get.withArgs('isFastBoot').returns(true);
 
         let cookieName = 'ember_simple_auth-redirectTarget';
-
-        route.reopen({
-          _isFastBoot: true
-        });
 
         route.beforeModel(transition);
         expect(cookiesMock.write).to.have.been.calledWith(cookieName, transition.intent.url, {


### PR DESCRIPTION
Part of effort described in #1619 
Supercedes #1628 