### PR TITLE
Remove old Chrome option on CI

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -14,14 +14,11 @@ module.exports = {
     Chrome: {
       mode: 'ci',
       args: [
-        // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
-
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
-      ].filter(Boolean)
+      ]
     },
   }
 };


### PR DESCRIPTION
This removes an old option for Chrome that we did set on CI but that is apparently not needed anymore since we're now running on GitHub actions where the option was not set anyway.