### PR TITLE
Add resolveWithResponse to oauth2-password-grant

### DIFF
--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -209,6 +209,27 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         });
       });
 
+      describe('when resolveWithResponse is enabled', function() {
+        beforeEach(function() {
+          authenticator.set('resolveWithResponse', true);
+          server.post('/token', () => [200, { 'Content-Type': 'application/json', 'X-Custom-Context': 'foobar' }, '{ "access_token": "secret token!" }']);
+        });
+
+        it('responds with response object containing responseJSON', function(done) {
+          authenticator.authenticate('username', 'password').then((data) => {
+            expect(data.responseJSON).to.eql({ 'access_token': 'secret token!' });
+            done();
+          });
+        });
+
+        it('provides access to custom headers', function(done) {
+          authenticator.authenticate('username', 'password').then((data) => {
+            expect(data.headers.get('x-custom-context')).to.eql('foobar');
+            done();
+          });
+        });
+      });
+
       describe('when the server response includes expiration data', function() {
         beforeEach(function() {
           server.post('/token', () => [200, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token!", "expires_in": 12345, "refresh_token": "refresh token!" }']);


### PR DESCRIPTION
This is an implementation suggestion to cover issue #1714.

This adds the `resolveWithResponse` property to `oauth2-password-grant`. When enabled, this will allow for the return of the full response object upon successful authentication. This allows the consumer to pull details from the response header if desired.