### PR TITLE
Fix deprecations regarding Computed Property Overrides

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -3,6 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { run } from '@ember/runloop';
 import { A, makeArray } from '@ember/array';
 import { warn } from '@ember/debug';
+import { getOwner } from '@ember/application';
 import {
   keys as emberKeys,
   merge,
@@ -329,7 +330,7 @@ export default BaseAuthenticator.extend({
   },
 
   _scheduleAccessTokenRefresh(expiresIn, expiresAt, refreshToken) {
-    const refreshAccessTokens = this.get('refreshAccessTokens') && !isFastBoot();
+    const refreshAccessTokens = this.get('refreshAccessTokens') && !isFastBoot(getOwner(this));
     if (refreshAccessTokens) {
       const now = (new Date()).getTime();
       if (isEmpty(expiresAt) && !isEmpty(expiresIn)) {

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -194,7 +194,7 @@ export default ObjectProxy.extend(Evented, {
 
   _lookupAuthenticator(authenticatorName) {
     let owner = getOwner(this);
-    let authenticator = getOwner(this).lookup(authenticatorName);
+    let authenticator = owner.lookup(authenticatorName);
     setOwner(authenticator, owner);
     return authenticator;
   }

--- a/addon/internal-session.js
+++ b/addon/internal-session.js
@@ -5,7 +5,7 @@ import Evented from '@ember/object/evented';
 import { merge, assign as emberAssign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
-import { getOwner } from '@ember/application';
+import { getOwner, setOwner } from '@ember/application';
 const assign = emberAssign || merge;
 
 export default ObjectProxy.extend(Evented, {
@@ -192,7 +192,10 @@ export default ObjectProxy.extend(Evented, {
     });
   },
 
-  _lookupAuthenticator(authenticator) {
-    return getOwner(this).lookup(authenticator);
+  _lookupAuthenticator(authenticatorName) {
+    let owner = getOwner(this);
+    let authenticator = getOwner(this).lookup(authenticatorName);
+    setOwner(authenticator, owner);
+    return authenticator;
   }
 });

--- a/addon/mixins/application-route-mixin.js
+++ b/addon/mixins/application-route-mixin.js
@@ -55,8 +55,6 @@ export default Mixin.create({
   */
   session: inject('session'),
 
-  _isFastBoot: isFastBoot(),
-
   /**
     The route to transition to after successful authentication.
 
@@ -69,6 +67,8 @@ export default Mixin.create({
 
   init() {
     this._super(...arguments);
+
+    this._isFastBoot = this.hasOwnProperty('_isFastBoot') ? this._isFastBoot : isFastBoot(getOwner(this));
     this._subscribeToSessionEvents();
   },
 

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -3,7 +3,7 @@ import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
-import isFastBootCPM, { isFastBoot } from '../utils/is-fastboot';
+import isFastBoot from '../utils/is-fastboot';
 
 /**
  * If the user is unauthenticated, invoke `callback`
@@ -65,8 +65,6 @@ export default Mixin.create({
     let owner = getOwner(this);
     return owner.lookup('service:router') || owner.lookup('router:main');
   }),
-
-  _isFastBoot: isFastBootCPM(),
 
   /**
     The route to transition to for authentication. The

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
-import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import isFastBoot from '../utils/is-fastboot';
 
@@ -61,11 +60,6 @@ export default Mixin.create({
   */
   session: service('session'),
 
-  _authRouter: computed(function() {
-    let owner = getOwner(this);
-    return owner.lookup('service:router') || owner.lookup('router:main');
-  }),
-
   /**
     The route to transition to for authentication. The
     {{#crossLink "AuthenticatedRouteMixin"}}{{/crossLink}} will transition to
@@ -123,6 +117,8 @@ export default Mixin.create({
     let authenticationRoute = this.get('authenticationRoute');
     assert('The route configured as AuthenticatedRouteMixin.authenticationRoute cannot implement the AuthenticatedRouteMixin mixin as that leads to an infinite transitioning loop!', this.get('routeName') !== authenticationRoute);
 
-    this.get('_authRouter').transitionTo(authenticationRoute);
+    let owner = getOwner(this);
+    let authRouter = owner.lookup('service:router') || owner.lookup('router:main');
+    authRouter.transitionTo(authenticationRoute);
   },
 });

--- a/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -1,7 +1,8 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
+import { getOwner } from '@ember/application';
 import location from '../utils/location';
-import isFastBootCPM from '../utils/is-fastboot';
+import isFastBoot from '../utils/is-fastboot';
 
 function _parseResponse(locationHash) {
   let params = {};
@@ -77,7 +78,8 @@ export default Mixin.create({
     @public
   */
   activate() {
-    if (this.get('_isFastBoot')) {
+    let _isFastBoot = this.hasOwnProperty('_isFastBoot') ? this._isFastBoot : isFastBoot(getOwner(this));
+    if (_isFastBoot) {
       return;
     }
 
@@ -89,6 +91,4 @@ export default Mixin.create({
       this.set('error', err);
     });
   },
-
-  _isFastBoot: isFastBootCPM()
 });

--- a/addon/mixins/unauthenticated-route-mixin.js
+++ b/addon/mixins/unauthenticated-route-mixin.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
-import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 import { getOwner } from '@ember/application';
 
 /**
@@ -47,8 +46,6 @@ export default Mixin.create({
     @public
   */
   session: service('session'),
-
-  _isFastBoot: isFastBoot(),
 
   /**
     The route to transition to if a route that implements the

--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -105,12 +105,6 @@ export default Base.extend({
 
   _cookies: service('cookies'),
 
-  _fastboot: computed(function() {
-    let owner = getOwner(this);
-
-    return owner && owner.lookup('service:fastboot');
-  }),
-
   _isLocalStorageAvailable: computed(function() {
     try {
       localStorage.setItem(LOCAL_STORAGE_TEST_KEY, true);
@@ -123,6 +117,11 @@ export default Base.extend({
 
   init() {
     this._super(...arguments);
+
+    let owner = getOwner(this);
+    if (owner && !this.hasOwnProperty('_fastboot')) {
+      this._fastboot = owner.lookup('service:fastboot');
+    }
 
     let store;
     if (this.get('_isLocalStorageAvailable')) {

--- a/addon/session-stores/adaptive.js
+++ b/addon/session-stores/adaptive.js
@@ -105,16 +105,6 @@ export default Base.extend({
 
   _cookies: service('cookies'),
 
-  _isLocalStorageAvailable: computed(function() {
-    try {
-      localStorage.setItem(LOCAL_STORAGE_TEST_KEY, true);
-      localStorage.removeItem(LOCAL_STORAGE_TEST_KEY);
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }),
-
   init() {
     this._super(...arguments);
 
@@ -122,6 +112,8 @@ export default Base.extend({
     if (owner && !this.hasOwnProperty('_fastboot')) {
       this._fastboot = owner.lookup('service:fastboot');
     }
+
+    this._isLocalStorageAvailable = this.hasOwnProperty('_isLocalStorageAvailable') ? this._isLocalStorageAvailable : testLocalStorageAvailable();
 
     let store;
     if (this.get('_isLocalStorageAvailable')) {
@@ -187,3 +179,13 @@ export default Base.extend({
     return this.get('_store').clear();
   }
 });
+
+function testLocalStorageAvailable() {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_TEST_KEY, true);
+    localStorage.removeItem(LOCAL_STORAGE_TEST_KEY);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/addon/session-stores/cookie.js
+++ b/addon/session-stores/cookie.js
@@ -149,12 +149,6 @@ export default BaseStore.extend({
 
   _cookies: service('cookies'),
 
-  _fastboot: computed(function() {
-    let owner = getOwner(this);
-
-    return owner && owner.lookup('service:fastboot');
-  }),
-
   _secureCookies() {
     if (this.get('_fastboot.isFastBoot')) {
       return this.get('_fastboot.request.protocol') === 'https';
@@ -174,6 +168,11 @@ export default BaseStore.extend({
 
   init() {
     this._super(...arguments);
+
+    let owner = getOwner(this);
+    if (owner && !this.hasOwnProperty('_fastboot')) {
+      this._fastboot = owner.lookup('service:fastboot');
+    }
 
     let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
     if (cachedExpirationTime) {

--- a/addon/session-stores/local-storage.js
+++ b/addon/session-stores/local-storage.js
@@ -2,6 +2,7 @@
 import RSVP from 'rsvp';
 
 import { bind } from '@ember/runloop';
+import { getOwner } from '@ember/application';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
@@ -26,8 +27,6 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
   @public
 */
 export default BaseStore.extend({
-  _isFastBoot: isFastBoot(),
-
   /**
     The `localStorage` key the store persists data in.
 
@@ -41,6 +40,7 @@ export default BaseStore.extend({
   init() {
     this._super(...arguments);
 
+    this._isFastBoot = this.hasOwnProperty('_isFastBoot') ? this._isFastBoot : isFastBoot(getOwner(this));
     this._boundHandler = bind(this, this._handleStorageEvent);
     if (!this.get('_isFastBoot')) {
       window.addEventListener('storage', this._boundHandler);

--- a/addon/session-stores/session-storage.js
+++ b/addon/session-stores/session-storage.js
@@ -2,6 +2,7 @@
 import RSVP from 'rsvp';
 
 import { bind } from '@ember/runloop';
+import { getOwner } from '@ember/application';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
 import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
@@ -22,8 +23,6 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
   @public
 */
 export default BaseStore.extend({
-  _isFastBoot: isFastBoot(),
-
   /**
     The `sessionStorage` key the store persists data in.
 
@@ -37,6 +36,7 @@ export default BaseStore.extend({
   init() {
     this._super(...arguments);
 
+    this._isFastBoot = this.hasOwnProperty('_isFastBoot') ? this._isFastBoot : isFastBoot(getOwner(this));
     if (!this.get('_isFastBoot')) {
       window.addEventListener('storage', bind(this, this._handleStorageEvent));
     }

--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -1,27 +1,10 @@
 /* eslint-disable no-unused-vars */
 // @ts-check
-import { computed } from '@ember/object';
-import ComputedProperty from '@ember/object/computed';
-import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
 import ApplicationInstance from '@ember/application/instance';
 
-/**
- * @return {ComputedProperty<boolean>}
- */
-export default function isFastBootCPM() {
-  return computed(function() {
-    return isFastBoot(getOwner(this));
-  });
-}
-
-/**
- *
- * @param {ApplicationInstance} owner
- * @return {boolean}
- */
-export function isFastBoot(owner) {
-  assert('You may only use isFastBoot() on a container-aware object', owner && typeof owner.lookup === 'function');
+export default function isFastBoot(owner) {
+  assert('You must pass in an owner to isFastBoot!', owner && typeof owner.lookup === 'function');
   const fastboot = owner.lookup('service:fastboot');
   return fastboot ? fastboot.get('isFastBoot') : false;
 }

--- a/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -6,11 +6,15 @@ import {
   afterEach,
   it
 } from 'mocha';
+import { setOwner } from '@ember/application';
+import { setupTest } from 'ember-mocha';
 import { expect } from 'chai';
 import Pretender from 'pretender';
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
 
 describe('OAuth2PasswordGrantAuthenticator', () => {
+  setupTest();
+
   let authenticator;
   let server;
   let parsePostData = ((query) => {
@@ -24,6 +28,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
   beforeEach(function() {
     authenticator = OAuth2PasswordGrant.create();
+    setOwner(authenticator, this.owner);
     server = new Pretender();
   });
 

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -33,19 +33,20 @@ describe('AuthenticatedRouteMixin', () => {
         }
       });
 
-      router = { transitionTo() {} };
       transition = {
         intent: {
           url: '/transition/target/url'
         },
         send() {}
       };
+      this.owner.register('service:router', Service.extend({
+        transitionTo() {}
+      }));
+      router = this.owner.lookup('service:router');
 
       this.owner.register('service:session', Service.extend());
 
-      route = Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin).create({
-        _authRouter: router
-      });
+      route = Route.extend(MixinImplementingBeforeModel, AuthenticatedRouteMixin).create();
       setOwner(route, this.owner);
 
       sinon.spy(transition, 'send');
@@ -67,7 +68,7 @@ describe('AuthenticatedRouteMixin', () => {
       it('does not transition to the authentication route', function() {
         route.beforeModel(transition);
 
-        expect(route._authRouter.transitionTo).to.not.have.been.calledWith('login');
+        expect(router.transitionTo).to.not.have.been.calledWith('login');
       });
     });
 
@@ -78,7 +79,7 @@ describe('AuthenticatedRouteMixin', () => {
 
       it('transitions to "login" as the default authentication route', function() {
         route.beforeModel(transition);
-        expect(route._authRouter.transitionTo).to.have.been.calledWith('login');
+        expect(router.transitionTo).to.have.been.calledWith('login');
       });
 
       it('transitions to the set authentication route', function() {
@@ -86,7 +87,7 @@ describe('AuthenticatedRouteMixin', () => {
         route.set('authenticationRoute', authenticationRoute);
 
         route.beforeModel(transition);
-        expect(route._authRouter.transitionTo).to.have.been.calledWith(authenticationRoute);
+        expect(router.transitionTo).to.have.been.calledWith(authenticationRoute);
       });
 
       it('sets the redirectTarget cookie in fastboot', function() {

--- a/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
+++ b/tests/unit/mixins/oauth2-implicit-grant-callback-route-mixin-test.js
@@ -2,7 +2,8 @@ import EmberObject from '@ember/object';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { isEmpty } from '@ember/utils';
-import { it } from 'ember-mocha';
+import { setOwner } from '@ember/application';
+import { it, setupTest } from 'ember-mocha';
 import { describe, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
@@ -10,6 +11,8 @@ import OAuth2ImplicitGrantCallbackRouteMixin from 'ember-simple-auth/mixins/oaut
 import * as LocationUtil from 'ember-simple-auth/utils/location';
 
 describe('OAuth2ImplicitGrantCallbackRouteMixin', function() {
+  setupTest();
+
   let sinon;
   let route;
   let session;
@@ -40,6 +43,7 @@ describe('OAuth2ImplicitGrantCallbackRouteMixin', function() {
         authenticator: 'authenticator:oauth2',
         _isFastBoot: false
       }).create({ session });
+      setOwner(route, this.owner);
 
       sinon.spy(route, 'transitionTo');
     });


### PR DESCRIPTION
This fixes the deprecations regarding overridden computed properties. Most of these CPs were only used in testing and should be properly mocked via the container anyway (e.g. `_fastBoot`).

### TODO

- [x] all deprecations in app code should be fixed but there are some left in the testing code (mainly the code around testing adaptive and cookie session stores which is relatively messy anyway 😞) - that should be fixed before releasing this as well.

closes #1908
closes #2044 
closes #1938 