### PR TITLE
Fix empty object check in `_renew()` cookie session store

### DIFF
--- a/packages/ember-simple-auth/addon/session-stores/cookie.js
+++ b/packages/ember-simple-auth/addon/session-stores/cookie.js
@@ -287,7 +287,7 @@ export default BaseStore.extend({
 
   _renew() {
     return this.restore().then((data) => {
-      if (!isEmpty(data) && data !== {}) {
+      if (!isEmpty(data) && !(data.constructor === Object && Object.keys(data).length === 0)) {
         data = typeOf(data) === 'string' ? data : JSON.stringify(data || {});
         let expiration = this._calculateExpirationTime();
         this._write(data, expiration);


### PR DESCRIPTION
The `_renew` implementation in the cookie session store includes a check for `data !== {}`.

While this deceptively looks like it's checking for an empty object, `{} === {}` is `false` in JavaScript so the check never resolved. This replaces that check with an alternative that correctly identifies empty objects.
