### PR TITLE
fix: ember-try release channel array usage

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,8 +9,8 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then(urls => {
     const releaseUrl = urls[0];
-    const betaUrl = urls[0];
-    const canaryUrl = urls[0];
+    const betaUrl = urls[1];
+    const canaryUrl = urls[2];
     return {
       useYarn: true,
       scenarios: [


### PR DESCRIPTION
All urls were being assiged to the releaseUrl