### PR TITLE
fix computed import deprecation

### DIFF
--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import { alias, oneWay } from '@ember/object/computed';
 import { A } from '@ember/array';
 import Service from '@ember/service';
 import Evented from '@ember/object/evented';
@@ -92,7 +92,7 @@ export default Service.extend(Evented, {
     @default false
     @public
   */
-  isAuthenticated: computed.oneWay('session.isAuthenticated'),
+  isAuthenticated: oneWay('session.isAuthenticated'),
 
   /**
     The current session data as a plain object. The
@@ -109,7 +109,7 @@ export default Service.extend(Evented, {
     @default { authenticated: {} }
     @public
   */
-  data: computed.oneWay('session.content'),
+  data: oneWay('session.content'),
 
   /**
     The session store.
@@ -120,7 +120,7 @@ export default Service.extend(Evented, {
     @default null
     @public
   */
-  store: computed.oneWay('session.store'),
+  store: oneWay('session.store'),
 
   /**
     A previously attempted but intercepted transition (e.g. by the
@@ -135,7 +135,7 @@ export default Service.extend(Evented, {
     @default null
     @public
   */
-  attemptedTransition: computed.alias('session.attemptedTransition'),
+  attemptedTransition: alias('session.attemptedTransition'),
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
Resolving this deprecation: `DEPRECATION: Using `computed.oneWay` has been deprecated. Instead, import the value directly from @ember/object/computed`