### PR TITLE
CI: Only run for `master` branch, version tags and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
----
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+\.\d+/  # npm version tags
+
 language: node_js
 node_js:
   - "6"


### PR DESCRIPTION
This prevents double-runs for dependabot PRs and PRs from `simplabs` branches, which cuts the CI time in half for those PRs.

Copied from https://github.com/ember-cli/ember-addon-output/blob/v3.10.0/.travis.yml#L23-L27