### PR TITLE
Unset attemptedTransition on invalidation

### DIFF
--- a/packages/ember-simple-auth/addon/internal-session.js
+++ b/packages/ember-simple-auth/addon/internal-session.js
@@ -40,6 +40,7 @@ export default ObjectProxy.extend(Evented, {
 
   invalidate() {
     this._busy = true;
+    this.set('attemptedTransition', null);
 
     if (!this.get('isAuthenticated')) {
       this._busy = false;

--- a/packages/ember-simple-auth/tests/unit/internal-session-test.js
+++ b/packages/ember-simple-auth/tests/unit/internal-session-test.js
@@ -373,6 +373,14 @@ describe('InternalSession', () => {
       await session.authenticate('authenticator:test');
     });
 
+    it('unsets the attemptedTransition', function() {
+      session.set('attemptedTransition', { some: 'transition' });
+      session.invalidate();
+
+      expect(session.get('attemptedTransition')).to.be.null;
+    });
+
+
     describe('when invalidate gets called with additional params', function() {
       beforeEach(function() {
         sinon.spy(authenticator, 'invalidate');


### PR DESCRIPTION
This makes sure that the `session` service's `attemptedTransition` property is cleared when the session is invalidated. Otherwise you could run into situations where a user logs in and they are redirected to a route that they have tried to access previously but that transition did not actually trigger the current redirect to the login route (or there was no redirect at all and they just clicked on a direct link to the login route).

closes #2176 