### PR TITLE
Remove unused `mocha-only-detector` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "marked": "^0.6.0",
     "mermaid": "^7.0.3",
     "mocha": "^6.0.2",
-    "mocha-only-detector": "^1.0.0",
     "morgan": "^1.8.2",
     "rimraf": "^2.6.1",
     "sinon-chai": "~3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4879,7 +4879,7 @@ esprima@^3.1.3, esprima@~3.1.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -4888,11 +4888,6 @@ esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
   integrity sha1-U88kes2ncxPlUcOqLnM0LT+099k=
-
-esprimaq@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/esprimaq/-/esprimaq-0.0.1.tgz#3ea3a41f55ba0ab98fc3564c875818bd890aa2a3"
-  integrity sha1-PqOkH1W6CrmPw1ZMh1gYvYkKoqM=
 
 esquery@^1.0.1:
   version "1.0.1"
@@ -7814,15 +7809,6 @@ mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha1-bQUVYRyKjITkhKogABKbmOmB/ws=
-
-mocha-only-detector@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mocha-only-detector/-/mocha-only-detector-1.0.1.tgz#a60392d253653fb3da77d783ed96aec8eaa7293e"
-  integrity sha512-lTnCIwmL5xKS4dWa+vlYfTOwioG1Vot5KUE5bD1jvwCHGmJUk71g9QHuy1B99r52Mih2cFQmLWlfeOyFXVqRxw==
-  dependencies:
-    esprima "^4.0.1"
-    esprimaq "^0.0.1"
-    glob "^7.1.2"
 
 mocha@^2.5.3:
   version "2.5.3"


### PR DESCRIPTION
We don't seem to be using this anymore and `eslint-plugin-mocha` should take care of this these days.