### PR TITLE
Rethrow fetch exception after clearing the provider

### DIFF
--- a/addon/authenticators/torii.js
+++ b/addon/authenticators/torii.js
@@ -59,10 +59,16 @@ export default BaseAuthenticator.extend({
     if (!isEmpty(data.provider)) {
       const { provider } = data;
 
-      return this.get('torii').fetch(data.provider, data).then((fetchedData) => {
-        this._authenticateWithProvider(provider, fetchedData);
-        return emberAssign(data, fetchedData);
-      }, () => delete this._provider);
+      return this.get('torii').fetch(data.provider, data).then(
+        (fetchedData) => {
+          this._authenticateWithProvider(provider, fetchedData);
+          return emberAssign(data, fetchedData);
+        },
+        (err) => {
+          delete this._provider;
+          throw err;
+        }
+      );
     } else {
       delete this._provider;
       return RSVP.reject();

--- a/tests/unit/authenticators/torii-test.js
+++ b/tests/unit/authenticators/torii-test.js
@@ -20,9 +20,14 @@ describe('ToriiAuthenticator', () => {
   describe('#restore', function() {
     function itDoesNotRestore(data) {
       it('returns a rejecting promise', function() {
-        return authenticator.restore(data).catch(() => {
-          expect(true).to.be.true;
-        });
+        return authenticator.restore(data).then(
+          () => {
+            expect(false).to.be.true;
+          },
+          () => {
+            expect(true).to.be.true;
+          }
+        );
       });
     }
 


### PR DESCRIPTION
In the torii authenticator, rejected promises from `fetch` are being swallowed. There is a test for this, but it only passes because it runs 0 expectations.