### PR TITLE
Fix Github Action for releasing new versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm publish
         env:


### PR DESCRIPTION
…which is currently broken 😞 

Apparently it's necessary to explicitly set the registry url you want to publish to.