### PR TITLE
Fix outdated guide.

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -151,8 +151,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   },
 
   async sessionAuthenticated() {
+    let _super = this._super;
     await this._loadCurrentUser();
-    this._super(...arguments);
+    _super.call(this, ...arguments);
   },
 
   _loadCurrentUser() {


### PR DESCRIPTION
Per https://github.com/ember-cli/ember-cli/issues/6282, we can't call ``this._super`` after ``await`` anymore. This updates the guide to conform to these changes. Had me stuck a while.