### PR TITLE
lock jsdom to ^11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,8 @@
       "eslint-plugin-ember",
       "eslint-plugin-mocha"
     ]
+  },
+  "resolutions": {
+    "jsdom": "^11.10.0"
   }
 }


### PR DESCRIPTION
This should fix the build - versions of jsdom > 11 don't work with Node 6 which we still support.