### PR TITLE
Fix Heroku Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "repository": "https://github.com/simplabs/ember-simple-auth",
   "scripts": {
     "changelog": "lerna-changelog",
-    "diagrams": "mmdc -i guides/assets/esa-initial-flow.txt -o guides/assets/esa-initial-flow.svg"
+    "diagrams": "mmdc -i guides/assets/esa-initial-flow.txt -o guides/assets/esa-initial-flow.svg",
+    "heroku-postbuild": "yarn workspace test-app build -prod"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
#2184 broken the Heroku deployment since the yarn workspaces structure is no longer compatible with the ember buildpack. This removes the buildpack which we didn't really need anyway and customizes the build step to fix the deployment.