### PR TITLE
Fix CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           - test:one ember-release
           - test:one ember-beta
           - test:one ember-canary
+        allow-failure: [false]
         include:
           - test-suite: "test:one ember-canary"
             allow-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: tests
         run: yarn workspace ${{ matrix.workspace }} ${{ matrix.test-suite }}
-        continue-on-error: ${{matrix.allow-failure}}
+        continue-on-error: ${{ matrix.allow-failure }}
 
   extra-tests:
     name: Tests (Floating Dependenies)

--- a/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -148,7 +148,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
     it('sends an AJAX request to the token endpoint with customized headers', async function() {
       server.post('/token', (request) => {
-        expect(request.requestHeaders['x-custom-context']).to.eql('foobar');
+        expect(request.requestHeaders['X-Custom-Context']).to.eql('foobar');
 
         return [200, { 'Content-Type': 'application/json' }, '{ "access_token": "secret token!" }'];
       });
@@ -279,7 +279,7 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           await authenticator.authenticate('username', 'password');
           expect(false).to.be.true;
         } catch (error) {
-          expect(error.headers.get('x-custom-context')).to.eql('foobar');
+          expect(error.headers.get('X-Custom-Context')).to.eql('foobar');
         }
       });
     });


### PR DESCRIPTION
There were a number of problems with CI:

* Headers are now capitalized vs. all lower-case which made one of the tests fail that was not able to read a header that was expected to be present
* It seems there should be a default for the `allow-failure` flag (this did not cause the test failure but prevented the runner from handling the failure correctly)