### PR TITLE
Fixed case of `rootURL` config property in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.7.0
 
-* The `baseURL` configuration property is now deprecated; use the `rootUrl`
+* The `baseURL` configuration property is now deprecated; use the `rootURL`
   property instead, see #1597.
 * ESA works with ember-fetch@"^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0" now, see
   #1608.


### PR DESCRIPTION
The `baseURL` property has been deprecated in favour of `rootURL` not `rootUrl`.