### PR TITLE
Modernize docs and examples

### DIFF
--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,9 +1,7 @@
-import DS from 'ember-data';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import config from '../config/environment';
 import { computed } from '@ember/object';
-
-const { JSONAPIAdapter } = DS;
 
 export default JSONAPIAdapter.extend(DataAdapterMixin, {
   host: config.apiHost,

--- a/tests/dummy/app/components/login-form.js
+++ b/tests/dummy/app/components/login-form.js
@@ -32,6 +32,18 @@ export default Component.extend({
                             + `&response_type=${responseType}`
                             + `&scope=${scope}`
       );
-    }
+    },
+
+    updateIdentification(e) {
+      this.set('identification', e.target.value);
+    },
+
+    updatePassword(e) {
+      this.set('password', e.target.value);
+    },
+
+    updateRememberMe(e) {
+      this.set('rememberMe', e.target.checked);
+    },
   }
 });

--- a/tests/dummy/app/components/login-form.js
+++ b/tests/dummy/app/components/login-form.js
@@ -6,7 +6,9 @@ export default Component.extend({
   session: service('session'),
 
   actions: {
-    async authenticateWithOAuth2() {
+    async authenticateWithOAuth2(e) {
+      e.preventDefault();
+
       try {
         let { identification, password } = this;
         await this.get('session').authenticate('authenticator:oauth2', identification, password);

--- a/tests/dummy/app/components/login-form.js
+++ b/tests/dummy/app/components/login-form.js
@@ -6,15 +6,18 @@ export default Component.extend({
   session: service('session'),
 
   actions: {
-    authenticateWithOAuth2() {
-      let { identification, password } = this.getProperties('identification', 'password');
-      this.get('session').authenticate('authenticator:oauth2', identification, password)
-        .then(() => {
-          this.get('rememberMe') && this.set('session.store.cookieExpirationTime', 60 * 60 * 24 * 14);
-        })
-        .catch((reason) => {
-          this.set('errorMessage', reason.error);
-        });
+    async authenticateWithOAuth2() {
+      try {
+        let { identification, password } = this;
+        await this.get('session').authenticate('authenticator:oauth2', identification, password);
+
+        if (this.rememberMe) {
+          this.get('session').set('store.cookieExpirationTime', 60 * 60 * 24 * 14);
+        }
+      } catch (response) {
+        let responseBody = await response.clone().json();
+        this.errorMessage = responseBody.error;
+      }
     },
 
     authenticateWithFacebook() {

--- a/tests/dummy/app/models/account.js
+++ b/tests/dummy/app/models/account.js
@@ -1,6 +1,4 @@
-import DS from 'ember-data';
-
-const { attr, Model } = DS;
+import Model, { attr } from '@ember-data/model';
 
 export default Model.extend({
   login: attr('string'),

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,6 +1,4 @@
-import DS from 'ember-data';
-
-const { attr, Model } = DS;
+import Model, { attr } from '@ember-data/model';
 
 export default Model.extend({
   title: attr('string'),

--- a/tests/dummy/app/services/session-account.js
+++ b/tests/dummy/app/services/session-account.js
@@ -1,22 +1,14 @@
-import RSVP from 'rsvp';
 import Service, { inject as service } from '@ember/service';
-import { isEmpty } from '@ember/utils';
 
 export default Service.extend({
   session: service('session'),
   store: service(),
 
-  loadCurrentUser() {
-    return new RSVP.Promise((resolve, reject) => {
-      const accountId = this.get('session.data.authenticated.account_id');
-      if (!isEmpty(accountId)) {
-        this.get('store').find('account', accountId).then((account) => {
-          this.set('account', account);
-          resolve();
-        }, reject);
-      } else {
-        resolve();
-      }
-    });
+  async loadCurrentUser() {
+    let accountId = this.get('session.data.authenticated.account_id');
+    if (accountId) {
+      let account = await this.get('store').find('account', accountId);
+      this.account = account;
+    }
   }
 });

--- a/tests/dummy/app/templates/components/login-form.hbs
+++ b/tests/dummy/app/templates/components/login-form.hbs
@@ -4,7 +4,7 @@
 <a {{action 'authenticateWithGoogleImplicitGrant'}} class="btn btn-primary" href="#" role="button">Login with Google (Implicit Grant)</a>
 <hr/>
 <p>or login with OAuth 2.0 <em>Resource Owner Password Credentials</em>:</p>
-<form {{action 'authenticateWithOAuth2' on='submit'}}>
+<form onsubmit={{action 'authenticateWithOAuth2'}}>
   <div class="form-group">
     <label for="identification">Login</label>
     <input type="text" placeholder="Enter Login" class="form-control" onchange={{action 'updateIdentification'}} value={{this.identification}} />

--- a/tests/dummy/app/templates/components/login-form.hbs
+++ b/tests/dummy/app/templates/components/login-form.hbs
@@ -7,14 +7,14 @@
 <form {{action 'authenticateWithOAuth2' on='submit'}}>
   <div class="form-group">
     <label for="identification">Login</label>
-    {{input value=identification placeholder='Enter Login' class='form-control'}}
+    <input type="text" placeholder="Enter Login" class="form-control" onchange={{action 'updateIdentification'}} value={{this.identification}} />
   </div>
   <div class="form-group">
     <label for="password">Password</label>
-    {{input value=password placeholder='Enter Password' class='form-control' type='password'}}
+    <input type="password" placeholder="Enter Password" class="form-control" onchange={{action 'updatePassword'}} value={{this.password}} />
   </div>
   <div class="form-group form-check">
-    {{input checked=rememberMe name='rememberMe' type='checkbox' id='rememberMe' class='form-check-input'}}
+    <input type="checkbox" class="form-check-input" id="rememberMe" onchange={{action 'updateRememberMe'}} checked={{this.rememberMe}} />
     <label for="rememberMe" class="form-check-label">
       Remember me
     </label>


### PR DESCRIPTION
This modernizes the docs and examples by:

* using Octane syntax in the API docs and README
* using `async`/`await` in the dummy app
* using modularized ember-data imports vs. `import DS from 'ember-data';`

Unfortunately we cannot use Octane features in the dummy app itself as we're still supporting Ember 3.0 and the polyfills for Octane features only support Ember >= 3.4.