### PR TITLE
add annotation to deprecations so Ember deprecate fn does not complain

### DIFF
--- a/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
+++ b/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/application';
 import Configuration from '../configuration';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 
 export default function setupSessionRestoration(registry) {
   if (Configuration.useSessionSetupMethod) {

--- a/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
+++ b/packages/ember-simple-auth/addon/initializers/setup-session-restoration.js
@@ -10,7 +10,11 @@ export default function setupSessionRestoration(registry) {
 
   deprecate('Ember Simple Auth: The automatic session initialization is deprecated. Please inject session service in your application route and call the setup method manually.', false, {
     id: 'ember-simple-auth.initializer.setup-session-restoration',
-    until: '5.0.0'
+    until: '5.0.0',
+    for: 'ember-simple-auth',
+    since: {
+      enabled: '4.1.0'
+    }
   });
 
   const ApplicationRoute = registry.resolveRegistration

--- a/packages/ember-simple-auth/addon/mixins/application-route-mixin.js
+++ b/packages/ember-simple-auth/addon/mixins/application-route-mixin.js
@@ -12,7 +12,11 @@ import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 deprecate('Ember Simple Auth: The ApplicationRouteMixin is now deprecated; it can be safely removed.', false, {
   id: 'ember-simple-auth.mixins.application-route-mixin',
-  until: '4.0.0'
+  until: '4.0.0',
+  for: 'ember-simple-auth',
+  since: {
+    enabled: '3.1.0'
+  }
 });
 
 /**

--- a/packages/ember-simple-auth/addon/mixins/authenticated-route-mixin.js
+++ b/packages/ember-simple-auth/addon/mixins/authenticated-route-mixin.js
@@ -8,7 +8,11 @@ import { requireAuthentication, triggerAuthentication } from '../-internals/rout
 
 deprecate("Ember Simple Auth: The AuthenticatedRouteMixin is now deprecated; call the session service's requireAuthentication method in the respective route's beforeModel method instead.", false, {
   id: 'ember-simple-auth.mixins.authenticated-route-mixin',
-  until: '4.0.0'
+  until: '4.0.0',
+  for: 'ember-simple-auth',
+  since: {
+    enabled: '3.1.0'
+  }
 });
 
 /**

--- a/packages/ember-simple-auth/addon/mixins/data-adapter-mixin.js
+++ b/packages/ember-simple-auth/addon/mixins/data-adapter-mixin.js
@@ -6,7 +6,11 @@ import { deprecate } from '@ember/debug';
 
 deprecate("Ember Simple Auth: The DataAdapterMixin is now deprecated; call the session service's invalidate method in the adapter's handleResponse method instead in case of a 401 response.", false, {
   id: 'ember-simple-auth.mixins.data-adapter-mixin',
-  until: '4.0.0'
+  until: '4.0.0',
+  for: 'ember-simple-auth',
+  since: {
+    enabled: '3.1.0'
+  }
 });
 
 /**

--- a/packages/ember-simple-auth/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
+++ b/packages/ember-simple-auth/addon/mixins/oauth2-implicit-grant-callback-route-mixin.js
@@ -10,7 +10,11 @@ import { parseResponse } from '../authenticators/oauth2-implicit-grant';
 
 deprecate("Ember Simple Auth: The OAuth2ImplicitGrantCallbackRouteMixin is now deprecated; call the session service's authenticate method with the appropriate authenticator in the respective route's activate method instead.", false, {
   id: 'ember-simple-auth.mixins.oauth2-implicit-grant-callback-route-mixin',
-  until: '4.0.0'
+  until: '4.0.0',
+  for: 'ember-simple-auth',
+  since: {
+    enabled: '3.1.0'
+  }
 });
 
 /**

--- a/packages/ember-simple-auth/addon/mixins/unauthenticated-route-mixin.js
+++ b/packages/ember-simple-auth/addon/mixins/unauthenticated-route-mixin.js
@@ -8,7 +8,11 @@ import { prohibitAuthentication } from '../-internals/routing';
 
 deprecate("Ember Simple Auth: The UnauthenticatedRouteMixin is now deprecated; call the session service's prohibitAuthentication method in the respective route's beforeModel method instead.", false, {
   id: 'ember-simple-auth.mixins.unauthenticated-route-mixin',
-  until: '4.0.0'
+  until: '4.0.0',
+  for: 'ember-simple-auth',
+  since: {
+    enabled: '3.1.0'
+  }
 });
 
 /**

--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -21,7 +21,11 @@ function deprecateSessionEvents() {
   if (enableEventsDeprecation) {
     deprecate("Ember Simple Auth: The session service's events API is deprecated; to add custom behavior to the authentication or invalidation handling, override the handleAuthentication or handleInvalidation methods.", false, {
       id: 'ember-simple-auth.events.session-service',
-      until: '4.0.0'
+      until: '4.0.0',
+      for: 'ember-simple-auth',
+      since: {
+        enabled: '3.1.0'
+      }
     });
   }
 }


### PR DESCRIPTION
Add `for` and `since` options to `deprecate()` calls