### PR TITLE
Add missing actions for login controller to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ export default class LoginController extends Controller {
       // What to do with all this success?
     }
   }
+
+  @action
+  updateIdentification(e) {
+    this.identification = e.target.value;
+  }
+
+  @action
+  updatePassword(e) {
+    this.password = e.target.value;
+  }
 }
 ```
 


### PR DESCRIPTION
This adds the missing `updateIdentification` and `updatePassword` actions to the `LoginController` in the README. This has some people confused since it is unclear how the values would ever be assigned otherwise.

closes #2228