### PR TITLE
[2308] Refactor Adaptive store to use DI

### DIFF
--- a/packages/ember-simple-auth/addon/session-stores/adaptive.js
+++ b/packages/ember-simple-auth/addon/session-stores/adaptive.js
@@ -139,10 +139,13 @@ export default Base.extend({
       options._isFastBoot = false;
       store.setProperties(options);
     } else {
-      store = getOwner(this).lookup(`session-store:cookie`, { dupa: true });
+      store = this.get('cookie');
       const options = this.getProperties('sameSite', 'cookieDomain', 'cookieName', 'cookieExpirationTime', 'cookiePath');
+
       store._initialize(options);
+      this.set('cookieExpirationTime', store.get('cookieExpirationTime'));
     }
+
     this.set('_store', store);
     this._setupStoreEvents(store);
   },

--- a/packages/ember-simple-auth/addon/session-stores/cookie.js
+++ b/packages/ember-simple-auth/addon/session-stores/cookie.js
@@ -173,11 +173,20 @@ export default BaseStore.extend({
 
   init() {
     this._super(...arguments);
-
     let owner = getOwner(this);
     if (owner && !this.hasOwnProperty('_fastboot')) {
       this._fastboot = owner.lookup('service:fastboot');
     }
+  },
+
+  _initialize(options) {
+    const clonedOptions = Object.assign({}, options);
+    if (clonedOptions.cookieName) {
+      this.set('_cookieName', clonedOptions.cookieName);
+    }
+
+    delete clonedOptions.cookieName;
+    this.setProperties(clonedOptions);
 
     let cachedExpirationTime = this._read(`${this.get('cookieName')}-expiration_time`);
     if (cachedExpirationTime) {

--- a/packages/ember-simple-auth/app/initializers/ember-simple-auth.js
+++ b/packages/ember-simple-auth/app/initializers/ember-simple-auth.js
@@ -3,6 +3,9 @@ import Configuration from 'ember-simple-auth/configuration';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
 import setupSessionService from 'ember-simple-auth/initializers/setup-session-service';
 import setupSessionRestoration from 'ember-simple-auth/initializers/setup-session-restoration';
+import Adaptive from 'ember-simple-auth/session-stores/adaptive';
+import LocalStorage from 'ember-simple-auth/session-stores/local-storage';
+import Cookie from 'ember-simple-auth/session-stores/cookie';
 
 export default {
   name: 'ember-simple-auth',
@@ -11,6 +14,10 @@ export default {
     const config = ENV['ember-simple-auth'] || {};
     config.rootURL = ENV.rootURL || ENV.baseURL;
     Configuration.load(config);
+
+    registry.register('session-store:adaptive', Adaptive);
+    registry.register('session-store:cookie', Cookie);
+    registry.register('session-store:local-storage', LocalStorage);
 
     setupSession(registry);
     setupSessionService(registry);

--- a/packages/ember-simple-auth/tests/helpers/create-adaptive-store.js
+++ b/packages/ember-simple-auth/tests/helpers/create-adaptive-store.js
@@ -1,25 +1,13 @@
 import Adaptive from 'ember-simple-auth/session-stores/adaptive';
-import createCookieStore from './create-cookie-store';
-import { merge, assign as emberAssign } from '@ember/polyfills';
-
-const assign = emberAssign || merge;
 
 export default function createAdaptiveStore(
   cookiesService,
   options = {},
-  props = {}
+  owner
 ) {
-  let cookieStore = createCookieStore(
-    cookiesService,
-    assign({}, options, { _isFastboot: false })
-  );
-  props._createStore = function() {
-    cookieStore.on('sessionDataUpdated', data => {
-      this.trigger('sessionDataUpdated', data);
-    });
+  owner.register('session-store:adaptive', Adaptive.extend(Object.assign({
+    _isLocalStorageAvailable: false,
+  }, options)));
 
-    return cookieStore;
-  };
-
-  return Adaptive.extend(props).create(options);
+  return owner.lookup('session-store:adaptive');
 }

--- a/packages/ember-simple-auth/tests/helpers/create-cookie-store.js
+++ b/packages/ember-simple-auth/tests/helpers/create-cookie-store.js
@@ -1,7 +1,4 @@
 import Cookie from 'ember-simple-auth/session-stores/cookie';
 
-export default function createCookieStore(cookiesService, options = {}) {
-  options._cookies = cookiesService;
-  options._fastboot = { isFastBoot: false };
-  return Cookie.create(options);
+export default function createCookieStore(cookiesService, options = {}, owner) {
 }

--- a/packages/ember-simple-auth/tests/helpers/create-cookie-store.js
+++ b/packages/ember-simple-auth/tests/helpers/create-cookie-store.js
@@ -1,4 +1,0 @@
-import Cookie from 'ember-simple-auth/session-stores/cookie';
-
-export default function createCookieStore(cookiesService, options = {}, owner) {
-}

--- a/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
@@ -10,6 +10,7 @@ import { setupTest } from 'ember-mocha';
 
 describe('AdaptiveStore', () => {
   setupTest();
+
   describe('when localStorage is available', function() {
     itBehavesLikeAStore({
       store(sinon, owner) {
@@ -20,7 +21,6 @@ describe('AdaptiveStore', () => {
         sinon.spy(cookieService, 'read');
         sinon.spy(cookieService, 'write');
         store = createAdaptiveStore(cookieService, {
-          _isLocal: false,
           _isLocalStorageAvailable: true,
         }, owner);
         return store;
@@ -38,7 +38,6 @@ describe('AdaptiveStore', () => {
         sinon.spy(cookieService, 'read');
         sinon.spy(cookieService, 'write');
         store = createAdaptiveStore(cookieService, {
-          _isLocal: false,
           _isLocalStorageAvailable: false,
           _cookieName: 'test:session',
         }, owner);
@@ -56,7 +55,6 @@ describe('AdaptiveStore', () => {
           sinon.spy(cookieService, 'read');
           sinon.spy(cookieService, 'write');
           let store = createAdaptiveStore(cookieService, Object.assign({
-            _isLocal: false,
             _isLocalStorageAvailable: false,
             _cookieName: 'test:session',
           }, storeOptions), owner);
@@ -88,7 +86,6 @@ describe('AdaptiveStore', () => {
       run(() => {
         now = new Date();
         store = createAdaptiveStore(cookieService, {
-          _isLocal: false,
           _isLocalStorageAvailable: false,
           _cookieName: 'test:session',
         }, this.owner);

--- a/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
@@ -78,20 +79,24 @@ describe('AdaptiveStore', () => {
       let sinon = sinonjs.createSandbox();
       let store;
       let cookieService;
+      let now;
+
       this.owner.register('service:cookies', FakeCookieService);
       cookieService = this.owner.lookup('service:cookies');
       sinon.spy(cookieService, 'read');
       sinon.spy(cookieService, 'write');
-      store = createAdaptiveStore(cookieService, {
-        _isLocal: false,
-        _isLocalStorageAvailable: false,
-        _cookieName: 'test:session',
-      }, this.owner);
-      let now = new Date();
+      run(() => {
+        now = new Date();
+        store = createAdaptiveStore(cookieService, {
+          _isLocal: false,
+          _isLocalStorageAvailable: false,
+          _cookieName: 'test:session',
+        }, this.owner);
 
-      store.setProperties({
-        cookieName:           'test:session',
-        cookieExpirationTime: 60
+        store.setProperties({
+          cookieName:           'test:session',
+          cookieExpirationTime: 60
+        });
       });
       await store.persist({ key: 'value' });
 

--- a/packages/ember-simple-auth/tests/unit/session-stores/cookie-test.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/cookie-test.js
@@ -1,45 +1,60 @@
-import { describe, beforeEach } from 'mocha';
-import sinonjs from 'sinon';
+import { describe } from 'mocha';
 import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
-import createCookieStore from '../../helpers/create-cookie-store';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import { setupTest } from 'ember-mocha';
 
 describe('CookieStore', () => {
-  let sinon;
-  let store;
+  setupTest();
 
-  beforeEach(function() {
-    sinon = sinonjs.createSandbox();
-    store = createCookieStore(FakeCookieService.create());
+  describe('StoreBehavior', function() {
+    itBehavesLikeAStore({
+      store(sinon, owner) {
+        let store;
+        let cookieService;
+        owner.register('service:cookies', FakeCookieService);
+        cookieService = owner.lookup('service:cookies');
+        sinon.spy(cookieService, 'read');
+        sinon.spy(cookieService, 'write');
+        owner.register('session-store:cookie', CookieStore.extend({
+          _cookieName: 'test-session',
+        }));
+        store = owner.lookup('session-store:cookie');
+        return store;
+      },
+      syncExternalChanges(store) {
+        store._syncData();
+      }
+    });
   });
 
-  afterEach(function() {
-    sinon.restore();
-  });
-
-  itBehavesLikeAStore({
-    store() {
-      return store;
-    },
-    syncExternalChanges() {
-      store._syncData();
-    }
-  });
-
-  itBehavesLikeACookieStore({
-    createStore(cookiesService, options = {}) {
-      return createCookieStore(cookiesService, options);
-    },
-    renew(store, data) {
-      return store._renew(data);
-    },
-    sync(store) {
-      store._syncData();
-    },
-    spyRewriteCookieMethod(store) {
-      sinon.spy(store, 'rewriteCookie');
-      return store.rewriteCookie;
-    }
+  describe('CookieStoreBehavior', function() {
+    itBehavesLikeACookieStore({
+      store(sinon, owner, storeOptions) {
+        owner.register('service:cookies', FakeCookieService);
+        let cookieService = owner.lookup('service:cookies');
+        sinon.spy(cookieService, 'read');
+        sinon.spy(cookieService, 'write');
+        owner.register('session-store:cookie', CookieStore.extend(Object.assign({
+          _cookieName: 'test:session',
+        }, storeOptions)));
+        let store = owner.lookup('session-store:cookie');
+        return store;
+      },
+      createStore(store) {
+        return store;
+      },
+      renew(store, data) {
+        return store._renew(data);
+      },
+      sync(store) {
+        store._syncData();
+      },
+      spyRewriteCookieMethod(sinon, store) {
+        sinon.spy(store, 'rewriteCookie');
+        return store.rewriteCookie;
+      }
+    });
   });
 });

--- a/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -302,13 +302,15 @@ export default function(options) {
       );
     });
 
-    // eslint-disable-next-line require-await
-    it('clears cached expiration times when setting expiration to null', async function() {
+    it('clears cached expiration times when setting expiration to null', function(done) {
       run(() => {
         store.set('cookieExpirationTime', null);
       });
 
-      expect(cookieService.clear).to.have.been.calledWith(`session-foo-expiration_time`);
+      next(() => {
+        expect(cookieService.clear).to.have.been.calledWith(`session-foo-expiration_time`);
+        done();
+      });
     });
 
     it('only rewrites the cookie once per run loop when multiple properties are changed', function(done) {
@@ -330,16 +332,15 @@ export default function(options) {
     let cookieName = 'ember_simple_auth-session-expiration_time';
     let expirationTime = 60 * 60 * 24;
 
-    beforeEach(function() {
+    beforeEach(async function() {
       store = options.store(sinon, this.owner, {
         cookieExpirationTime: expirationTime,
       });
       cookieService = store.get('_cookies');
-      cookieService.write(cookieName, expirationTime);
+      await cookieService.write(cookieName, expirationTime);
     });
 
-    // eslint-disable-next-line require-await
-    it('restores expiration time from cookie', async function() {
+    it('restores expiration time from cookie', function() {
       expect(store.get('cookieExpirationTime')).to.equal(expirationTime);
     });
   });

--- a/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -9,7 +9,6 @@ import {
 import { expect } from 'chai';
 import sinonjs from 'sinon';
 import FakeCookieService from '../../../helpers/fake-cookie-service';
-import { setupTest } from 'ember-mocha';
 
 let warnings;
 registerWarnHandler((message, options, next) => {
@@ -61,8 +60,10 @@ export default function(options) {
 
     it('respects the configured cookieDomain', async function() {
       let cookieService = store.get('_cookies');
-      store.set('cookieName', 'session-cookie-domain');
-      store.set('cookieDomain', 'example.com');
+      run(() => {
+        store.set('cookieName', 'session-cookie-domain');
+        store.set('cookieDomain', 'example.com');
+      });
       await store.persist({ key: 'value' });
 
       expect(cookieService.write).to.have.been.calledWith(
@@ -73,9 +74,11 @@ export default function(options) {
     });
 
     it('respects the configured cookiePath', async function() {
-      store.set('cookieName', 'session-cookie-domain');
-      store.set('cookieDomain', 'example.com');
-      store.set('cookiePath', '/hello-world');
+      run(() => {
+        store.set('cookieName', 'session-cookie-domain');
+        store.set('cookieDomain', 'example.com');
+        store.set('cookiePath', '/hello-world');
+      });
       let cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
 
@@ -87,9 +90,11 @@ export default function(options) {
     });
 
     it('respects the configured sameSite', async function() {
-      store.set('cookieName', 'session-cookie-domain');
-      store.set('cookieDomain', 'example.com');
-      store.set('sameSite', 'Strict');
+      run(() => {
+        store.set('cookieName', 'session-cookie-domain');
+        store.set('cookieDomain', 'example.com');
+        store.set('sameSite', 'Strict');
+      });
       let cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
       expect(cookieService.write).to.have.been.calledWith(
@@ -100,9 +105,11 @@ export default function(options) {
     });
 
     it('sends a warning when `cookieExpirationTime` is less than 90 seconds', async function(done) {
-      store.set('cookieName', 'session-cookie-domain');
-      store.set('cookieDomain', 'example.com');
-      store.set('cookieExpirationTime', 60);
+      run(() => {
+        store.set('cookieName', 'session-cookie-domain');
+        store.set('cookieDomain', 'example.com');
+        store.set('cookieExpirationTime', 60);
+      });
       await store.persist({ key: 'value' });
       run(() => {
         expect(warnings).to.have.length(1);
@@ -214,7 +221,9 @@ export default function(options) {
     });
 
     it('deletes the old cookie and writes a new one when name property changes', async function() {
-      store.set('cookieName', 'session-bar');
+      run(() => {
+        store.set('cookieName', 'session-bar');
+      });
       await store.persist({ key: 'value' });
 
       expect(cookieService.clear).to.have.been.calledWith('session-foo');
@@ -246,8 +255,10 @@ export default function(options) {
 
     it('deletes the old cookie and writes a new one when domain property changes', async function() {
       let defaultName = 'session-foo';
-      store.set('cookieDomain', 'example.com');
-      store.set('cookieName', 'session-bar');
+      run(() => {
+        store.set('cookieDomain', 'example.com');
+        store.set('cookieName', 'session-bar');
+      });
       await store.persist({ key: 'value' });
 
       expect(cookieService.clear).to.have.been.calledWith(defaultName);
@@ -269,8 +280,10 @@ export default function(options) {
     it('deletes the old cookie and writes a new one when expiration property changes', async function() {
       let defaultName = 'session-foo';
       let expirationTime = 180;
-      store.set('cookieExpirationTime', expirationTime);
-      store.set('cookieName', 'session-bar');
+      run(() => {
+        store.set('cookieExpirationTime', expirationTime);
+        store.set('cookieName', 'session-bar');
+      });
       await store.persist({ key: 'value' });
 
       expect(cookieService.clear).to.have.been.calledWith(defaultName);
@@ -291,7 +304,9 @@ export default function(options) {
 
     // eslint-disable-next-line require-await
     it('clears cached expiration times when setting expiration to null', async function() {
-      await store.set('cookieExpirationTime', null);
+      run(() => {
+        store.set('cookieExpirationTime', null);
+      });
 
       expect(cookieService.clear).to.have.been.calledWith(`session-foo-expiration_time`);
     });

--- a/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/shared/cookie-store-behavior.js
@@ -49,7 +49,7 @@ export default function(options) {
     });
 
     it('respects the configured cookieName', async function() {
-      let cookieService = store._cookies;
+      let cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
 
       expect(cookieService.write).to.have.been.calledWith(
@@ -60,7 +60,7 @@ export default function(options) {
     });
 
     it('respects the configured cookieDomain', async function() {
-      let cookieService = store._cookies;
+      let cookieService = store.get('_cookies');
       store.set('cookieName', 'session-cookie-domain');
       store.set('cookieDomain', 'example.com');
       await store.persist({ key: 'value' });
@@ -76,7 +76,7 @@ export default function(options) {
       store.set('cookieName', 'session-cookie-domain');
       store.set('cookieDomain', 'example.com');
       store.set('cookiePath', '/hello-world');
-      let cookieService = store._cookies;
+      let cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
 
       expect(cookieService.write).to.have.been.calledWith(
@@ -90,7 +90,7 @@ export default function(options) {
       store.set('cookieName', 'session-cookie-domain');
       store.set('cookieDomain', 'example.com');
       store.set('sameSite', 'Strict');
-      let cookieService = store._cookies;
+      let cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
       expect(cookieService.write).to.have.been.calledWith(
         'session-cookie-domain',
@@ -123,7 +123,7 @@ export default function(options) {
         cookieName: 'test-session',
         cookieExpirationTime: 60,
       });
-      cookieService = store._cookies;
+      cookieService = store.get('_cookies');
       await store.persist({ key: 'value' });
       await renew(store);
     });

--- a/packages/ember-simple-auth/tests/unit/session-stores/shared/store-behavior.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/shared/store-behavior.js
@@ -1,7 +1,6 @@
-import { next } from '@ember/runloop';
+import { next, run } from '@ember/runloop';
 import { describe, beforeEach, afterEach, it } from 'mocha';
 import { expect } from 'chai';
-import { setupTest } from 'ember-mocha';
 import sinonjs from 'sinon';
 
 export default function(options) {
@@ -19,8 +18,12 @@ export default function(options) {
   });
 
   describe('#persist', function() {
+    let store;
+    beforeEach(function() {
+      store = options.store(sinon, this.owner);
+    });
+
     it('persists an object', async function() {
-      let store = options.store(sinon, this.owner);
       await store.persist({ key: 'value' });
       let restoredContent = await store.restore();
 
@@ -28,7 +31,7 @@ export default function(options) {
     });
 
     it('overrides existing data', async function() {
-      let store = options.store(sinon, this.owner);
+      await store.persist({ key: 'value' });
       await store.persist({ key1: 'value1' });
       await store.persist({ key2: 'value2' });
       let restoredContent = await store.restore();
@@ -37,7 +40,6 @@ export default function(options) {
     });
 
     it('does not trigger the "sessionDataUpdated" event', function(done) {
-      let store = options.store(sinon, this.owner);
       let triggered = false;
       store.one('sessionDataUpdated', () => (triggered = true));
       store.persist({ key: 'other value' });
@@ -53,7 +55,10 @@ export default function(options) {
   describe('#restore', function() {
     describe('when the store is empty', function() {
       it('returns an empty object', async function() {
-        let store = options.store(sinon, this.owner);
+        let store;
+        run(() => {
+          store = options.store(sinon, this.owner);
+        });
         await store.clear();
         let restoredContent = await store.restore();
 
@@ -86,7 +91,10 @@ export default function(options) {
 
   describe('#clear', function() {
     it('empties the store', async function() {
-      let store = options.store(sinon, this.owner);
+      let store;
+      run(() => {
+        store = options.store(sinon, this.owner);
+      });
       await store.persist({ key1: 'value1', key2: 'value2' });
       await store.clear();
       let restoredContent = await store.restore();


### PR DESCRIPTION
- registers session-stores in Ember's DI system.
- refactors AdaptiveStore to use registered CookieStore and LocalStorageStore.
- modifies test to use `setupTest` so there's access to ember's container
- the side effect of `setupTest` is that it seems to require the test to be asynchronous, so all test functions are marked as `async` so they return a promise implicitly
- changes how CookieStore is initialized by implementing `_initialize` method that handles setting of properties that would normally be provided during creation of CookieStore instance.
- changed e.g `cookieName` property to `_cookieName` in some tests because using 'non private' property would override the underlying computed property which acts as a proxy, because of this behaviour, the private 'default' values are changed and not the public ones.

closes #2308 