### PR TITLE
Fix code example in guide

### DIFF
--- a/guides/managing-current-user.md
+++ b/guides/managing-current-user.md
@@ -162,7 +162,7 @@ service:
 import { inject as service } from '@ember/service';
 import BaseSessionService from 'ember-simple-auth/services/session';
 
-export default SessionService extends BaseSessionService {
+export default class SessionService extends BaseSessionService {
   @service currentUser;
 
   async handleAuthentication() {


### PR DESCRIPTION
This adds a missing ˋclassˋ in a code example in the „managing current user“ guide. 

closes #2211 