### PR TITLE
Fix tests failing in master

### DIFF
--- a/packages/ember-simple-auth/config/ember-try.js
+++ b/packages/ember-simple-auth/config/ember-try.js
@@ -105,6 +105,7 @@ module.exports = function() {
             devDependencies: {
               'ember-data': 'beta',
               'ember-source': betaUrl,
+              'ember-bootstrap': '^4.6.2',
             },
           },
         },
@@ -120,6 +121,7 @@ module.exports = function() {
             devDependencies: {
               'ember-data': 'canary',
               'ember-source': canaryUrl,
+              'ember-bootstrap': '^4.6.2',
             },
           },
         },

--- a/packages/test-app/config/ember-try.js
+++ b/packages/test-app/config/ember-try.js
@@ -105,6 +105,7 @@ module.exports = function() {
             devDependencies: {
               'ember-data': 'beta',
               'ember-source': betaUrl,
+              'ember-bootstrap': '^4.6.2',
             },
           },
         },
@@ -120,6 +121,7 @@ module.exports = function() {
             devDependencies: {
               'ember-data': 'canary',
               'ember-source': canaryUrl,
+              'ember-bootstrap': '^4.6.2',
             },
           },
         },


### PR DESCRIPTION
[Tests in master are failing](https://github.com/simplabs/ember-simple-auth/runs/1746492928?check_suite_focus=true#step:7:193) for the canary and beta versions, it seems to be related to the latest Ember not working well with a dependency of the `ember-bootstrap` we have. 

This is a temporary solution to allow us to release version 3.1.0, since we only use `ember-bootstrap` for the test apps it shouldn't be an issue. Upgrading `ember-bootstrap` on the actual app, breaks tests for Ember 3.12. I think we should consider removing the `ember-bootstrap` dependency and just have our own CSS.