### PR TITLE
Add docs for rejections with server responses

### DIFF
--- a/addon/authenticators/devise.js
+++ b/addon/authenticators/devise.js
@@ -99,7 +99,7 @@ export default BaseAuthenticator.extend({
     @method authenticate
     @param {String} identification The user's identification
     @param {String} password The user's password
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   authenticate(identification, password) {

--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -131,7 +131,7 @@ export default BaseAuthenticator.extend({
 
     @method restore
     @param {Object} data The data to restore the session from
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated
+    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming or remaining authenticated. If restoration fails, the promise will reject with the server response (in case the access token had expired and was refreshed using a refresh token); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   restore(data) {
@@ -207,7 +207,7 @@ export default BaseAuthenticator.extend({
     @param {String} password The resource owner password
     @param {String|Array} scope The scope of the access request (see [RFC 6749, section 3.3](http://tools.ietf.org/html/rfc6749#section-3.3))
     @param {Object} headers Optional headers that particular backends may require (for example sending 2FA challenge responses)
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated
+    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session becoming authenticated. If authentication fails, the promise will reject with the server response; however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   authenticate(identification, password, scope = [], headers = {}) {
@@ -250,7 +250,7 @@ export default BaseAuthenticator.extend({
 
     @method invalidate
     @param {Object} data The current authenticated session data
-    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated
+    @return {Ember.RSVP.Promise} A promise that when it resolves results in the session being invalidated. If invalidation fails, the promise will reject with the server response (in case token revocation is used); however, the authenticator reads that response already so if you need to read it again you need to clone the response object first
     @public
   */
   invalidate(data) {


### PR DESCRIPTION
When fixing error handling in the dummy app (see #2138), I realized that the reponse the OAuth2 Password Grant authenticator rejects with when authentication fails, has its body read by the authenticator already which means the body cannot be read again in the error handling code. In order to read the body again, the response has to be cloned first.

While we could do the cloning in the authenticators so that the error handling code would not have to worry about that, that could be wasteful in cases where the error handling code only needs access to e.g. the response headers. While we might still do that in the future, this for now adds some info to the docs.

All of the above also applies to the Devise authenticator which also rejects with the server response when authentication fails.