### PR TITLE
Fixed 3 readonly tests.

### DIFF
--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -1,4 +1,4 @@
-import { alias, oneWay } from '@ember/object/computed';
+import { alias, readOnly } from '@ember/object/computed';
 import { A } from '@ember/array';
 import Service from '@ember/service';
 import Evented from '@ember/object/evented';
@@ -97,7 +97,7 @@ export default Service.extend(Evented, {
     @default false
     @public
   */
-  isAuthenticated: oneWay('session.isAuthenticated'),
+  isAuthenticated: readOnly('session.isAuthenticated'),
 
   /**
     The current session data as a plain object. The
@@ -114,7 +114,7 @@ export default Service.extend(Evented, {
     @default { authenticated: {} }
     @public
   */
-  data: oneWay('session.content'),
+  data: readOnly('session.content'),
 
   /**
     The session store.
@@ -125,7 +125,7 @@ export default Service.extend(Evented, {
     @default null
     @public
   */
-  store: oneWay('session.store'),
+  store: readOnly('session.store'),
 
   /**
     A previously attempted but intercepted transition (e.g. by the

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -100,7 +100,7 @@ describe('SessionService', () => {
     it('is read-only', function() {
       expect(() => {
         sessionService.set('isAuthenticated', false);
-      }).to.throw;
+      }).to.throw();
     });
   });
 
@@ -114,7 +114,7 @@ describe('SessionService', () => {
     it('is read-only', function() {
       expect(() => {
         sessionService.set('store', 'some other store');
-      }).to.throw;
+      }).to.throw();
     });
   });
 
@@ -154,7 +154,7 @@ describe('SessionService', () => {
     it('is read-only', function() {
       expect(() => {
         sessionService.set('data', false);
-      }).to.throw;
+      }).to.throw();
     });
   });
 


### PR DESCRIPTION
I have found bug in 3 unit tests.

```
expect(() => {
        sessionService.set('isAuthenticated', false);
      }).to.throw;
```
there should be 
```
}).to.throw();
```

These tests expect session.isAuthenticated, session.data and session.store to throw an error when set, so I have changed them from oneWay to readOnly.