### PR TITLE
build(travis): fix failing ember-release build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,8 @@
       "eslint-plugin-ember",
       "eslint-plugin-mocha"
     ]
+  },
+  "resolutions": {
+    "ip-regex": "^2.1.0"
   }
 }


### PR DESCRIPTION
Failing builds during the `ember-release` build process seem to stem from an indirect [dependency issue with the tough-cookie dep](https://github.com/salesforce/tough-cookie/issues/140) that now installs ip-regex@3 which dropped support for Node 6.