### PR TITLE
Fix deprecation until versions

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -84,7 +84,7 @@ export default BaseAuthenticator.extend({
   */
   rejectWithXhr: computed.deprecatingAlias('rejectWithResponse', {
     id: `ember-simple-auth.authenticator.reject-with-xhr`,
-    until: '2.0.0'
+    until: '3.0.0'
   }),
 
   /**

--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -145,7 +145,7 @@ export default BaseAuthenticator.extend({
       if (!useResponse) {
         deprecate('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.', false, {
           id: `ember-simple-auth.authenticator.no-reject-with-response`,
-          until: '2.0.0'
+          until: '3.0.0'
         });
       }
 

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -284,7 +284,7 @@ export default BaseAuthenticator.extend({
       if (!useResponse) {
         deprecate('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.', false, {
           id: `ember-simple-auth.authenticator.no-reject-with-response`,
-          until: '2.0.0'
+          until: '3.0.0'
         });
       }
 

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -152,7 +152,7 @@ export default BaseAuthenticator.extend({
   */
   rejectWithXhr: computed.deprecatingAlias('rejectWithResponse', {
     id: `ember-simple-auth.authenticator.reject-with-xhr`,
-    until: '2.0.0'
+    until: '3.0.0'
   }),
 
   /**
@@ -270,7 +270,7 @@ export default BaseAuthenticator.extend({
         false,
         {
           id: 'ember-simple-auth.oauth2-password-grant-authenticator.client-id-as-authorization',
-          until: '2.0.0',
+          until: '3.0.0',
           url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-client-id-as-header',
         }
       );

--- a/addon/authorizers/base.js
+++ b/addon/authorizers/base.js
@@ -29,7 +29,7 @@ export default EmberObject.extend({
       false,
       {
         id: 'ember-simple-auth.baseAuthorizer',
-        until: '2.0.0',
+        until: '3.0.0',
         url: 'https://github.com/simplabs/ember-simple-auth#deprecation-of-authorizers',
       }
     );

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -43,7 +43,7 @@ export default {
   get baseURL() {
     deprecate('The baseURL property should no longer be used. Instead, use rootURL.', false, {
       id: `ember-simple-auth.configuration.base-url`,
-      until: '2.0.0'
+      until: '3.0.0'
     });
     return this.rootURL;
   },
@@ -97,7 +97,7 @@ export default {
       if (['authenticationRoute', 'routeAfterAuthentication', 'routeIfAlreadyAuthenticated'].indexOf(property) >= 0 && DEFAULTS[property] !== this[property]) {
         deprecate(`Ember Simple Auth: ${property} should no longer be overridden in the configuration. Instead, override the ${property} property in the route.`, false, {
           id: `ember-simple-auth.configuration.routes`,
-          until: '2.0.0'
+          until: '3.0.0'
         });
       }
 

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -97,7 +97,7 @@ export default ObjectProxy.extend(Evented, {
     if (typeof result === 'undefined' || typeof result.then === 'undefined') {
       deprecate(`Ember Simple Auth: Synchronous stores have been deprecated. Make sure your custom store's ${method} method returns a promise.`, false, {
         id: `ember-simple-auth.session-store.synchronous-${method}`,
-        until: '2.0.0'
+        until: '3.0.0'
       });
       return RSVP.Promise.resolve(result);
     } else {

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -134,7 +134,7 @@ export default Mixin.create({
   headersForRequest() {
     deprecate('Ember Simple Auth: The headersForRequest method should no longer be used. Instead, implement the authorize method or the headers property.', false, {
       id: `ember-simple-auth.data-adapter-mixin.headers-for-request`,
-      until: '2.0.0'
+      until: '3.0.0'
     });
 
     const authorizer = this.get('authorizer');

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -237,7 +237,7 @@ export default Service.extend(Evented, {
   authorize(authorizerFactory, block) {
     deprecate(`Ember Simple Auth: 'authorize' is deprecated.`, false, {
       id: 'ember-simple-auth.session.authorize',
-      until: '2.0.0',
+      until: '3.0.0',
       url: 'https://github.com/simplabs/ember-simple-auth#authorizers'
     });
     if (this.get('isAuthenticated')) {


### PR DESCRIPTION
When deprecating the `rejectWithResponse` for the `Devise` and `OAuth2PasswordGrant` authenticators, we put the wrong `until` version in the deprecation - that version should be `3.0.0` of course, not `2.0.0` which is the version the deprecations were introduced with.

This also updates all previous deprecations that we took over from 1.x and didn't actually remove in 2.0.0 to now say `until: '3.0.0'`.