### PR TITLE
Use Sinon sandbox

### DIFF
--- a/tests/unit/authenticators/torii-test.js
+++ b/tests/unit/authenticators/torii-test.js
@@ -1,20 +1,26 @@
 import RSVP from 'rsvp';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import Torii from 'ember-simple-auth/authenticators/torii';
 
 describe('ToriiAuthenticator', () => {
+  let sinon;
   let authenticator;
   let torii;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     torii = {
       fetch() {},
       open() {},
       close() {}
     };
     authenticator = Torii.create({ torii });
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   describe('#restore', function() {

--- a/tests/unit/authorizers/devise-test.js
+++ b/tests/unit/authorizers/devise-test.js
@@ -1,17 +1,23 @@
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import Devise from 'ember-simple-auth/authorizers/devise';
 import { registerDeprecationHandler } from '@ember/debug';
 
 describe('DeviseAuthorizer', () => {
+  let sinon;
   let authorizer;
   let block;
   let data;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     authorizer = Devise.create();
     block = sinon.spy();
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('shows deprecation warning from BaseAuthorizer', function() {

--- a/tests/unit/authorizers/oauth2-bearer-test.js
+++ b/tests/unit/authorizers/oauth2-bearer-test.js
@@ -1,16 +1,22 @@
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import OAuth2BearerAuthorizer from 'ember-simple-auth/authorizers/oauth2-bearer';
 import { registerDeprecationHandler } from '@ember/debug';
 
 describe('OAuth2BearerAuthorizer', () => {
+  let sinon;
   let authorizer;
   let data;
   let block;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     block = sinon.spy();
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('shows deprecation warning from BaseAuthorizer', function() {

--- a/tests/unit/initializers/setup-session-restoration-test.js
+++ b/tests/unit/initializers/setup-session-restoration-test.js
@@ -3,15 +3,17 @@ import { getOwner, setOwner } from '@ember/application';
 import RSVP from 'rsvp';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import setupSessionRestoration from 'ember-simple-auth/initializers/setup-session-restoration';
 
 describe('setupSessionRestoration', () => {
+  let sinon;
   let registry;
   let resolveStub;
   let ApplicationRoute;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     registry = {
       resolve() {}
     };
@@ -19,6 +21,10 @@ describe('setupSessionRestoration', () => {
     ApplicationRoute = Route.extend();
 
     resolveStub = sinon.stub(registry, 'resolve');
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('adds a beforeModel method', function() {

--- a/tests/unit/initializers/setup-session-service-test.js
+++ b/tests/unit/initializers/setup-session-service-test.js
@@ -1,15 +1,21 @@
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import setupSessionService from 'ember-simple-auth/initializers/setup-session-service';
 
 describe('setupSessionService', () => {
+  let sinon;
   let registry;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     registry = {
       injection() {}
     };
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('injects the session into the session service', function() {

--- a/tests/unit/initializers/setup-session-test.js
+++ b/tests/unit/initializers/setup-session-test.js
@@ -6,20 +6,26 @@ import {
   it
 } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
 import Ephemeral from 'ember-simple-auth/session-stores/ephemeral';
 import InternalSession from 'ember-simple-auth/internal-session';
 
 describe('setupSession', () => {
+  let sinon;
   let registry;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     registry = {
       register() {},
       injection() {}
     };
     Ember.testing = true;
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('registers the session', function() {

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -2,7 +2,7 @@ import RSVP from 'rsvp';
 import { next } from '@ember/runloop';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import Authenticator from 'ember-simple-auth/authenticators/base';
@@ -10,17 +10,23 @@ import Authenticator from 'ember-simple-auth/authenticators/base';
 import createWithContainer from '../helpers/create-with-container';
 
 describe('InternalSession', () => {
+  let sinon;
   let session;
   let store;
   let authenticator;
   let container;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     container = { lookup() {} };
     store = EphemeralStore.create();
     authenticator = Authenticator.create();
     session = createWithContainer(InternalSession, { store }, container);
     sinon.stub(container, 'lookup').withArgs('authenticator').returns(authenticator);
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('does not allow data to be stored for the key "authenticated"', function() {

--- a/tests/unit/internal-session-test.js
+++ b/tests/unit/internal-session-test.js
@@ -387,20 +387,14 @@ describe('InternalSession', () => {
     });
 
     describe('when invalidate gets called with additional params', function() {
-      let spy;
-
       beforeEach(function() {
-        spy = sinon.spy(authenticator, 'invalidate');
+        sinon.spy(authenticator, 'invalidate');
       });
 
       it('passes the params on to the authenticators invalidate method', function() {
         let param = { some: 'random data' };
         session.invalidate(param);
         expect(authenticator.invalidate).to.have.been.calledWith(session.get('authenticated'), param);
-      });
-
-      afterEach(function() {
-        spy.restore();
       });
     });
 

--- a/tests/unit/mixins/application-route-mixin-test.js
+++ b/tests/unit/mixins/application-route-mixin-test.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { next } from '@ember/runloop';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
@@ -10,12 +10,14 @@ import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import createWithContainer from '../../helpers/create-with-container';
 
 describe('ApplicationRouteMixin', () => {
+  let sinon;
   let session;
   let route;
   let cookiesMock;
   let containerMock;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     session = InternalSession.create({ store: EphemeralStore.create() });
     cookiesMock = {
       read: sinon.stub(),
@@ -30,6 +32,10 @@ describe('ApplicationRouteMixin', () => {
     route = createWithContainer(Route.extend(ApplicationRouteMixin, {
       transitionTo() {}
     }), { session }, containerMock);
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   describe('mapping of service events to route methods', function() {

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -3,7 +3,7 @@ import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import InternalSession from 'ember-simple-auth/internal-session';
 import Configuration from 'ember-simple-auth/configuration';
@@ -12,12 +12,21 @@ import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import createWithContainer from '../../helpers/create-with-container';
 
 describe('AuthenticatedRouteMixin', () => {
+  let sinon;
   let route;
   let session;
   let transition;
   let cookiesMock;
   let fastbootMock;
   let containerMock;
+
+  beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
 
   describe('#beforeModel', function() {
     beforeEach(function() {

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -1,16 +1,18 @@
 import EmberObject from '@ember/object';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 describe('DataAdapterMixin', () => {
+  let sinon;
   let adapter;
   let sessionService;
   let hash;
   let Adapter;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     hash = {};
     sessionService = EmberObject.create({
       authorize() {},
@@ -34,6 +36,10 @@ describe('DataAdapterMixin', () => {
       authorizer: 'authorizer:some'
     });
     adapter = Adapter.create({ session: sessionService });
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   describe('#ajaxOptions', function() {

--- a/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
+++ b/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
@@ -23,9 +23,7 @@ describe('OAuth2ImplicitGrantCallbackRouteMixin', function() {
   });
 
   describe('#activate', function() {
-    let sinon;
     beforeEach(function() {
-      sinon = sinonjs.sandbox.create();
       session = EmberObject.extend({
         authenticate(authenticator, hash) {
           if (!isEmpty(hash.access_token)) {
@@ -44,9 +42,6 @@ describe('OAuth2ImplicitGrantCallbackRouteMixin', function() {
       }).create({ session });
 
       sinon.spy(route, 'transitionTo');
-    });
-    afterEach(function() {
-      sinon.restore();
     });
 
     it('correctly passes the auth parameters if authentication succeeds', function(done) {

--- a/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
+++ b/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
@@ -10,8 +10,17 @@ import OAuth2ImplicitGrantCallbackRouteMixin from 'ember-simple-auth/mixins/oaut
 import * as LocationUtil from 'ember-simple-auth/utils/location';
 
 describe('OAuth2ImplicitGrantCallbackRouteMixin', function() {
+  let sinon;
   let route;
   let session;
+
+  beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
 
   describe('#activate', function() {
     let sinon;

--- a/tests/unit/mixins/unauthenticated-route-mixin-test.js
+++ b/tests/unit/mixins/unauthenticated-route-mixin-test.js
@@ -3,16 +3,25 @@ import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import InternalSession from 'ember-simple-auth/internal-session';
 import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
 import createWithContainer from '../../helpers/create-with-container';
 
 describe('UnauthenticatedRouteMixin', () => {
+  let sinon;
   let route;
   let session;
   let containerMock;
+
+  beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
 
   describe('#beforeModel', function() {
     beforeEach(function() {

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -5,17 +5,19 @@ import { set } from '@ember/object';
 import { registerDeprecationHandler } from '@ember/debug';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import Session from 'ember-simple-auth/services/session';
 
 import createWithContainer from '../../helpers/create-with-container';
 
 describe('SessionService', () => {
+  let sinon;
   let sessionService;
   let session;
   let authorizer;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     session = ObjectProxy.extend(Evented, {
       content: {}
     }).create();
@@ -27,6 +29,10 @@ describe('SessionService', () => {
     stub.withArgs('authorizer').returns(authorizer);
     stub.withArgs('bad-authorizer').returns(undefined);
     sessionService = createWithContainer(Session, { session }, container);
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   it('forwards the "authenticationSucceeded" event from the session', function(done) {

--- a/tests/unit/session-stores/adaptive-test.js
+++ b/tests/unit/session-stores/adaptive-test.js
@@ -6,7 +6,7 @@ import {
   it
 } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import Adaptive from 'ember-simple-auth/session-stores/adaptive';
 import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
 import itBehavesLikeAStore from './shared/store-behavior';
@@ -15,10 +15,16 @@ import FakeCookieService from '../../helpers/fake-cookie-service';
 import createAdaptiveStore from '../../helpers/create-adaptive-store';
 
 describe('AdaptiveStore', () => {
+  let sinon;
   let store;
+
+  beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
+  });
 
   afterEach(function() {
     store.clear();
+    sinon.restore();
   });
 
   describe('when localStorage is available', function() {

--- a/tests/unit/session-stores/cookie-test.js
+++ b/tests/unit/session-stores/cookie-test.js
@@ -1,15 +1,21 @@
 import { describe, beforeEach } from 'mocha';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import createCookieStore from '../../helpers/create-cookie-store';
 
 describe('CookieStore', () => {
+  let sinon;
   let store;
 
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     store = createCookieStore(FakeCookieService.create());
+  });
+
+  afterEach(function() {
+    sinon.restore();
   });
 
   itBehavesLikeAStore({

--- a/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -7,7 +7,7 @@ import {
   it
 } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 import FakeCookieService from '../../../helpers/fake-cookie-service';
 
 let warnings;
@@ -22,6 +22,7 @@ registerWarnHandler((message, options, next) => {
 });
 
 export default function(options) {
+  let sinon;
   let store;
   let createStore;
   let renew;
@@ -31,6 +32,7 @@ export default function(options) {
 
   // eslint-disable-next-line mocha/no-top-level-hooks
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     createStore = options.createStore;
     renew = options.renew;
     sync = options.sync;
@@ -43,8 +45,7 @@ export default function(options) {
 
   // eslint-disable-next-line mocha/no-top-level-hooks
   afterEach(function() {
-    cookieService.read.restore();
-    cookieService.write.restore();
+    sinon.restore();
     store.clear();
   });
 

--- a/tests/unit/session-stores/shared/storage-event-handler-behavior.js
+++ b/tests/unit/session-stores/shared/storage-event-handler-behavior.js
@@ -1,14 +1,21 @@
 import { run } from '@ember/runloop';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinonjs from 'sinon';
 
 export default function(options) {
+  let sinon;
   let store;
 
   // eslint-disable-next-line mocha/no-top-level-hooks
   beforeEach(function() {
+    sinon = sinonjs.sandbox.create();
     store = options.store();
+  });
+
+  // eslint-disable-next-line mocha/no-top-level-hooks
+  afterEach(function() {
+    sinon.restore();
   });
 
   describe('storage events', function() {


### PR DESCRIPTION
This uses the sinon sandbox and correctly cleans up after the tests have run. That also allows us to remove some of the individual `restore` calls on stubbed methods.

closes #1626 