### PR TITLE
remove config for removed checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,8 +6,6 @@ module.exports = {
     'plugin:ember/recommended',
   ],
   rules: {
-    'ember/local-modules': 'off',
-    'ember/avoid-leaking-state-in-components': 'off',
   },
   parserOptions: {
     ecmaVersion: 2017,


### PR DESCRIPTION
This removes ESLint configuration that disables the `ember/local-modules` and `ember/avoid-leaking-state-in-components` which have been removed in `eslint-plugin-ember@7.0` already.