### PR TITLE
Allow ember-release to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,13 @@ jobs:
             allow-failure: true
           - workspace: ember-simple-auth
             test-suite: "test:one ember-release"
-            allow-failure: false
+            allow-failure: true
           - workspace: test-app
             test-suite: "test:one ember-release"
-            allow-failure: false
+            allow-failure: true
           - workspace: classic-test-app
             test-suite: "test:one ember-release"
-            allow-failure: false
+            allow-failure: true
           - workspace: ember-simple-auth
             test-suite: "test:one ember-canary"
             allow-failure: true


### PR DESCRIPTION
CI is failing for ember-release because ember-release is ember version 4 (4.0.0-release+6efc59c9 ).
I have allowed ember-release to fail because ember-simple-auth does not support ember 4.