### PR TITLE
use https to access api in demo

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -75,7 +75,7 @@ module.exports = function(environment) {
     ENV.fastboot = {
       hostWhitelist: ['demo.ember-simple-auth.com', 'esa-demo.herokuapp.com']
     };
-    ENV.apiHost = 'http://demo-api.ember-simple-auth.com';
+    ENV.apiHost = 'https://demo-api.ember-simple-auth.com';
   }
 
   return ENV;


### PR DESCRIPTION
We must use https to access the API in the demo app. Cloudflare redirects http to https for demo.ember-simple-auth.com but if we then try to access the API via http from that origin, that fails for security reasons. It's better to use the API via https anyway of course (although in this case no sensitive data is actually transmitted of course).