### PR TITLE
upgrade ember-cli-babel dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-file-creator": "^2.0.0",
     "broccoli-funnel": "^1.2.0 || ^2.0.0",
     "broccoli-merge-trees": "^2.0.0 || ^3.0.0",
-    "ember-cli-babel": "^6.8.2",
+    "ember-cli-babel": "^7.12.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.3.0 || ^0.4.0",
     "ember-getowner-polyfill": "^1.1.0 || ^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,7 +4209,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.5.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.5.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.12.0.tgz#064997d199384be8c88d251f30ef67953d3bddc5"
   integrity sha512-+EGQsbPvh19nNXHCm6rVBx2CdlxQlzxMyhey5hsGViDPriDI4PFYXYaFWdGizDrmZoDcG/Ywpeph3hl0NxGQTg==


### PR DESCRIPTION
We were previously still using ember-cli-babel 6 which uses Babel 6.