### PR TITLE
Replaced .volatile properties with native getters

### DIFF
--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -141,23 +141,21 @@ export default BaseStore.extend({
     return owner && owner.lookup('service:fastboot');
   }),
 
-  _secureCookies: computed(function() {
+  get _secureCookies() {
     if (this.get('_fastboot.isFastBoot')) {
       return this.get('_fastboot.request.protocol') === 'https';
     }
 
-    return window.location.protocol === 'https:';
-  }).volatile(),
-
-  _isPageVisible: computed(function() {
-    if (this.get('_fastboot.isFastBoot')) {
+    return window.location.protocol === 'https:';    
+  },
+  get _isPageVisible () {
+      if (this.get('_fastboot.isFastBoot')) {
       return false;
     } else {
       const visibilityState = typeof document !== 'undefined' ? document.visibilityState || 'visible' : false;
       return visibilityState === 'visible';
     }
-  }).volatile(),
-
+  },
   init() {
     this._super(...arguments);
 


### PR DESCRIPTION
My app throws the following deprecation notice.

```
deprecate.js:120 DEPRECATION: Setting a computed property as volatile has been deprecated. Instead, consider using a native getter with native class syntax. [deprecation id: computed-property.volatile] See https://emberjs.com/deprecations/v3.x#toc_computed-property-volatile for more details.
```
The pull request converts them to native getters.