### PR TITLE
In some tests was thrown undefined.

### DIFF
--- a/packages/ember-simple-auth/tests/unit/internal-session-test.js
+++ b/packages/ember-simple-auth/tests/unit/internal-session-test.js
@@ -214,9 +214,11 @@ describe('InternalSession', () => {
       });
 
       it('is not authenticated', async function() {
-        await session.restore();
-
-        expect(session.get('isAuthenticated')).to.be.false;
+        try {
+          await session.restore();
+        } catch (_error) {
+          expect(session.get('isAuthenticated')).to.be.false;
+        }
       });
     });
 
@@ -226,9 +228,11 @@ describe('InternalSession', () => {
       });
 
       it('is not authenticated', async function() {
-        await session.restore();
-
-        expect(session.get('isAuthenticated')).to.be.false;
+        try {
+          await session.restore();
+        } catch (_error) {
+          expect(session.get('isAuthenticated')).to.be.false;
+        }
       });
     });
   });
@@ -355,9 +359,11 @@ describe('InternalSession', () => {
       });
 
       it('is not authenticated', async function() {
-        await session.authenticate('authenticator:test');
-
-        expect(session.get('isAuthenticated')).to.be.false;
+        try {
+          await session.authenticate('authenticator:test');
+        } catch (_error) {
+          expect(session.get('isAuthenticated')).to.be.false;
+        }
       });
     });
   });
@@ -565,9 +571,11 @@ describe('InternalSession', () => {
         sinon.spy(authenticator, 'restore');
         let restoration = session.restore();
         store.trigger('sessionDataUpdated', { some: 'other property', authenticated: { authenticator: 'authenticator:test' } });
-        await restoration;
-
-        expect(authenticator.restore).to.not.have.been.called;
+        try {
+          await restoration;
+        } catch (_error) {
+          expect(authenticator.restore).to.not.have.been.called;
+        }
       });
     });
 


### PR DESCRIPTION
In 4 tests was thrown undefined in async call. Test finished on that line without executing expect statement. It was expected that it would throw.
```
await session.restore();
expect(session.get('isAuthenticated')).to.be.false;
```

I have fixed it by moving expect statement into a catch block.

```
try {
          await session.restore();
} catch (_error) {
          expect(session.get('isAuthenticated')).to.be.false;
}
```