### PR TITLE
Fix volatile deprecations

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -109,21 +109,17 @@ export default BaseAuthenticator.extend({
     multiple tabs, we need to prevent the tabs from sending refresh token
     request at the same exact moment.
 
-    __When overriding this property, make sure to mark the overridden property
-    as volatile so it will actually have a different value each time it is
-    accessed.__
-
     @property tokenRefreshOffset
     @type Integer
     @default a random number between 5 and 10
     @public
   */
-  tokenRefreshOffset: computed(function() {
+  get tokenRefreshOffset() {
     const min = 5;
     const max = 10;
 
     return (Math.floor(Math.random() * (max - min)) + min) * 1000;
-  }).volatile(),
+  },
 
   _refreshTokenTimeout: null,
 

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -141,22 +141,22 @@ export default BaseStore.extend({
     return owner && owner.lookup('service:fastboot');
   }),
 
-  _secureCookies: computed(function() {
+  get _secureCookies() {
     if (this.get('_fastboot.isFastBoot')) {
       return this.get('_fastboot.request.protocol') === 'https';
     }
 
     return window.location.protocol === 'https:';
-  }).volatile(),
+  },
 
-  _isPageVisible: computed(function() {
+  get _isPageVisible() {
     if (this.get('_fastboot.isFastBoot')) {
       return false;
     } else {
       const visibilityState = typeof document !== 'undefined' ? document.visibilityState || 'visible' : false;
       return visibilityState === 'visible';
     }
-  }).volatile(),
+  },
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
Handles this https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile as well as removing the unneeded `ember-getowner-polyfill`.