### PR TITLE
Rename `_router` property to `_authRouter` to avoid conflicts

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -62,7 +62,7 @@ export default Mixin.create({
   */
   session: service('session'),
 
-  _router: computed(function() {
+  _authRouter: computed(function() {
     let owner = getOwner(this);
     return owner.lookup('service:router') || owner.lookup('router:main');
   }),
@@ -128,6 +128,6 @@ export default Mixin.create({
     let authenticationRoute = this.get('authenticationRoute');
     assert('The route configured as Configuration.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== authenticationRoute);
 
-    this.get('_router').transitionTo(authenticationRoute);
+    this.get('_authRouter').transitionTo(authenticationRoute);
   },
 });

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -61,7 +61,7 @@ describe('AuthenticatedRouteMixin', () => {
 
       route = createWithContainer(Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin, {}), {
         session,
-        _router: router
+        _authRouter: router
       }, containerMock);
 
       sinon.spy(transition, 'send');
@@ -82,7 +82,7 @@ describe('AuthenticatedRouteMixin', () => {
       it('does not transition to the authentication route', function() {
         route.beforeModel(transition);
 
-        expect(route._router.transitionTo).to.not.have.been.calledWith(Configuration.authenticationRoute);
+        expect(route._authRouter.transitionTo).to.not.have.been.calledWith(Configuration.authenticationRoute);
       });
     });
 
@@ -96,7 +96,7 @@ describe('AuthenticatedRouteMixin', () => {
         route.set('authenticationRoute', authenticationRoute);
 
         route.beforeModel(transition);
-        expect(route._router.transitionTo).to.have.been.calledWith(authenticationRoute);
+        expect(route._authRouter.transitionTo).to.have.been.calledWith(authenticationRoute);
       });
 
       it('sets the redirectTarget cookie in fastboot', function() {


### PR DESCRIPTION
This is a subset of #1841 as requested by @locks:
https://discordapp.com/channels/480462759797063690/491905849405472769/600683165929177091