### PR TITLE
[DOC] add documentation how to use it with ember-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,21 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
 });
 ```
 
+When using with `ember-fetch` the `authorize` will not be called and the `headers` property must be used instead:
+
+```js
+export default DS.JSONAPIAdapter.extend(AdapterFetch, DataAdapterMixin, {
+  headers: computed('session.data.authenticated.token', function() {
+    const headers = {};
+    if(this.session.isAuthenticated) {
+      headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
+    }
+
+    return headers;
+  }),
+});
+```
+
 ## Session Stores
 
 Ember Simple Auth __persists the session state via a session store so it

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -49,6 +49,8 @@ export default Mixin.create({
     name and header content arguments. __This property must be overridden in
     adapters using this mixin.__
 
+    When using `ember-fetch` and the `AdapterFetch` mixin this method __will not be called__.
+
     @property authorizer
     @type String
     @default null


### PR DESCRIPTION
I'm not sure why there is the authorize() method at all. (backward compatibility?) Actually I would always prefer the headers property. The DataAdapterMixin is still useful for the invalidation feature.

I think this will get more important when people use the possibility to get rid of jQuery.

Looks like I've overwritten the changes for #1662. Sorry for that! Here again. I hope the change itself it welcome, otherwise sorry for opening this up again.