### PR TITLE
Prepare README for 3.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ and go to [http://localhost:4200](http://localhost:4200).
 Installing the library is as easy as:
 
 ```bash
-ember install ember-simple-auth@3.1.0-beta.1
+ember install ember-simple-auth
 ```
 
 ### Upgrading from a pre-3.0 release?


### PR DESCRIPTION
Removing the beta version from the install command. It shouldn't be necessary once we release 3.1.0