### PR TITLE
Deprecate authorize method

### DIFF
--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -90,6 +90,7 @@ export default Mixin.create({
     `headersForRequest` *should* replace it after the resolution of the RFC.
 
     @method ajaxOptions
+    @deprecated DataAdapterMixin/ajaxOptions:method
     @protected
   */
   ajaxOptions() {
@@ -103,6 +104,10 @@ export default Mixin.create({
           xhr.setRequestHeader(headerName, headerValue);
         });
       } else {
+        deprecate('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
+          id: `ember-simple-auth.data-adapter-mixin.authorize`,
+          until: '3.0.0'
+        });
         this.authorize(xhr);
       }
 

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -146,7 +146,7 @@ export default Mixin.create({
   headersForRequest() {
     deprecate('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
       id: `ember-simple-auth.data-adapter-mixin.headers-for-request`,
-      until: '2.0.0'
+      until: '3.0.0'
     });
 
     const authorizer = this.get('authorizer');

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -132,7 +132,7 @@ export default Mixin.create({
     @protected
    */
   headersForRequest() {
-    deprecate('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, implement the authorize method or the headers property.', false, {
+    deprecate('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
       id: `ember-simple-auth.data-adapter-mixin.headers-for-request`,
       until: '2.0.0'
     });

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -6,10 +6,9 @@ import { isPresent } from '@ember/utils';
 
 /**
   __This mixin can be used to make Ember Data adapters authorize all outgoing
-  API requests by injecting a header.__ It works with all authorizers that call
-  the authorization callback (see
-  {{#crossLink "BaseAuthorizer/authorize:method"}}{{/crossLink}}) with header
-  name and header content arguments.
+  API requests by injecting a header.__ The adapter's `headers` property can be
+  set using data read from the `session` service that is injected by this
+  mixin.
 
   __The `DataAdapterMixin` will also invalidate the session whenever it
   receives a 401 response for an API request.__
@@ -20,7 +19,15 @@ import { isPresent } from '@ember/utils';
   import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
   export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-    authorizer: 'authorizer:application'
+      headers: computed('session.data.authenticated.token', function() {
+        let headers = {};
+        if (this.session.isAuthenticated) {
+          headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
+        }
+
+        return headers;
+      }),
+    }
   });
   ```
 

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -19,15 +19,14 @@ import { isPresent } from '@ember/utils';
   import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
   export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-      headers: computed('session.data.authenticated.token', function() {
-        let headers = {};
-        if (this.session.isAuthenticated) {
-          headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
-        }
+    headers: computed('session.data.authenticated.token', function() {
+      let headers = {};
+      if (this.session.isAuthenticated) {
+        headers['Authorization'] = `Bearer ${this.session.data.authenticated.token}`;
+      }
 
-        return headers;
-      }),
-    }
+      return headers;
+    })
   });
   ```
 

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -133,7 +133,7 @@ describe('DataAdapterMixin', () => {
 
       adapter.headersForRequest();
 
-      expect(warnings[0]).to.eq('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, implement the authorize method or the headers property.');
+      expect(warnings[0]).to.eq('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, set the headers property or implement it as a computed property.');
     });
 
     it('preserves existing headers by parent adapter', function() {

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -69,6 +69,21 @@ describe('DataAdapterMixin', () => {
       expect(authorize).to.have.been.called;
     });
 
+    it('shows a deprecation warning when `authorize` is called', function() {
+      let warnings = [];
+      registerDeprecationHandler((message, options, next) => {
+        warnings.push(message);
+        next(message, options);
+      });
+
+      adapter.authorize = () => {};
+      adapter.set('authorizer', null);
+      adapter.ajaxOptions();
+      hash.beforeSend();
+
+      expect(warnings[0]).to.eq('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.');
+    });
+
     it('preserves an existing beforeSend hook', function() {
       const existingBeforeSend = sinon.spy();
       hash.beforeSend = existingBeforeSend;


### PR DESCRIPTION
This deprecates the `DataAdapterMixin`'s `authorize` method in favor of setting the `headers` property on the adapter.