### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ export default class AuthenticatedRoute extends Route {
   @service session;
 
   beforeModel(transition) {
-    this.get('session').requireAuthentication(transition, 'login');
+    this.session.requireAuthentication(transition, 'login');
   }
 }
 ```


### PR DESCRIPTION
It's not necessary to use `get` when accessing the session service in the example in the README.