### PR TITLE
deprecate rejectWithResponse=false

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -3,6 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { run } from '@ember/runloop';
 import { merge, assign as emberAssign } from '@ember/polyfills';
 import { computed } from '@ember/object';
+import { deprecate } from '@ember/application/deprecations';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
 
@@ -140,6 +141,14 @@ export default BaseAuthenticator.extend({
   authenticate(identification, password) {
     return new Promise((resolve, reject) => {
       const useResponse = this.get('rejectWithResponse');
+
+      if (!useResponse) {
+        deprecate('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.', false, {
+          id: `ember-simple-auth.authenticator.no-reject-with-response`,
+          until: '2.0.0'
+        });
+      }
+
       const { resourceName, identificationAttributeName, tokenAttributeName } = this.getProperties('resourceName', 'identificationAttributeName', 'tokenAttributeName');
       const data = {};
       data[resourceName] = { password };

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -280,6 +280,14 @@ export default BaseAuthenticator.extend({
       const data = { 'grant_type': 'password', username: identification, password };
       const serverTokenEndpoint = this.get('serverTokenEndpoint');
       const useResponse = this.get('rejectWithResponse');
+
+      if (!useResponse) {
+        deprecate('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.', false, {
+          id: `ember-simple-auth.authenticator.no-reject-with-response`,
+          until: '2.0.0'
+        });
+      }
+
       const scopesString = makeArray(scope).join(' ');
       if (!isEmpty(scopesString)) {
         data.scope = scopesString;

--- a/tests/unit/authenticators/devise-test.js
+++ b/tests/unit/authenticators/devise-test.js
@@ -1,4 +1,5 @@
 import { tryInvoke } from '@ember/utils';
+import { registerDeprecationHandler } from '@ember/debug';
 import {
   describe,
   beforeEach,
@@ -59,6 +60,20 @@ describe('DeviseAuthenticator', () => {
         expect(JSON.parse(request.requestBody)).to.eql({ user: { email: 'identification', password: 'password' } });
         expect(request.requestHeaders['content-type']).to.eql('application/json');
         expect(request.requestHeaders.accept).to.eql('application/json');
+      });
+    });
+
+    it('shows a deprecation warning when rejectWithResponse is not enabled', function() {
+      authenticator.set('rejectWithResponse', false);
+
+      let warnings = [];
+      registerDeprecationHandler((message, options, next) => {
+        warnings.push(message);
+        next(message, options);
+      });
+
+      return authenticator.authenticate('identification', 'password').then(() => {
+        expect(warnings[0]).to.eq('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.');
       });
     });
 


### PR DESCRIPTION
This deprecates relying on the current default value of `false` for the `rejectWithResponse` in the OAuth 2.0 Password Grant and Devise authenticators. We want to remove the property in the future and need everyone to switch to the new behavior before we can do that. That deprecation should have been added long ago already 🤦‍♂ 