### PR TITLE
Don't schedule token refresh checks in FastBoot

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -13,6 +13,7 @@ import { deprecate } from '@ember/application/deprecations';
 import Ember from 'ember';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
+import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 const assign = emberAssign || merge;
 const keys = Object.keys || emberKeys; // Ember.keys deprecated in 1.13
@@ -403,7 +404,7 @@ export default BaseAuthenticator.extend({
   },
 
   _scheduleAccessTokenRefresh(expiresIn, expiresAt, refreshToken) {
-    const refreshAccessTokens = this.get('refreshAccessTokens');
+    const refreshAccessTokens = this.get('refreshAccessTokens') && !isFastBoot();
     if (refreshAccessTokens) {
       const now = (new Date()).getTime();
       if (isEmpty(expiresAt) && !isEmpty(expiresIn)) {


### PR DESCRIPTION
In FastBoot mode timers were being scheduled for refreshing an access token. This doesn't make a ton of sense in FastBoot since there's no long-live session.

I couldn't find an example of a FastBoot specific test (I imagine because Pretender doesn't run on the server ... yet!). If someone can point me to one to copy, I can update this PR.

I did verify that this resoles the issues we encountered in #1912.

Closes #1912