### PR TITLE
Lookup and modify ApplicationRoute after EmberRouter is initialized

### DIFF
--- a/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
+++ b/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
@@ -1,27 +1,35 @@
 import { getOwner } from '@ember/application';
 
 export default function setupSessionRestoration(registry) {
-  const ApplicationRoute = registry.resolveRegistration
-    ? registry.resolveRegistration('route:application')
-    : registry.resolve('route:application');
+  const Router = registry.resolveRegistration ? registry.resolveRegistration('router:main') : registry.resolve('router:main');
 
-  ApplicationRoute.reopen({
-    init() {
-      this._super(...arguments);
+  Router.reopen({
+    setupRouter() {
+      const superValue = this._super(...arguments);
+      const ApplicationRoute =
+        getOwner(this).factoryFor('route:application').class;
 
-      const originalBeforeModel = this.beforeModel;
-      this.beforeModel = function() {
-        if (!this.__usesApplicationRouteMixn__) {
-          const sessionService = getOwner(this).lookup('service:session');
-          sessionService._setupHandlers();
-        }
+      ApplicationRoute.reopen({
+        init() {
+          this._super(...arguments);
 
-        const session = getOwner(this).lookup('session:main');
-        return session.restore().then(
-          () => originalBeforeModel.apply(this, arguments),
-          () => originalBeforeModel.apply(this, arguments)
-        );
-      };
+          const originalBeforeModel = this.beforeModel;
+          this.beforeModel = function() {
+            if (!this.__usesApplicationRouteMixn__) {
+              const sessionService = getOwner(this).lookup('service:session');
+              sessionService._setupHandlers();
+            }
+
+            const session = getOwner(this).lookup('session:main');
+            return session.restore().then(
+              () => originalBeforeModel.apply(this, arguments),
+              () => originalBeforeModel.apply(this, arguments)
+            );
+          };
+        },
+      });
+
+      return superValue;
     },
   });
 }

--- a/packages/ember-simple-auth/app/routes/application.js
+++ b/packages/ember-simple-auth/app/routes/application.js
@@ -1,4 +1,0 @@
-import Route from '@ember/routing/route';
-
-// Ensure the application route exists for ember-simple-auth's `setup-session-restoration` initializer
-export default Route.extend();


### PR DESCRIPTION
closes #1854, and closes #2279

It extends EmberRouter#setupRouter, looks up ApplicationRouter and extends it with session service methods.
The reason for extending EmberRouter is that we need to extend user's ApplicationRoute without providing our own, or even users might not have *explicit* ApplicationRoute themselves, but only it's template.

Routes are dynamically registered and instantiated during transitions.