### PR TITLE
Allow CI for ember-beta to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,17 @@ jobs:
           - test:one ember-lts-3.16
           - test:one ember-lts-3.20
           - test:one ember-lts-3.24
-          - test:one ember-beta
         allow-failure: [false]
         include:
+          - workspace: ember-simple-auth
+            test-suite: "test:one ember-beta"
+            allow-failure: true
+          - workspace: test-app
+            test-suite: "test:one ember-beta"
+            allow-failure: true
+          - workspace: classic-test-app
+            test-suite: "test:one ember-beta"
+            allow-failure: true
           - workspace: ember-simple-auth
             test-suite: "test:one ember-release"
             allow-failure: false


### PR DESCRIPTION
Allow CI for ember-beta to fail because the current version of ember-simple-auth does not support ember 4.