### PR TITLE
Drop `ember-cli-shims` dependency

### DIFF
--- a/packages/classic-test-app/package.json
+++ b/packages/classic-test-app/package.json
@@ -35,7 +35,6 @@
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mocha": "^0.15.0-beta.1",
     "ember-cli-pretender": "^3.0.0",
-    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-data": "~3.17.0",

--- a/packages/ember-simple-auth/config/ember-try.js
+++ b/packages/ember-simple-auth/config/ember-try.js
@@ -19,7 +19,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -35,7 +34,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -51,7 +49,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -67,7 +64,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -82,7 +78,6 @@ module.exports = function() {
           name: 'ember-release',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             }
           },
@@ -97,7 +92,6 @@ module.exports = function() {
           name: 'ember-beta',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -113,7 +107,6 @@ module.exports = function() {
           name: 'ember-canary',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -47,7 +47,6 @@
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mocha": "^0.15.0-beta.1",
     "ember-cli-pretender": "^3.0.0",
-    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-cli-yuidoc": "^0.9.1",

--- a/packages/test-app/config/ember-try.js
+++ b/packages/test-app/config/ember-try.js
@@ -19,7 +19,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -35,7 +34,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -51,7 +49,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -67,7 +64,6 @@ module.exports = function() {
           bower: {
             dependencies: {
               ember: null,
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -82,7 +78,6 @@ module.exports = function() {
           name: 'ember-release',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             }
           },
@@ -97,7 +92,6 @@ module.exports = function() {
           name: 'ember-beta',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },
@@ -113,7 +107,6 @@ module.exports = function() {
           name: 'ember-canary',
           bower: {
             dependencies: {
-              'ember-cli-shims': null,
               'ember-data': null,
             },
           },

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -37,7 +37,6 @@
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mocha": "^0.15.0-beta.1",
     "ember-cli-pretender": "^3.0.0",
-    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-data": "~3.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,14 +3657,6 @@ broccoli-dependency-funnel@^2.1.2:
     rimraf "^2.6.2"
     symlink-or-copy "^1.2.0"
 
-broccoli-file-creator@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
-  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
-  dependencies:
-    broccoli-plugin "^1.1.0"
-    mkdirp "^0.5.1"
-
 broccoli-file-creator@^2.0.0, broccoli-file-creator@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
@@ -6508,17 +6500,6 @@ ember-cli-pretender@^3.0.0:
     route-recognizer "^0.3.3"
     whatwg-fetch "^3.0.0"
 
-ember-cli-shims@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-shims/-/ember-cli-shims-1.2.0.tgz#0f53aff0aab80b5f29da3a9731bac56169dd941f"
-  integrity sha1-D1Ov8Kq4C18p2jqXMbrFYWndlB8=
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-version-checker "^2.0.0"
-    ember-rfc176-data "^0.3.1"
-    silent-error "^1.0.1"
-
 ember-cli-sri@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz#971620934a4b9183cf7923cc03e178b83aa907fd"
@@ -7163,7 +7144,7 @@ ember-resolver@^8.0.0:
     ember-cli-version-checker "^5.1.1"
     resolve "^1.17.0"
 
-ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
+ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
   integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==


### PR DESCRIPTION
[ember-cli-shims is deprecated](https://github.com/ember-cli/ember-cli-shims) and we don't need it anymore…