### PR TITLE
fix demo link on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,7 +390,7 @@
             </ul>
             <ul class="nav navbar-nav navbar-right">
               <li>
-                <a href="https://ember-simple-auth.now.sh/">Demo App</a>
+                <a href="https://demo.ember-simple-auth.com">Demo App</a>
               </li>
               <li>
                 <a href="api/">API Docs</a>


### PR DESCRIPTION
This changes the demo link to point to the new demo app running on Heroku – see #2168 