### PR TITLE
[DOC] add documentation how to use it with ember-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,22 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
 });
 ```
 
+When using with `ember-fetch` the `authorize` will not be called and the
+`headers` computed property must be used instead, e.g.:
+
+```js
+export default DS.JSONAPIAdapter.extend(AdapterFetch, DataAdapterMixin, {
+  headers: computed('session.data.authenticated.token', function() {
+    const headers = {};
+    if (this.session.isAuthenticated) {
+      headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
+    }
+
+    return headers;
+  }),
+});
+```
+
 ### Deprecation of Client ID as Header
 
 Sending the Client ID as Base64 Encoded in the Authorization Header was against the spec and caused

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
 });
 ```
 
-When using with `ember-fetch` the `authorize` will not be called and the
+When used with `ember-fetch` the `authorize` method will not be called and the
 `headers` computed property must be used instead, e.g.:
 
 ```js

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -49,6 +49,22 @@ export default Mixin.create({
     name and header content arguments. __This property must be overridden in
     adapters using this mixin.__
 
+    When using with `ember-fetch` the `authorize` will not be called and the
+    `headers` computed property must be used instead, e.g.:
+
+    ```js
+    export default DS.JSONAPIAdapter.extend(AdapterFetch, DataAdapterMixin, {
+      headers: computed('session.data.authenticated.token', function() {
+        const headers = {};
+        if (this.session.isAuthenticated) {
+          headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
+        }
+
+        return headers;
+      }),
+    });
+    ```
+
     @property authorizer
     @type String
     @default null

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -49,8 +49,8 @@ export default Mixin.create({
     name and header content arguments. __This property must be overridden in
     adapters using this mixin.__
 
-    When using with `ember-fetch` the `authorize` will not be called and the
-    `headers` computed property must be used instead, e.g.:
+    When used with `ember-fetch` the `authorize` method will not be called and
+    the `headers` computed property must be used instead, e.g.:
 
     ```js
     export default DS.JSONAPIAdapter.extend(AdapterFetch, DataAdapterMixin, {


### PR DESCRIPTION
This replaces #1662 and adds a not on usage with `ember-fetch`.