### PR TITLE
Deprecate legacy response handling

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -397,13 +397,43 @@ export default BaseAuthenticator.extend({
           try {
             let json = JSON.parse(text);
             if (!response.ok) {
-              response.responseJSON = json;
+              Object.defineProperty(
+                response,
+                'responseJSON',
+                {
+                  get() {
+                    deprecate(`Ember Simple Auth: The response's responseJSON property is deprecated.`,
+                      false,
+                      {
+                        id: 'ember-simple-auth.oauth2-password-grant-authenticator.response-json',
+                        until: '3.0.0',
+                      }
+                    );
+                    return json;
+                  }
+                }
+              );
               reject(response);
             } else {
               resolve(json);
             }
           } catch (SyntaxError) {
-            response.responseText = text;
+            Object.defineProperty(
+              response,
+              'responseText',
+              {
+                get() {
+                  deprecate(`Ember Simple Auth: The response's responseText property is deprecated.`,
+                    false,
+                    {
+                      id: 'ember-simple-auth.oauth2-password-grant-authenticator.response-text',
+                      until: '3.0.0',
+                    }
+                  );
+                  return text;
+                }
+              }
+            );
             reject(response);
           }
         });

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -305,8 +305,8 @@ export default BaseAuthenticator.extend({
             resolve(json);
           }).catch(reject);
         }).catch(reject);
-      }, (response) => {
-        run(null, reject, rejectWithResponse ? response : (response.responseJSON || response.responseText));
+      }, (error) => {
+        run(null, reject, error);
       });
     });
   },
@@ -440,8 +440,8 @@ export default BaseAuthenticator.extend({
             resolve(data);
           }).catch(reject);
         }).catch(reject);
-      }, (response) => {
-        warn(`Access token could not be refreshed - server responded with ${response.responseJSON}.`, false, { id: 'ember-simple-auth.failedOAuth2TokenRefresh' });
+      }, (body) => {
+        warn(`Access token could not be refreshed - server responded with ${body}.`, false, { id: 'ember-simple-auth.failedOAuth2TokenRefresh' });
         reject();
       });
     });

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -504,7 +504,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         server.post('/token', () => [200, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }']);
       });
 
-      it('shows a deprecation warning when not resolcing with a Response object', function() {
+      it('shows a deprecation warning when not resolving with a Response object', function() {
         let warnings = [];
         registerDeprecationHandler((message, options, next) => {
           warnings.push(message);

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -115,6 +115,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           'password': 'password'
         });
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.authenticate('username', 'password');
@@ -124,6 +126,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       server.post('/token', (request) => {
         expect(request.requestHeaders['authorization']).to.eql('Basic dGVzdC1jbGllbnQ6');
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.set('clientId', 'test-client');
@@ -142,7 +146,11 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         next(message, options);
       });
 
-      server.post('/token', () => done());
+      server.post('/token', () => {
+        done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
+      });
       authenticator.set('clientId', 'test-client');
       authenticator.authenticate('username', 'password');
 
@@ -159,6 +167,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           'password': 'password'
         });
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.set('sendClientIdAsQueryParam', true);
@@ -170,6 +180,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
       server.post('/token', (request) => {
         expect(request.requestHeaders['x-custom-context']).to.eql('foobar');
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.authenticate('username', 'password', [], { 'X-Custom-Context': 'foobar' });
@@ -181,6 +193,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         let { scope } = parsePostData(requestBody);
         expect(scope).to.eql('public');
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.authenticate('username', 'password', 'public');
@@ -192,6 +206,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         let { scope } = parsePostData(requestBody);
         expect(scope).to.eql('public private');
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       authenticator.authenticate('username', 'password', ['public', 'private']);
@@ -204,6 +220,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         let { scope } = parsePostData(requestBody);
         expect(scope).to.eql('public private');
         done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
       });
 
       let warnings = [];
@@ -212,7 +230,11 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
         next(message, options);
       });
 
-      server.post('/token', () => done());
+      server.post('/token', () => {
+        done();
+
+        return [201, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token 2!" }'];
+      });
       authenticator.authenticate('username', 'password');
 
       expect(warnings[1]).to.eq('Ember Simple Auth: The default value of false for the rejectWithResponse property should no longer be relied on; instead set the property to true to enable the future behavior.');

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -290,6 +290,19 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           });
         });
 
+        it('shows a deprecation warning when accessing the responseJSON property', function() {
+          let warnings = [];
+          registerDeprecationHandler((message, options, next) => {
+            warnings.push(message);
+            next(message, options);
+          });
+
+          return authenticator.authenticate('username', 'password').catch((error) => {
+            error.responseJSON; // triggering deprecation
+            expect(warnings[1]).to.eq(`Ember Simple Auth: The response's responseJSON property is deprecated.`);
+          });
+        });
+
         it('provides access to custom headers', function() {
           return authenticator.authenticate('username', 'password').catch((error) => {
             expect(error.headers.get('x-custom-context')).to.eql('foobar');
@@ -319,6 +332,19 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           return authenticator.authenticate('username', 'password').catch((error) => {
             expect(error.responseJSON).to.not.exist;
             expect(error.responseText).to.eql('The server has failed completely.');
+          });
+        });
+
+        it('shows a deprecation warning when accessing the responseText property', function() {
+          let warnings = [];
+          registerDeprecationHandler((message, options, next) => {
+            warnings.push(message);
+            next(message, options);
+          });
+
+          return authenticator.authenticate('username', 'password').catch((error) => {
+            error.responseText; // triggering deprecation
+            expect(warnings[1]).to.eq(`Ember Simple Auth: The response's responseText property is deprecated.`);
           });
         });
 


### PR DESCRIPTION
This deprecates:

* returning anything but a `Response` object from the (overridable) `OAuth2PasswordGrant` authenticator's `makeRequest` method
* the custom `responseJSON` and `responseText` properties on the response object that we reject with after a failing request