### PR TITLE
[Docs] use async/await when loading current user

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -150,9 +150,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     return this._loadCurrentUser();
   },
 
-  sessionAuthenticated() {
+  async sessionAuthenticated() {
+    await this._loadCurrentUser();
     this._super(...arguments);
-    this._loadCurrentUser();
   },
 
   _loadCurrentUser() {


### PR DESCRIPTION
use async/await when loading current user so that the post-authentication transition won't happen until the user has finished loading

https://github.com/simplabs/ember-simple-auth/issues/1838