### PR TITLE
Updating sessionAuthenticated for Octane

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -148,10 +148,9 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   },
 
   async sessionAuthenticated() {
-    let _super = this._super;
     await this._loadCurrentUser();
-    _super.call(this, ...arguments);
-  },
+    super.sessionAuthenticated(...arguments)
+  }
 
   async _loadCurrentUser() {
     try {


### PR DESCRIPTION
The documented version of sessionAuthenticated was no longer working under Ember Octane. Using the new super keyword as documented [here](https://guides.emberjs.com/release/upgrading/current-edition/native-classes/) worked.