### PR TITLE
Update /guides/auth-torii-with-github.md

### DIFF
--- a/guides/auth-torii-with-github.md
+++ b/guides/auth-torii-with-github.md
@@ -636,8 +636,7 @@ export default class ToriiAuthenticator extends Torii {
   @service torii;
 
   async authenticate() {
-    const tokenExchangeUri = config.torii.providers['google-oauth2'].tokenExchangeUri;
-
+    const tokenExchangeUri = config.torii.providers['github-oauth2'].tokenExchangeUri;
     let data = await super.authenticate(...arguments);
     const response = await fetch(tokenExchangeUri, {
       // Adding method type 

--- a/guides/auth-torii-with-github.md
+++ b/guides/auth-torii-with-github.md
@@ -634,19 +634,24 @@ import config from '../config/environment';
 
 export default class ToriiAuthenticator extends Torii {
   @service torii;
-  @service ajax;
 
   async authenticate() {
-    const tokenExchangeUri = config.torii.providers['github-oauth2'].tokenExchangeUri;
+    const tokenExchangeUri = config.torii.providers['google-oauth2'].tokenExchangeUri;
 
     let data = await super.authenticate(...arguments);
-    let response = await this.ajax.request(tokenExchangeUri, {
-      type: 'POST',
-      crossDomain: true,
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify({
+    const response = await fetch(tokenExchangeUri, {
+      // Adding method type 
+      method: "POST",
+      // no-cors, *cors, same-origin
+      mode: 'cors',
+      // Adding body or contents to send 
+      body: JSON.stringify({
         authorizationCode: data.authorizationCode
+      }),
+      // Adding headers to the request 
+      headers: {
+        'Content-Type': 'application/json' // 'Content-Type': 'application/x-www-form-urlencoded',
+      }
     });
 
     return {
@@ -654,7 +659,7 @@ export default class ToriiAuthenticator extends Torii {
       provider: data.provider
     };
   }
-});
+}
 ```
 
 This makes a `POST` request to your service and gives the response back to Ember Simple Auth. Notice that it returns the `access_token`

--- a/guides/auth-torii-with-github.md
+++ b/guides/auth-torii-with-github.md
@@ -650,7 +650,7 @@ export default class ToriiAuthenticator extends Torii {
       }),
       // Adding headers to the request 
       headers: {
-        'Content-Type': 'application/json' // 'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/json'
       }
     });
 


### PR DESCRIPTION
Includes minor corrections for closing bracket mismatch and preferred ember style of using fetch. Also, means no dependency on ember-ajax for this particular section atleast.