### PR TITLE
Copy README to ember-simple-auth package before NPM release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
           node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
 
-      - run: cd packages/ember-simple-auth && npm publish
+      - name: copy readme to package folder
+        run: cp README.md packages/ember-simple-auth
+      - name: publish to npm
+        run: cd packages/ember-simple-auth && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Our last releases don't show the README file in [npm](https://www.npmjs.com/package/ember-simple-auth), this is because the file now doesn't leave at the root of the package.

This copies the README to the ember-simple-auth package folder before doing the release, so it shows up in NPM, while still remaining at the root of our repository and visible by default in https://github.com/simplabs/ember-simple-auth.