### PR TITLE
Migrate away from volatile cps to methods

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -104,11 +104,6 @@ export default BaseAuthenticator.extend({
   refreshAccessTokens: true,
 
   /**
-    The offset time in milliseconds to refresh the access token. This must
-    return a random number. This randomization is needed because in case of
-    multiple tabs, we need to prevent the tabs from sending refresh token
-    request at the same exact moment.
-
     __When overriding this property, make sure to mark the overridden property
     as volatile so it will actually have a different value each time it is
     accessed.__
@@ -119,11 +114,33 @@ export default BaseAuthenticator.extend({
     @public
   */
   tokenRefreshOffset: computed(function() {
+    deprecate(`Ember Simple Auth: 'tokenRefreshOffset' is deprecated. Use getTokenRefreshOffset()`, false, {
+      id: 'ember-simple-auth.authenticators.oauth2.token-refresh-offset',
+      until: '2.0.0',
+      url: 'https://github.com/simplabs/ember-simple-auth#token-refresh'
+    });
+
+    return this.getTokenRefreshOffset();
+  }).volatile(),
+
+
+  /**
+    The offset time in milliseconds to refresh the access token. This must
+    return a random number. This randomization is needed because in case of
+    multiple tabs, we need to prevent the tabs from sending refresh token
+    request at the same exact moment.
+
+    @method getTokenRefreshOffset
+    @type Integer
+    @return a random number between 5 and 10
+    @public
+  */
+  getTokenRefreshOffset() {
     const min = 5;
     const max = 10;
 
     return (Math.floor(Math.random() * (max - min)) + min) * 1000;
-  }).volatile(),
+  },
 
   _refreshTokenTimeout: null,
 
@@ -409,7 +426,7 @@ export default BaseAuthenticator.extend({
       if (isEmpty(expiresAt) && !isEmpty(expiresIn)) {
         expiresAt = new Date(now + expiresIn * 1000).getTime();
       }
-      const offset = this.get('tokenRefreshOffset');
+      const offset = this.getTokenRefreshOffset();
       if (!isEmpty(refreshToken) && !isEmpty(expiresAt) && expiresAt > now - offset) {
         run.cancel(this._refreshTokenTimeout);
         delete this._refreshTokenTimeout;

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -141,22 +141,22 @@ export default BaseStore.extend({
     return owner && owner.lookup('service:fastboot');
   }),
 
-  _secureCookies: computed(function() {
+  _secureCookies() {
     if (this.get('_fastboot.isFastBoot')) {
       return this.get('_fastboot.request.protocol') === 'https';
     }
 
     return window.location.protocol === 'https:';
-  }).volatile(),
+  },
 
-  _isPageVisible: computed(function() {
+  _isPageVisible() {
     if (this.get('_fastboot.isFastBoot')) {
       return false;
     } else {
       const visibilityState = typeof document !== 'undefined' ? document.visibilityState || 'visible' : false;
       return visibilityState === 'visible';
     }
-  }).volatile(),
+  },
 
   init() {
     this._super(...arguments);
@@ -237,7 +237,7 @@ export default BaseStore.extend({
       domain: this.get('cookieDomain'),
       expires: isEmpty(expiration) ? null : new Date(expiration),
       path: this.get('cookiePath'),
-      secure: this.get('_secureCookies')
+      secure: this._secureCookies()
     };
     if (this._oldCookieName) {
       A([this._oldCookieName, `${this._oldCookieName}-expiration_time`]).forEach((oldCookie) => {
@@ -281,7 +281,7 @@ export default BaseStore.extend({
       cancel(this._renewExpirationTimeout);
       this._renewExpirationTimeout = later(this, this._renewExpiration, 60000);
     }
-    if (this.get('_isPageVisible')) {
+    if (this._isPageVisible()) {
       return this._renew();
     } else {
       return RSVP.resolve();


### PR DESCRIPTION
Volatile computed properties are now deprecated in 3.9.

This PR transitions each of the existing volatile computed properties into methods. Only one of them was public, so the volatile computed property still exists with a deprecation message (I didn't put much though into the deprecation message, documentation link, version, etc).

Comments appreciated!
