### PR TITLE
fix: Incorrect path to fetch the routeAfterAuthentication property in the config object

### DIFF
--- a/packages/ember-simple-auth/addon/configuration.js
+++ b/packages/ember-simple-auth/addon/configuration.js
@@ -40,6 +40,10 @@ export default {
 
   load(config) {
     this.rootURL = getWithDefault(config, 'rootURL', DEFAULTS.rootURL);
-    this.routeAfterAuthentication = getWithDefault(config, 'ember-simple-auth.routeAfterAuthentication', DEFAULTS.routeAfterAuthentication);
-  }
+    this.routeAfterAuthentication = getWithDefault(
+      config,
+      'routeAfterAuthentication',
+      DEFAULTS.routeAfterAuthentication
+    );
+  },
 };

--- a/packages/ember-simple-auth/tests/unit/configuration-test.js
+++ b/packages/ember-simple-auth/tests/unit/configuration-test.js
@@ -31,7 +31,7 @@ describe('Configuration', () => {
     });
 
     it('sets routeAfterAuthentication correctly', function() {
-      Configuration.load({ 'ember-simple-auth': { routeAfterAuthentication: '/some-route' } });
+      Configuration.load({ routeAfterAuthentication: '/some-route' });
 
       expect(Configuration.routeAfterAuthentication).to.eql('/some-route');
     });


### PR DESCRIPTION
Simple fix to properly get the `routeAfterAuthentication` property from the `config` object upon application load.