### PR TITLE
refactor(authentication-route-mixin): use router service

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -62,6 +62,11 @@ export default Mixin.create({
   */
   session: service('session'),
 
+  _router: computed(function() {
+    let owner = getOwner(this);
+    return owner.lookup('service:router') || owner.lookup('router:main');
+  }),
+
   _isFastBoot: isFastBootCPM(),
 
   /**
@@ -123,6 +128,6 @@ export default Mixin.create({
     let authenticationRoute = this.get('authenticationRoute');
     assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== authenticationRoute);
 
-    this.transitionTo(authenticationRoute);
+    this.get('_router').transitionTo(authenticationRoute);
   },
 });


### PR DESCRIPTION
- use router service instead of the routes `transitionTo` method

@mike-north in line with one of your todos from #1619 (https://github.com/simplabs/ember-simple-auth/issues/1619#issuecomment-403178107) is this correct? If so I can do this wherever else `router.transitionTo` is used.