### PR TITLE
Remove use of the deprecated getWithDefault API

### DIFF
--- a/packages/ember-simple-auth/addon/configuration.js
+++ b/packages/ember-simple-auth/addon/configuration.js
@@ -1,5 +1,3 @@
-import { getWithDefault } from '@ember/object';
-
 const DEFAULTS = {
   rootURL: '',
   routeAfterAuthentication: 'index',
@@ -39,11 +37,10 @@ export default {
   routeAfterAuthentication: DEFAULTS.routeAfterAuthentication,
 
   load(config) {
-    this.rootURL = getWithDefault(config, 'rootURL', DEFAULTS.rootURL);
-    this.routeAfterAuthentication = getWithDefault(
-      config,
-      'routeAfterAuthentication',
-      DEFAULTS.routeAfterAuthentication
-    );
+    this.rootURL = config.rootURL !== undefined ? config.rootURL : DEFAULTS.rootURL;
+    this.routeAfterAuthentication =
+      config.routeAfterAuthentication !== undefined
+        ? config.routeAfterAuthentication
+        : DEFAULTS.routeAfterAuthentication;
   },
 };


### PR DESCRIPTION
Now that `getWithDefault` is deprecated in Ember 3.21 it's recommended to use `get()` (if needed) then directly check for `undefined`.

I would have used nullish coalescing but couldn't see any other uses of that in the codebase so decided against it.