### PR TITLE
Update versionCompatibility to >=3.0

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -79,7 +79,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=1.12"
+      "ember": ">=3.0"
     }
   },
   "resolutions": {


### PR DESCRIPTION
We have dropped support for Ember versions < 3.0 in https://github.com/simplabs/ember-simple-auth/releases/tag/3.0.0 but never updated the respective setting in `package.json`…