### PR TITLE
CI: Run deployment job only when a tag is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ jobs:
     - env: SCRIPT="test:one ember-canary"
 
     - stage: 'Deploy'
+      if: tag IS present
       script: skip     # usually you do not want to rerun any tests
       deploy:
-        # ...
         provider: npm
         email: info@simplabs.com
         api_key:


### PR DESCRIPTION
looks like `on: tags: true` is not enough when using the `jobs` feature of TravisCI