### PR TITLE
[2314] Add setup method in session service

### DIFF
--- a/guides/upgrade-to-v4.md
+++ b/guides/upgrade-to-v4.md
@@ -1,0 +1,64 @@
+### Call session#setup method in your ApplicationRoute
+ESA implemented setup method on session service for users to manually implement in their ApplicationRoutes.
+Reason being that ESA wants to move away from relying on initializers which have been spinning up the session services for you by default.
+
+***READ THIS if you are on ESA 4.1.0 and want to opt-in into this behavior***
+In order to opt-in into this early, you'll need to add some configuration for ember-simple-auth.
+
+Inside your `ember-cli-build.js` you'll need to add `useSessionSetupMethod` flag and set it to `true`:
+```js
+  'ember-simple-auth': {
+    useSessionSetupMethod: true,
+  }
+```
+This will tell ESA to not use initializer to spin-up the session service.
+And will exclude `routes/application.js` file from Ember Simple Auth addon which might've been causing some build issues while using with typescript.
+
+With initializers gone, you'll need to call `session#setup` method directly in your application route.
+
+```js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class Application extends Route {
+  @service session;
+
+  async beforeModel() {
+    await this.session.setup();
+  }
+}
+```
+
+If you had any custom setup in your `beforeModel` then you'll want to move this below the session setup to preserve timings.
+
+***Old***
+```
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class Application extends Route {
+  @service intl;
+
+  beforeModel() {
+    this.intl.setLocale('pl-PL');
+  }
+}
+```
+
+
+***New***
+```js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class Application extends Route {
+  @service session;
+  @service intl;
+
+  async beforeModel() {
+    await this.session.setup();
+    this.intl.setLocale('pl-PL');
+  }
+}
+```
+

--- a/packages/ember-simple-auth/addon/configuration.js
+++ b/packages/ember-simple-auth/addon/configuration.js
@@ -36,11 +36,24 @@ export default {
   */
   routeAfterAuthentication: DEFAULTS.routeAfterAuthentication,
 
+  /**
+    Flag used to determine whether users have decided to setup session service themselves.
+    This lets us to return early from initializer which would setup the service automatically.
+
+    This will be the default behavior in the future.
+
+    @property useSessionSetupMethod
+    @default false
+    @public
+  */
+  useSessionSetupMethod: false,
+
   load(config) {
     this.rootURL = config.rootURL !== undefined ? config.rootURL : DEFAULTS.rootURL;
     this.routeAfterAuthentication =
       config.routeAfterAuthentication !== undefined
         ? config.routeAfterAuthentication
         : DEFAULTS.routeAfterAuthentication;
+    this.useSessionSetupMethod = Boolean(config.useSessionSetupMethod);
   },
 };

--- a/packages/ember-simple-auth/addon/configuration.js
+++ b/packages/ember-simple-auth/addon/configuration.js
@@ -1,3 +1,5 @@
+import useSessionSetupMethod from 'ember-simple-auth/use-session-setup-method';
+
 const DEFAULTS = {
   rootURL: '',
   routeAfterAuthentication: 'index',
@@ -44,9 +46,9 @@ export default {
 
     @property useSessionSetupMethod
     @default false
-    @public
+    @private
   */
-  useSessionSetupMethod: false,
+  useSessionSetupMethod,
 
   load(config) {
     this.rootURL = config.rootURL !== undefined ? config.rootURL : DEFAULTS.rootURL;
@@ -54,6 +56,5 @@ export default {
       config.routeAfterAuthentication !== undefined
         ? config.routeAfterAuthentication
         : DEFAULTS.routeAfterAuthentication;
-    this.useSessionSetupMethod = Boolean(config.useSessionSetupMethod);
   },
 };

--- a/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
+++ b/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
@@ -1,6 +1,12 @@
 import { getOwner } from '@ember/application';
+import Configuration from '../configuration';
 
 export default function setupSessionRestoration(registry) {
+  if (Configuration.useSessionSetupMethod) {
+    // return early in case users chose to opt out of initializer behavior.
+    return;
+  }
+
   const ApplicationRoute = registry.resolveRegistration
     ? registry.resolveRegistration('route:application')
     : registry.resolve('route:application');

--- a/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
+++ b/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
@@ -1,11 +1,17 @@
 import { getOwner } from '@ember/application';
 import Configuration from '../configuration';
+import { deprecate } from '@ember/application/deprecations';
 
 export default function setupSessionRestoration(registry) {
   if (Configuration.useSessionSetupMethod) {
     // return early in case users chose to opt out of initializer behavior.
     return;
   }
+
+  deprecate('Ember Simple Auth: The automatic session initialization is deprecated. Please inject session service in your application route and call the setup method manually.', false, {
+    id: 'ember-simple-auth.initializer.setup-session-restoration',
+    until: '5.0.0'
+  });
 
   const ApplicationRoute = registry.resolveRegistration
     ? registry.resolveRegistration('route:application')

--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -26,6 +26,12 @@ function deprecateSessionEvents() {
   }
 }
 
+function assertSetupHasBeenCalled(isSetupCalled) {
+  if (!isSetupCalled && Configuration.useSessionSetupMethod) {
+    assert("Ember Simple Auth: session#setup wasn't called. Make sure to call session#setup in your application route's beforeModel hook.", false);
+  }
+}
+
 /**
   __The session service provides access to the current session as well as
   methods to authenticate it, invalidate it, etc.__ It is the main interface for
@@ -293,6 +299,7 @@ export default Service.extend(Evented, {
     @public
   */
   requireAuthentication(transition, routeOrCallback) {
+    assertSetupHasBeenCalled(this._setupIsCalled);
     let isAuthenticated = requireAuthentication(getOwner(this), transition);
     if (!isAuthenticated) {
       let argType = typeof routeOrCallback;
@@ -317,6 +324,7 @@ export default Service.extend(Evented, {
     @public
   */
   prohibitAuthentication(routeOrCallback) {
+    assertSetupHasBeenCalled(this._setupIsCalled);
     let isAuthenticated = this.get('isAuthenticated');
     if (isAuthenticated) {
       let argType = typeof routeOrCallback;
@@ -380,6 +388,7 @@ export default Service.extend(Evented, {
     @public
   */
   async setup() {
+    this._setupIsCalled = true;
     try {
       this._setupHandlers();
       await this.session.restore();

--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -367,5 +367,24 @@ export default Service.extend(Evented, {
   */
   handleInvalidation(routeAfterInvalidation) {
     handleSessionInvalidated(getOwner(this), routeAfterInvalidation);
-  }
+  },
+
+  /**
+    Sets up the session service.
+
+    This method must be called when the application starts up,
+    usually as the first thing in the `application` route's `beforeModel`
+    method.
+
+    @method setup
+    @public
+  */
+  async setup() {
+    try {
+      this._setupHandlers();
+      await this.session.restore();
+    } catch (error) {
+      // If it raises an error then it means that restore didn't find any restorable state.
+    }
+  },
 });

--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "base-64": "^0.1.0",
+    "broccoli-file-creator": "^2.1.1",
+    "broccoli-merge-trees": "^4.0.0",
     "broccoli-funnel": "^1.2.0 || ^2.0.0",
     "ember-cli-babel": "^7.20.5",
     "ember-cli-is-package-missing": "^1.0.0",

--- a/packages/ember-simple-auth/tests/unit/initializers/setup-session-restoration-test.js
+++ b/packages/ember-simple-auth/tests/unit/initializers/setup-session-restoration-test.js
@@ -6,6 +6,7 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
 import setupSessionRestoration from 'ember-simple-auth/initializers/setup-session-restoration';
+import Configuration from 'ember-simple-auth/configuration';
 
 describe('setupSessionRestoration', () => {
   setupTest();
@@ -27,6 +28,33 @@ describe('setupSessionRestoration', () => {
 
     const route = this.owner.lookup('route:application');
     expect(route).to.respondTo('beforeModel');
+  });
+
+  describe('useSessionSetupMethod', function() {
+    beforeEach(function() {
+      Configuration.useSessionSetupMethod = false;
+    });
+
+    afterEach(function() {
+      Configuration.useSessionSetupMethod = false;
+    });
+
+    it("doesn't extend application route when is true", function() {
+      Configuration.useSessionSetupMethod = true;
+      const route = this.owner.resolveRegistration('route:application');
+      const reopenStub = sinon.stub(route, 'reopen');
+
+      setupSessionRestoration(this.owner);
+      expect(reopenStub).to.not.have.been.called;
+    });
+
+    it('extends application route when is false', function() {
+      const route = this.owner.resolveRegistration('route:application');
+      const reopenStub = sinon.stub(route, 'reopen');
+
+      setupSessionRestoration(this.owner);
+      expect(reopenStub).to.have.been.called;
+    });
   });
 
   describe('the beforeModel method', function() {

--- a/packages/ember-simple-auth/tests/unit/initializers/setup-session-restoration-test.js
+++ b/packages/ember-simple-auth/tests/unit/initializers/setup-session-restoration-test.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 import sinonjs from 'sinon';
 import setupSessionRestoration from 'ember-simple-auth/initializers/setup-session-restoration';
 import Configuration from 'ember-simple-auth/configuration';
+import { registerDeprecationHandler } from '@ember/debug';
 
 describe('setupSessionRestoration', () => {
   setupTest();
@@ -31,12 +32,15 @@ describe('setupSessionRestoration', () => {
   });
 
   describe('useSessionSetupMethod', function() {
+    let useSessionSetupMethodDefault;
+
     beforeEach(function() {
+      useSessionSetupMethodDefault = Configuration.useSessionSetupMethod;
       Configuration.useSessionSetupMethod = false;
     });
 
     afterEach(function() {
-      Configuration.useSessionSetupMethod = false;
+      Configuration.useSessionSetupMethod = useSessionSetupMethodDefault;
     });
 
     it("doesn't extend application route when is true", function() {
@@ -54,6 +58,34 @@ describe('setupSessionRestoration', () => {
 
       setupSessionRestoration(this.owner);
       expect(reopenStub).to.have.been.called;
+    });
+
+    it("doesn't show deprecation when is true", function() {
+      Configuration.useSessionSetupMethod = true;
+
+      let deprecations = [];
+      registerDeprecationHandler((message, options, next) => {
+        deprecations.push(message);
+
+        next(message, options);
+      });
+
+      setupSessionRestoration(this.owner);
+
+      expect(deprecations.filter(deprecation => deprecation.includes('Ember Simple Auth:'))).to.have.length(0);
+    });
+
+    it('shows deprecation when is false', function() {
+      let deprecations = [];
+      registerDeprecationHandler((message, options, next) => {
+        deprecations.push(message);
+
+        next(message, options);
+      });
+
+      setupSessionRestoration(this.owner);
+
+      expect(deprecations.filter(deprecation => deprecation.includes('Ember Simple Auth:'))).to.have.length(1);
     });
   });
 

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -530,14 +530,14 @@ describe('SessionService', () => {
   });
 
   describe('setup', function() {
-    it('setups handlers', async function() {
+    it('sets up handlers', async function() {
       const setupHandlersStub = sinon.stub(sessionService, '_setupHandlers');
 
       await sessionService.setup();
       expect(setupHandlersStub).to.have.been.calledOnce;
     });
 
-    it("Doesn't raise an error when restore rejects", async function() {
+    it("doesn't raise an error when restore rejects", async function() {
       sinon.stub(sessionService, '_setupHandlers');
       sinon.stub(session, 'restore').throws();
 
@@ -545,12 +545,15 @@ describe('SessionService', () => {
     });
 
     describe('when using session methods', function() {
+      let useSessionSetupMethodDefault;
+
       beforeEach(function() {
+        useSessionSetupMethodDefault = Configuration.useSessionSetupMethod;
         Configuration.useSessionSetupMethod = false;
       });
 
       afterEach(function() {
-        Configuration.useSessionSetupMethod = false;
+        Configuration.useSessionSetupMethod = useSessionSetupMethodDefault;
       });
 
       it('throws assertion when session methods are called before session#setup', async function() {

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -527,4 +527,20 @@ describe('SessionService', () => {
       });
     });
   });
+
+  describe('setup', function() {
+    it('setups handlers', async function() {
+      const setupHandlersStub = sinon.stub(sessionService, '_setupHandlers');
+
+      await sessionService.setup();
+      expect(setupHandlersStub).to.have.been.calledOnce;
+    });
+
+    it("Doesn't raise an error when restore rejects", async function() {
+      sinon.stub(sessionService, '_setupHandlers');
+      sinon.stub(session, 'restore').throws();
+
+      await sessionService.setup();
+    });
+  });
 });

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -8,6 +8,7 @@ import { setupTest } from 'ember-mocha';
 import { expect } from 'chai';
 import sinonjs from 'sinon';
 import * as LocationUtil from 'ember-simple-auth/utils/location';
+import Configuration from 'ember-simple-auth/configuration';
 
 describe('SessionService', () => {
   setupTest();
@@ -541,6 +542,41 @@ describe('SessionService', () => {
       sinon.stub(session, 'restore').throws();
 
       await sessionService.setup();
+    });
+
+    describe('when using session methods', function() {
+      beforeEach(function() {
+        Configuration.useSessionSetupMethod = false;
+      });
+
+      afterEach(function() {
+        Configuration.useSessionSetupMethod = false;
+      });
+
+      it('throws assertion when session methods are called before session#setup', async function() {
+        Configuration.useSessionSetupMethod = true;
+        let error;
+        try {
+          await sessionService.prohibitAuthentication();
+        } catch (assertion) {
+          error = assertion;
+        }
+        expect(error.message).to.eq("Assertion Failed: Ember Simple Auth: session#setup wasn't called. Make sure to call session#setup in your application route's beforeModel hook.");
+      });
+
+      it("doesn't throw assertion when session methods are called after session#setup", async function() {
+        Configuration.useSessionSetupMethod = true;
+        let error;
+
+        await sessionService.setup();
+        try {
+          await sessionService.prohibitAuthentication();
+        } catch (assertion) {
+          error = assertion;
+        }
+
+        expect(error).to.be.undefined;
+      });
     });
   });
 });

--- a/packages/test-app/app/routes/application.js
+++ b/packages/test-app/app/routes/application.js
@@ -5,7 +5,8 @@ export default Route.extend({
   session: service(),
   sessionAccount: service(),
 
-  beforeModel() {
+  async beforeModel() {
+    await this.get('session').setup();
     return this.get('sessionAccount').loadCurrentUser().catch(() => this.get('session').invalidate());
   }
 });

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,7 +3753,7 @@ broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
-broccoli-merge-trees@^4.1.0, broccoli-merge-trees@^4.2.0:
+broccoli-merge-trees@^4.0.0, broccoli-merge-trees@^4.1.0, broccoli-merge-trees@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz#692d3c163ecea08c5714a9434d664e628919f47c"
   integrity sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==


### PR DESCRIPTION
closes #2314 
closes #1854, and closes #2279

- Adds #setup method for session service
- Adds `useSessionSetupMethod` 'run time' configuration for `setup-session-restoration` intiializer to return early
- Adds deprecation when initializer is being used indicating the migration to session#setup instead.
- Documents how to use the #setup method along with the configuration options `guides/upgrate-to-v4.md`.

I was able to successfully confirm this working in my private project which conveniently is written in typescript #1854, #2279.