### PR TITLE
Remove authorize assertion and update migration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ export default Base.extend({
 ### Deprecation of Authorizers
 
 Authorizers and the session service's `authorize` method are deprecated and
-will be removed from Ember Simple Auth 2.0. The concept seemed like a good idea
+will be removed from Ember Simple Auth 3.0. The concept seemed like a good idea
 in the early days of Ember Simple Auth, but proved to provide limited value for
 the added complexity. To replace authorizers in an application, simply get the
 session data from the session service and inject it where needed.
@@ -550,7 +550,7 @@ import DataAdapterMixin from "ember-simple-auth/mixins/data-adapter-mixin";
 const { JSONAPIAdapter } = DS;
 
 export default JSONAPIAdapter.extend(DataAdapterMixin, {
-  session: service(), 
+  session: service(),
   authorize(xhr) {
     let { access_token } = this.get('session.data.authenticated');
     if (isPresent(access_token)) {

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -4,8 +4,10 @@ import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
 import DS from 'ember-data';
+import { symbol } from '../utils/symbol';
+
 const { VERSION } = DS;
-const AUTHORIZE_SYMB = Symbol();
+const AUTHORIZE_SYMBOL = symbol('ORIGINAL_AUTHORIZE');
 
 /**
   __This mixin can be used to make Ember Data adapters authorize all outgoing
@@ -113,7 +115,7 @@ export default Mixin.create({
           xhr.setRequestHeader(headerName, headerValue);
         });
       } else {
-        if (this.authorize(xhr) !== AUTHORIZE_SYMB) {
+        if (this.authorize(xhr) !== AUTHORIZE_SYMBOL) {
           deprecate('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
             id: `ember-simple-auth.data-adapter-mixin.authorize`,
             until: '3.0.0'
@@ -133,7 +135,7 @@ export default Mixin.create({
 
     assert('The `authorize` method should be overridden in your application adapter. It should accept a single argument, the request object.', major_version >= 2);
 
-    return AUTHORIZE_SYMB;
+    return AUTHORIZE_SYMBOL;
   },
 
   /**

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -3,6 +3,8 @@ import { deprecate } from '@ember/application/deprecations';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
+import DS from 'ember-data';
+const { VERSION } = DS;
 
 /**
   __This mixin can be used to make Ember Data adapters authorize all outgoing
@@ -125,7 +127,9 @@ export default Mixin.create({
   },
 
   authorize() {
-    assert('The `authorize` method should be overridden in your application adapter. It should accept a single argument, the request object.');
+    let [major_version] = VERSION.split('.');
+
+    assert('The `authorize` method should be overridden in your application adapter. It should accept a single argument, the request object.', major_version >= 2);
   },
 
   /**

--- a/addon/mixins/data-adapter-mixin.js
+++ b/addon/mixins/data-adapter-mixin.js
@@ -5,6 +5,7 @@ import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
 import DS from 'ember-data';
 const { VERSION } = DS;
+const AUTHORIZE_SYMB = Symbol();
 
 /**
   __This mixin can be used to make Ember Data adapters authorize all outgoing
@@ -112,11 +113,12 @@ export default Mixin.create({
           xhr.setRequestHeader(headerName, headerValue);
         });
       } else {
-        deprecate('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
-          id: `ember-simple-auth.data-adapter-mixin.authorize`,
-          until: '3.0.0'
-        });
-        this.authorize(xhr);
+        if (this.authorize(xhr) !== AUTHORIZE_SYMB) {
+          deprecate('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.', false, {
+            id: `ember-simple-auth.data-adapter-mixin.authorize`,
+            until: '3.0.0'
+          });
+        }
       }
 
       if (beforeSend) {
@@ -130,6 +132,8 @@ export default Mixin.create({
     let [major_version] = VERSION.split('.');
 
     assert('The `authorize` method should be overridden in your application adapter. It should accept a single argument, the request object.', major_version >= 2);
+
+    return AUTHORIZE_SYMB;
   },
 
   /**

--- a/addon/utils/symbol.js
+++ b/addon/utils/symbol.js
@@ -1,0 +1,15 @@
+/**
+ * This symbol provides a Symbol replacement for browsers that do not have it
+ * (eg. IE 11).
+ *
+ * The replacement is different from the native Symbol in some ways. It is a
+ * function that produces an output:
+ * - iterable;
+ * - that is a string, not a symbol.
+ *
+ * @internal
+ */
+export const symbol =
+  typeof Symbol !== 'undefined'
+    ? Symbol
+    : (key) => `__${key}${Math.floor(Math.random() * Date.now())}__`;

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -54,17 +54,18 @@ describe('DataAdapterMixin', () => {
       expect(hash).to.have.ownProperty('beforeSend');
     });
 
-    if (ed_major_version < 2) {
-      it('asserts `authorize` is overridden', function() {
-        adapter.set('authorizer', null);
+    it('asserts `authorize` is overridden', function() {
+      if (ed_major_version >= 2) {
+        this.skip();
+      }
 
+      adapter.set('authorizer', null);
 
-        expect(function() {
-          adapter.ajaxOptions();
-          hash.beforeSend();
-        }).to.throw(/Assertion Failed/);
-      });
-    }
+      expect(function() {
+        adapter.ajaxOptions();
+        hash.beforeSend();
+      }).to.throw(/Assertion Failed/);
+    });
 
     it('calls `authorize` when request is made', function() {
       const authorize = sinon.spy();
@@ -92,6 +93,10 @@ describe('DataAdapterMixin', () => {
     });
 
     it('does not show a deprecation warning when `authorize` is not overriden', function() {
+      if (ed_major_version < 2) {
+        this.skip();
+      }
+
       let warnings = [];
       registerDeprecationHandler((message, options, next) => {
         warnings.push(message);

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -76,7 +76,7 @@ describe('DataAdapterMixin', () => {
       expect(authorize).to.have.been.called;
     });
 
-    it('shows a deprecation warning when `authorize` is called', function() {
+    it('shows a deprecation warning when `authorize` was overriden and is called', function() {
       let warnings = [];
       registerDeprecationHandler((message, options, next) => {
         warnings.push(message);
@@ -89,6 +89,20 @@ describe('DataAdapterMixin', () => {
       hash.beforeSend();
 
       expect(warnings[0]).to.eq('Ember Simple Auth: The authorize method should no longer be used. Instead, set the headers property or implement it as a computed property.');
+    });
+
+    it('does not show a deprecation warning when `authorize` is not overriden', function() {
+      let warnings = [];
+      registerDeprecationHandler((message, options, next) => {
+        warnings.push(message);
+        next(message, options);
+      });
+
+      adapter.set('authorizer', null);
+      adapter.ajaxOptions();
+      hash.beforeSend();
+
+      expect(warnings.length).to.eq(0);
     });
 
     it('preserves an existing beforeSend hook', function() {

--- a/tests/unit/mixins/data-adapter-mixin-test.js
+++ b/tests/unit/mixins/data-adapter-mixin-test.js
@@ -3,7 +3,11 @@ import { registerDeprecationHandler } from '@ember/debug';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
+import DS from 'ember-data';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+
+const { VERSION } = DS;
+const [ed_major_version] = VERSION.split('.');
 
 describe('DataAdapterMixin', () => {
   let sinon;
@@ -50,14 +54,17 @@ describe('DataAdapterMixin', () => {
       expect(hash).to.have.ownProperty('beforeSend');
     });
 
-    it('asserts `authorize` is overridden', function() {
-      adapter.set('authorizer', null);
+    if (ed_major_version < 2) {
+      it('asserts `authorize` is overridden', function() {
+        adapter.set('authorizer', null);
 
-      expect(function() {
-        adapter.ajaxOptions();
-        hash.beforeSend();
-      }).to.throw(/Assertion Failed/);
-    });
+
+        expect(function() {
+          adapter.ajaxOptions();
+          hash.beforeSend();
+        }).to.throw(/Assertion Failed/);
+      });
+    }
 
     it('calls `authorize` when request is made', function() {
       const authorize = sinon.spy();


### PR DESCRIPTION
Related to the StackOverflow question in https://github.com/simplabs/ember-simple-auth/issues/1998.

We are showing a deprecation warning that tells the user to use `headers` instead of `authorize`, but we also have an assert in `authorize` if it's not overridden, this causes an error when using ajax.