### PR TITLE
add missing dependent key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ import { inject as service } from '@ember/service';
 export default class ApplicationAdapter extends JSONAPIAdapter {
   @service session;
 
-  @computed('session.data.authenticated.access_token')
+  @computed('session.{data.authenticated.access_token,isAuthenticated}')
   get headers() {
     let headers = {};
     if (this.session.isAuthenticated) {


### PR DESCRIPTION
The `headers` CP in the adapter example relies on both `this.session.data.authenticated.access_token` and `this.session.isAuthenticated` but only specifies `session.data.authenticated.access_token` as a dependent key which triggers a linter error:

```
Use of undeclared dependencies in computed property: session.isAuthenticated ember/require-computed-property-dependencies
```

This adds the missing key to the README.

addresses (part of) #2289 