### PR TITLE
add missing test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
     - env: SCRIPT="test:one ember-lts-2.16"
     - env: SCRIPT="test:one ember-lts-2.18"
     - env: SCRIPT="test:one ember-3.0"
+    - env: SCRIPT="test:one ember-lts-3.4"
+    - env: SCRIPT="test:one ember-lts-3.8"
+    - env: SCRIPT="test:one ember-lts-3.12"
     - env: SCRIPT="test:one ember-beta"
     - env: SCRIPT=test:node
     - env: SCRIPT=test:fastboot

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -169,6 +169,54 @@ module.exports = function() {
           },
         },
         {
+          name: 'ember-lts-3.4',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.4.0',
+              'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.8',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.8.0',
+              'ember-source': '~3.8.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.12',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.12.0',
+              'ember-source': '~3.12.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           bower: {
             dependencies: {


### PR DESCRIPTION
This adds missing test environments for more recent Ember.js versions to our Travis pipeline, specifically for the 3.4, 3.8 and 3.12 releases.