### PR TITLE
 oauth2-password-grant: Convert `tokenRefreshOffset` to a native getter 

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -118,12 +118,12 @@ export default BaseAuthenticator.extend({
     @default a random number between 5 and 10
     @public
   */
-  tokenRefreshOffset: computed(function() {
+  get tokenRefreshOffset() {
     const min = 5;
     const max = 10;
 
     return (Math.floor(Math.random() * (max - min)) + min) * 1000;
-  }).volatile(),
+  },
 
   _refreshTokenTimeout: null,
 

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import { tryInvoke } from '@ember/utils';
 import {
   describe,
@@ -380,6 +381,14 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
     it('returns a number between 5000 and 10000', function() {
       expect(authenticator.get('tokenRefreshOffset')).to.be.at.least(5000);
       expect(authenticator.get('tokenRefreshOffset')).to.be.below(10000);
+    });
+
+    it('can be overridden in a subclass', function() {
+      let authenticator = OAuth2PasswordGrant.extend({
+        tokenRefreshOffset: computed(() => 42).volatile(),
+      }).create();
+
+      expect(authenticator.get('tokenRefreshOffset')).to.equal(42);
     });
   });
 

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -377,10 +377,9 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
   });
 
   describe('#tokenRefreshOffset', function() {
-    it('returns a number between 5000 and 10000', function(done) {
+    it('returns a number between 5000 and 10000', function() {
       expect(authenticator.get('tokenRefreshOffset')).to.be.at.least(5000);
       expect(authenticator.get('tokenRefreshOffset')).to.be.below(10000);
-      done();
     });
   });
 


### PR DESCRIPTION
This should resolve one part of https://github.com/simplabs/ember-simple-auth/issues/1799