### PR TITLE
prevent form submission in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ export default class LoginController extends Controller {
   @service session;
 
   @action
-  async authenticate() {
+  async authenticate(e) {
+    e.preventDefault();
     let { identification, password } = this;
     try {
       await this.session.authenticate('authenticator:oauth2', identification, password);


### PR DESCRIPTION
This adds `e.preventDefault()` to the `LoginController`'s `authenticate` method in the README. If we leave that out, the form will actually be submitted and the page reloaded - this can be very confusing when simply copy/pasting the code from the example.

closes #2220