### PR TITLE
Fixed doc error and file / class name inconsistancy in file oauth2-implicit-grant-callback-route-mixin.js

### DIFF
--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -5,13 +5,13 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 /**
   __This mixin is used in the callback route when using OAuth 2.0 Implicit
   Grant authentication.__ It implements the
-  {{#crossLink "OAuth2ImplicitGrantCallbackMixin/activate:method"}}{{/crossLink}}
+  {{#crossLink "OAuth2ImplicitGrantCallbackRouteMixin/activate:method"}}{{/crossLink}}
   method that retrieves and processes authentication parameters, such as
   `access_token`, from the hash parameters provided in the callback URL by
   the authentication server. The parameters are then passed to the
   {{#crossLink "OAuth2ImplicitGrantAuthenticator"}}{{/crossLink}}
 
-  @class OAuth2ImplicitGrantCallbackMixin
+  @class OAuth2ImplicitGrantCallbackRouteMixin
   @module ember-simple-auth/mixins/oauth2-implicit-grant-callback-route-mixin
   @extends Ember.Mixin
   @public

--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -12,7 +12,7 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
   {{#crossLink "OAuth2ImplicitGrantAuthenticator"}}{{/crossLink}}
 
   @class OAuth2ImplicitGrantCallbackMixin
-  @module ember-simple-auth/mixins/oauth2-implicit-grant-callback-mixin
+  @module ember-simple-auth/mixins/oauth2-implicit-grant-callback-route-mixin
   @extends Ember.Mixin
   @public
 */

--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -12,7 +12,7 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
   {{#crossLink "OAuth2ImplicitGrantAuthenticator"}}{{/crossLink}}
 
   @class OAuth2ImplicitGrantCallbackMixin
-  @module ember-simple-auth/mixins/ouath2-implicit-grant-callback-mixin
+  @module ember-simple-auth/mixins/oauth2-implicit-grant-callback-mixin
   @extends Ember.Mixin
   @public
 */


### PR DESCRIPTION
At some point, this file's name must have been changed from
- oauth2-implicit-grant-callback-mixin.js

to the current
- oauth2-implicit-grant-callback-**route**-mixin.js

but the documentation strings were not adapted to these changes. As a consequence, the API doc had an error, and the class name was not consistent with the file name.

This pull request just fixes the documentation and has no impact on code.