### PR TITLE
Deprecate data adapter mixin elements

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -67,6 +67,7 @@ export default Mixin.create({
     ```
 
     @property authorizer
+    @deprecated DataAdapterMixin/authorizer:property
     @type String
     @default null
     @public

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -1,4 +1,5 @@
 import { inject as service } from '@ember/service';
+import { deprecate } from '@ember/application/deprecations';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
@@ -126,9 +127,15 @@ export default Mixin.create({
     See `ajaxOptions` instead.
 
     @method headersForRequest
+    @deprecated DataAdapterMixin/headersForRequest:method
     @protected
    */
   headersForRequest() {
+    deprecate('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, implement the authorize method or the headers property.', false, {
+      id: `ember-simple-auth.data-adapter-mixin.headers-for-request`,
+      until: '2.0.0'
+    });
+
     const authorizer = this.get('authorizer');
     assert("You're using the DataAdapterMixin without specifying an authorizer. Please add `authorizer: 'authorizer:application'` to your adapter.", isPresent(authorizer));
 

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import { registerDeprecationHandler } from '@ember/debug';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
@@ -123,6 +124,18 @@ describe('DataAdapterMixin', () => {
   });
 
   describe('#headersForRequest', function() {
+    it('shows a deprecation warning', function() {
+      let warnings = [];
+      registerDeprecationHandler((message, options, next) => {
+        warnings.push(message);
+        next(message, options);
+      });
+
+      adapter.headersForRequest();
+
+      expect(warnings[0]).to.eq('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, implement the authorize method or the headers property.');
+    });
+
     it('preserves existing headers by parent adapter', function() {
       const headers = adapter.headersForRequest();
 


### PR DESCRIPTION
This deprecates the `DataAdapterMixin`'s `authorizer` property and `headersForRequest` method that will effectively be removed in 2.0 with the removal on authorizers.