### PR TITLE
remove unnecessary ESLint comments

### DIFF
--- a/packages/test-app/app/routes/application.js
+++ b/packages/test-app/app/routes/application.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 

--- a/packages/test-app/app/routes/auth-error.js
+++ b/packages/test-app/app/routes/auth-error.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 

--- a/packages/test-app/app/routes/login.js
+++ b/packages/test-app/app/routes/login.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 

--- a/packages/test-app/app/routes/protected.js
+++ b/packages/test-app/app/routes/protected.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 

--- a/packages/test-app/lib/my-engine/addon/routes/open-only.js
+++ b/packages/test-app/lib/my-engine/addon/routes/open-only.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 

--- a/packages/test-app/lib/my-engine/addon/routes/protected.js
+++ b/packages/test-app/lib/my-engine/addon/routes/protected.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 


### PR DESCRIPTION
This removes unnecessary ESLint comments that disable the `ember/no-mixins` rule which prevents the usage of mixins from the modern test app which doesn't use mixins anymore anyway.