### PR TITLE
Fix "Use of `merge`" deprecation warning in oauth2-password-grant when...

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -378,7 +378,7 @@ export default BaseAuthenticator.extend({
     if (!this.get('sendClientIdAsQueryParam')) {
       const clientIdHeader = this.get('_clientIdHeader');
       if (!isEmpty(clientIdHeader)) {
-        merge(options.headers, clientIdHeader);
+        assign(options.headers, clientIdHeader);
       }
     }
 


### PR DESCRIPTION
...used with clientIdHeader.

The functionality seems to have been implemented without considering the previously implemented workaround for this deprecation warning (https://github.com/simplabs/ember-simple-auth/pull/941/files).