### PR TITLE
Drop node 10 in favor of 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
 
       - name: get yarn cache dir
         id: yarn-cache
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
 
       - name: get yarn cache dir
         id: yarn-cache
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
 
       - name: get yarn cache dir
         id: yarn-cache
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
 
       - name: get yarn cache dir
         id: yarn-cache

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ __[Ember Simple Auth API docs](http://ember-simple-auth.com/api/)__
 __[![Discord](https://img.shields.io/discord/480462759797063690.svg?logo=discord)](https://discord.gg/zT3asNS)__
 
 Ember Simple Auth __supports all Ember.js versions starting with 3.0.__
+Node __12 is required__  
 
 #  Ember Simple Auth
 

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -78,7 +78,7 @@
     "torii": "^0.10.0"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": ">= 12"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Pipelines are failing to due to some dependencies being incompatible with node 10.
Node 10 also already reach it's end of life.

see #2312 