### PR TITLE
dasherize engine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ class App extends Application {
   …
 
   engines = {
-    myEngine: {
+    'my-engine': {
       dependencies: {
         services: [
           'session'

--- a/packages/classic-test-app/app/app.js
+++ b/packages/classic-test-app/app/app.js
@@ -9,7 +9,7 @@ const App = Application.extend({
   Resolver,
 
   engines: Object.freeze({
-    myEngine: {
+    'my-engine': {
       dependencies: {
         externalRoutes: {
           login: 'login'

--- a/packages/test-app/app/app.js
+++ b/packages/test-app/app/app.js
@@ -9,7 +9,7 @@ const App = Application.extend({
   Resolver,
 
   engines: Object.freeze({
-    myEngine: {
+    'my-engine': {
       dependencies: {
         externalRoutes: {
           login: 'login',


### PR DESCRIPTION
camel-cased engine names have been deprecated (see ember-engines/ember-engines#759).

This dasherizes the engine name in the classic test app and test app as well as in the README.