### PR TITLE
add FastBoot to TOC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ authorization mechanisms__.
 * [Session Stores](#session-stores)
   * [Store Types](#store-types)
   * [Implementing a Custom Store](#implementing-a-custom-store)
+* [FastBoot](#fastboot)
 * [Testing](#testing)
 
 **Other Guides**


### PR DESCRIPTION
This adds a link to the FastBoot docs in the README's table of contents.