### PR TITLE
disable FastBoot tests for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,8 @@ jobs:
           - test:one ember-release
           - test:one ember-beta
           - test:node
-          - test:fastboot
           - test:one ember-canary
         include:
-          - test-suite: "test:fastboot"
-            allow-failure: true
           - test-suite: "test:one ember-canary"
             allow-failure: true
 


### PR DESCRIPTION
We know that the FastBoot tests fail currently (and actually have known that for some time, see #1719 but until now nobody was able to fix that). The problem is that they don't just fail but they time out which means that our entire build takes more than 10min still (even if it should now be much faster as we're running it on github actions, see #2034). We could of course decrease the timeout so the build step fails faster but there's no real value in that over just disabling the tests completely for now - they aren't going to fix themselves and just start to work again anyway.

#1719 needs to be worked on though - we really should have proper test coverage that makes sure we're not breaking FastBoot support.