### PR TITLE
Fixes Handling of ClientID for Password Grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,15 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
 });
 ```
 
+### Deprecation of Client ID as Header
+
+Sending the Client ID as Base64 Encoded in the Authorization Header was against the spec and caused
+incorrect behavior with OAuth2 Servers that had implemented the spec properly.
+
+To change this behavior set `sendClientIdAsQueryParam` to `true`, and the client id will be correctly
+sent as a query parameter. Leaving it set to `false` (currently default) will result in a deprecation
+notice until the next major version.
+
 ## Session Stores
 
 Ember Simple Auth __persists the session state via a session store so it

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -126,6 +126,14 @@ export default BaseAuthenticator.extend({
 
   _refreshTokenTimeout: null,
 
+  _clientIdHeader: computed('clientId', function() {
+    const clientId = this.get('clientId');
+    if (!isEmpty(clientId)) {
+      const base64ClientId = window.base64.encode(clientId.concat(':'));
+      return { Authorization: `Basic ${base64ClientId}` };
+    }
+  }),
+
   /**
     When authentication fails, the rejection callback is provided with the whole
     Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
@@ -338,10 +346,14 @@ export default BaseAuthenticator.extend({
   makeRequest(url, data, headers = {}) {
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
-    if (this.get('clientId') !== null) {
-      data['client_id'] = this.get('clientId');
+    if (this.get('sendClientIdAsQueryParam')) {
+      const clientId = this.get('clientId');
+      if (!isEmpty(clientId)) {
+        data['client_id'] = this.get('clientId');
+      }
     }
-    if (this.get('refreshAccessTokens')) {
+
+    if (data['grant_type'] === 'password' && this.get('refreshAccessTokens')) {
       data['offline_token'] = true;
     }
 
@@ -354,6 +366,13 @@ export default BaseAuthenticator.extend({
       headers,
       method: 'POST'
     };
+
+    if (!this.get('sendClientIdAsQueryParam')) {
+      const clientIdHeader = this.get('_clientIdHeader');
+      if (!isEmpty(clientIdHeader)) {
+        merge(options.headers, clientIdHeader);
+      }
+    }
 
     return new RSVP.Promise((resolve, reject) => {
       fetch(url, options).then((response) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -9,6 +9,7 @@ import {
   merge,
   assign as emberAssign
 } from '@ember/polyfills';
+import { deprecate } from '@ember/application/deprecations';
 import Ember from 'ember';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
@@ -34,14 +35,15 @@ export default BaseAuthenticator.extend({
   init() {
     this._super(...arguments);
     deprecate(`Ember Simple Auth: Client ID as Authorization Header is deprecated in favour of Client ID as Query String Parameter.`,
-          false,
-          {
-            id: 'ember-simple-auth.OAuth2PasswordGrantAuthenticator',
-            until: '2.0.0',
-            url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
-          }
+      false,
+      {
+        id: 'ember-simple-auth.OAuth2PasswordGrantAuthenticator',
+        until: '2.0.0',
+        url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
+      }
     );
-  }
+  },
+
   /**
     Triggered when the authenticator refreshed the access token (see
     [RFC 6749, section 6](http://tools.ietf.org/html/rfc6749#section-6)).

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -115,15 +115,6 @@ export default BaseAuthenticator.extend({
 
   _refreshTokenTimeout: null,
 
-  _clientIdHeader: computed('clientId', function() {
-    const clientId = this.get('clientId');
-
-    if (!isEmpty(clientId)) {
-      const base64ClientId = window.base64.encode(clientId.concat(':'));
-      return { Authorization: `Basic ${base64ClientId}` };
-    }
-  }),
-
   /**
     When authentication fails, the rejection callback is provided with the whole
     Fetch API [Response](https://fetch.spec.whatwg.org/#response-class) object
@@ -336,6 +327,8 @@ export default BaseAuthenticator.extend({
   makeRequest(url, data, headers = {}) {
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
+    data['client_id'] = this.get('_clientId');
+
     const body = keys(data).map((key) => {
       return `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`;
     }).join('&');
@@ -345,11 +338,6 @@ export default BaseAuthenticator.extend({
       headers,
       method: 'POST'
     };
-
-    const clientIdHeader = this.get('_clientIdHeader');
-    if (!isEmpty(clientIdHeader)) {
-      merge(options.headers, clientIdHeader);
-    }
 
     return new RSVP.Promise((resolve, reject) => {
       fetch(url, options).then((response) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -31,6 +31,17 @@ const keys = Object.keys || emberKeys; // Ember.keys deprecated in 1.13
   @public
 */
 export default BaseAuthenticator.extend({
+  init() {
+    this._super(...arguments);
+    deprecate(`Ember Simple Auth: Client ID as Authorization Header is deprecated in favour of Client ID as Query String Parameter.`,
+          false,
+          {
+            id: 'ember-simple-auth.OAuth2PasswordGrantAuthenticator',
+            until: '2.0.0',
+            url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
+          }
+    );
+  }
   /**
     Triggered when the authenticator refreshed the access token (see
     [RFC 6749, section 6](http://tools.ietf.org/html/rfc6749#section-6)).
@@ -351,10 +362,6 @@ export default BaseAuthenticator.extend({
       if (!isEmpty(clientId)) {
         data['client_id'] = this.get('clientId');
       }
-    }
-
-    if (data['grant_type'] === 'password' && this.get('refreshAccessTokens')) {
-      data['offline_token'] = true;
     }
 
     const body = keys(data).map((key) => {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -54,16 +54,15 @@ export default BaseAuthenticator.extend({
   clientId: null,
 
   /**
-    The client_secret to be sent to the authentication server. This should be set
-    along with the client_id if the client needs to authenticate itself against
-    the authorization server in addition to the user
+   The OAuth2 standard is to send the client_id as a query parameter. This is a
+   feature flag that turns on the correct behavior for OAuth2 requests.
 
-    @property clientSecret
-    @type String
-    @default null
-    @public
+   @property sendClientIdAsQueryParam
+   @type Boolean
+   @default false
+   @public
   */
-  clientSecret: null,
+  sendClientIdAsQueryParam: false,
 
   /**
     The endpoint on the server that authentication and token refresh requests
@@ -341,9 +340,6 @@ export default BaseAuthenticator.extend({
 
     if (this.get('clientId') !== null) {
       data['client_id'] = this.get('clientId');
-    }
-    if (this.get('clientSecret') !== null) {
-      data['client_secret'] = this.get('clientSecret')
     }
     if (this.get('refreshAccessTokens')) {
       data['offline_token'] = true;

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -32,18 +32,6 @@ const keys = Object.keys || emberKeys; // Ember.keys deprecated in 1.13
   @public
 */
 export default BaseAuthenticator.extend({
-  init() {
-    this._super(...arguments);
-    deprecate(`Ember Simple Auth: Client ID as Authorization Header is deprecated in favour of Client ID as Query String Parameter.`,
-      false,
-      {
-        id: 'ember-simple-auth.OAuth2PasswordGrantAuthenticator',
-        until: '2.0.0',
-        url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
-      }
-    );
-  },
-
   /**
     Triggered when the authenticator refreshed the access token (see
     [RFC 6749, section 6](http://tools.ietf.org/html/rfc6749#section-6)).
@@ -276,6 +264,17 @@ export default BaseAuthenticator.extend({
     @public
   */
   authenticate(identification, password, scope = [], headers = {}) {
+    if (!this.get('sendClientIdAsQueryParam')) {
+      deprecate(`Ember Simple Auth: Client ID as Authorization Header is deprecated in favour of Client ID as Query String Parameter.`,
+        false,
+        {
+          id: 'ember-simple-auth.oauth2-password-grant-authenticator.client-id-as-authorization',
+          until: '2.0.0',
+          url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-client-id-header',
+        }
+      );
+    }
+
     return new RSVP.Promise((resolve, reject) => {
       const data = { 'grant_type': 'password', username: identification, password };
       const serverTokenEndpoint = this.get('serverTokenEndpoint');

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -345,6 +345,9 @@ export default BaseAuthenticator.extend({
     if (this.get('clientSecret') !== null) {
       data['client_secret'] = this.get('clientSecret')
     }
+    if (this.get('refreshAccessTokens')) {
+      data['offline_token'] = true;
+    }
 
     const body = keys(data).map((key) => {
       return `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`;

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -54,6 +54,18 @@ export default BaseAuthenticator.extend({
   clientId: null,
 
   /**
+    The client_secret to be sent to the authentication server. This should be set
+    along with the client_id if the client needs to authenticate itself against
+    the authorization server in addition to the user
+
+    @property clientSecret
+    @type String
+    @default null
+    @public
+  */
+  clientSecret: null,
+
+  /**
     The endpoint on the server that authentication and token refresh requests
     are sent to.
 
@@ -327,7 +339,12 @@ export default BaseAuthenticator.extend({
   makeRequest(url, data, headers = {}) {
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
-    data['client_id'] = this.get('_clientId');
+    if (this.get('clientId') !== null) {
+      data['client_id'] = this.get('clientId');
+    }
+    if (this.get('clientSecret') !== null) {
+      data['client_secret'] = this.get('clientSecret')
+    }
 
     const body = keys(data).map((key) => {
       return `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`;

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -127,9 +127,15 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       authenticator.authenticate('username', 'password');
     });
 
-    it('sends an AJAX request to the token endpoint with client_id as query parameter', function(done) {
+    it('sends an AJAX request to the token endpoint with client_id as parameter in the body', function(done) {
       server.post('/token', (request) => {
-        console.log(request.query);
+        let body = parsePostData(request.requestBody);
+        expect(body).to.eql({
+          'client_id': 'test-client',
+          'grant_type': 'password',
+          'username': 'username',
+          'password': 'password'
+        });
         done();
       });
 

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -8,6 +8,7 @@ import {
 import { expect } from 'chai';
 import Pretender from 'pretender';
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
+import { registerDeprecationHandler } from '@ember/debug';
 
 describe('OAuth2PasswordGrantAuthenticator', () => {
   let authenticator;
@@ -118,6 +119,17 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
     });
 
     it('(deprecated) sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
+      let warnings;
+      registerDeprecationHandler((message, options, next) => {
+        // in case a deprecation is issued before a test is started
+        if (!warnings) {
+          warnings = [];
+        }
+
+        warnings.push(message);
+        next(message, options);
+      });
+
       server.post('/token', (request) => {
         expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
         done();
@@ -125,6 +137,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
       authenticator.set('clientId', 'test-client');
       authenticator.authenticate('username', 'password');
+
+      expect(warnings[0]).to.eq('Ember Simple Auth: Client ID as Authorization Header is deprecated in favour of Client ID as Query String Parameter.');
     });
 
     it('sends an AJAX request to the token endpoint with client_id as parameter in the body', function(done) {

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -118,7 +118,17 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       authenticator.authenticate('username', 'password');
     });
 
-    it('(deprecated) sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
+    it('sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
+      server.post('/token', (request) => {
+        expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
+        done();
+      });
+
+      authenticator.set('clientId', 'test-client');
+      authenticator.authenticate('username', 'password');
+    });
+
+    it('shows a deprecation warning when sending the client_id in the Basic Auth header', function(done) {
       let warnings;
       registerDeprecationHandler((message, options, next) => {
         // in case a deprecation is issued before a test is started
@@ -130,11 +140,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         next(message, options);
       });
 
-      server.post('/token', (request) => {
-        expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
-        done();
-      });
-
+      server.post('/token', () => done());
       authenticator.set('clientId', 'test-client');
       authenticator.authenticate('username', 'password');
 

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -117,12 +117,23 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       authenticator.authenticate('username', 'password');
     });
 
-    it('sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
+    it('(deprecated) sends an AJAX request to the token endpoint with client_id Basic Auth header', function(done) {
       server.post('/token', (request) => {
         expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
         done();
       });
 
+      authenticator.set('clientId', 'test-client');
+      authenticator.authenticate('username', 'password');
+    });
+
+    it('sends an AJAX request to the token endpoint with client_id as query parameter', function(done) {
+      server.post('/token', (request) => {
+        console.log(request.query);
+        done();
+      });
+
+      authenticator.set('sendClientIdAsQueryParam', true);
       authenticator.set('clientId', 'test-client');
       authenticator.authenticate('username', 'password');
     });


### PR DESCRIPTION
* Fixes how `client_id` is passed on Password Grant for OAuth2.
* Adds support for `client_secret` and passing it as well for Password Grant if set.

References on Password Grants:
- https://www.oauth.com/oauth2-servers/access-tokens/password-grant/
- https://auth0.com/docs/api-auth/tutorials/password-grant
- https://alexbilbie.com/guide-to-oauth-2-grants/

Fixes #1678