### PR TITLE
Modernize dummy app

### DIFF
--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,9 +1,7 @@
-import DS from 'ember-data';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import config from '../config/environment';
 import { computed } from '@ember/object';
-
-const { JSONAPIAdapter } = DS;
 
 export default JSONAPIAdapter.extend(DataAdapterMixin, {
   host: config.apiHost,

--- a/tests/dummy/app/components/login-form.js
+++ b/tests/dummy/app/components/login-form.js
@@ -6,15 +6,17 @@ export default Component.extend({
   session: service('session'),
 
   actions: {
-    authenticateWithOAuth2() {
-      let { identification, password } = this.getProperties('identification', 'password');
-      this.get('session').authenticate('authenticator:oauth2', identification, password)
-        .then(() => {
-          this.get('rememberMe') && this.set('session.store.cookieExpirationTime', 60 * 60 * 24 * 14);
-        })
-        .catch((reason) => {
-          this.set('errorMessage', reason.error);
-        });
+    async authenticateWithOAuth2() {
+      try {
+        let { identification, password } = this;
+        await this.get('session').authenticate('authenticator:oauth2', identification, password);
+
+        if (this.rememberMe) {
+          this.get('session').set('store.cookieExpirationTime', 60 * 60 * 24 * 14);
+        }
+      } catch (reason) {
+        this.set('errorMessage', reason.error);
+      }
     },
 
     authenticateWithFacebook() {

--- a/tests/dummy/app/components/login-form.js
+++ b/tests/dummy/app/components/login-form.js
@@ -32,6 +32,18 @@ export default Component.extend({
                             + `&response_type=${responseType}`
                             + `&scope=${scope}`
       );
-    }
+    },
+
+    updateIdentification(e) {
+      this.set('identification', e.target.value);
+    },
+
+    updatePassword(e) {
+      this.set('password', e.target.value);
+    },
+
+    updateRememberMe(e) {
+      this.set('rememberMe', e.target.checked);
+    },
   }
 });

--- a/tests/dummy/app/components/main-navigation.js
+++ b/tests/dummy/app/components/main-navigation.js
@@ -6,12 +6,6 @@ export default Component.extend({
   sessionAccount: service('session-account'),
 
   actions: {
-    login() {
-      // Closure actions are not yet available in Ember 1.12
-      // eslint-disable-next-line ember/closure-actions
-      this.sendAction('onLogin');
-    },
-
     logout() {
       this.get('session').invalidate();
     }

--- a/tests/dummy/app/models/account.js
+++ b/tests/dummy/app/models/account.js
@@ -1,6 +1,4 @@
-import DS from 'ember-data';
-
-const { attr, Model } = DS;
+import Model, { attr } from '@ember-data/model';
 
 export default Model.extend({
   login: attr('string'),

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,6 +1,4 @@
-import DS from 'ember-data';
-
-const { attr, Model } = DS;
+import Model, { attr } from '@ember-data/model';
 
 export default Model.extend({
   title: attr('string'),

--- a/tests/dummy/app/services/session-account.js
+++ b/tests/dummy/app/services/session-account.js
@@ -1,22 +1,14 @@
-import RSVP from 'rsvp';
 import Service, { inject as service } from '@ember/service';
-import { isEmpty } from '@ember/utils';
 
 export default Service.extend({
   session: service('session'),
   store: service(),
 
-  loadCurrentUser() {
-    return new RSVP.Promise((resolve, reject) => {
-      const accountId = this.get('session.data.authenticated.account_id');
-      if (!isEmpty(accountId)) {
-        this.get('store').find('account', accountId).then((account) => {
-          this.set('account', account);
-          resolve();
-        }, reject);
-      } else {
-        resolve();
-      }
-    });
+  async loadCurrentUser() {
+    let accountId = this.get('session.data.authenticated.account_id');
+    if (accountId) {
+      let account = await this.get('store').find('account', accountId);
+      this.set('account', account);
+    }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{main-navigation onLogin='transitionToLoginRoute'}}
+{{main-navigation onLogin=(action 'transitionToLoginRoute')}}
 <div class="container mt-4">
   {{outlet}}
 </div>

--- a/tests/dummy/app/templates/components/login-form.hbs
+++ b/tests/dummy/app/templates/components/login-form.hbs
@@ -7,14 +7,14 @@
 <form {{action 'authenticateWithOAuth2' on='submit'}}>
   <div class="form-group">
     <label for="identification">Login</label>
-    {{input value=identification placeholder='Enter Login' class='form-control'}}
+    <input type="text" placeholder="Enter Login" class="form-control" onchange={{action 'updateIdentification'}} value={{this.identification}} />
   </div>
   <div class="form-group">
     <label for="password">Password</label>
-    {{input value=password placeholder='Enter Password' class='form-control' type='password'}}
+    <input type="password" placeholder="Enter Password" class="form-control" onchange={{action 'updatePassword'}} value={{this.password}} />
   </div>
   <div class="form-group form-check">
-    {{input checked=rememberMe name='rememberMe' type='checkbox' id='rememberMe' class='form-check-input'}}
+    <input type="checkbox" class="form-check-input" id="rememberMe" onchange={{action 'updateRememberMe'}} checked={{this.rememberMe}} />
     <label for="rememberMe" class="form-check-label">
       Remember me
     </label>

--- a/tests/dummy/app/templates/components/main-navigation.hbs
+++ b/tests/dummy/app/templates/components/main-navigation.hbs
@@ -18,7 +18,7 @@
       {{/if}}
       <a {{action 'logout'}} class="btn btn-danger" href="#" role="button">Logout</a>
     {{else}}
-      <a {{action 'login'}} class="btn btn-success" href="#" role="button">Login</a>
+      <a {{action onLogin}} class="btn btn-success" href="#" role="button">Login</a>
     {{/if}}
   </form>
 </nav>


### PR DESCRIPTION
This modernizes the dummy app by:

* using `async`/`await` instead of dealing with promises
* using closure actions instead of old actions or `sendAction`
* using ember-data's package imports
* using native inputs in the login form instead of the `input` helper

It also fixes handling of invalid credentials and other login errors in the `<LoginForm>` which is currently broken.