### PR TITLE
remove ember-getowner-polyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-cli-babel": "^7.12.0",
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cookies": "^0.5.0",
-    "ember-getowner-polyfill": "^1.1.0 || ^2.0.0",
     "silent-error": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…as it's only needed for Ember < 2.3 which we're no longer supporting