### PR TITLE
Fixed failing unit test - ember/object get function was removed from source code so I have changed unit test accordingly

### DIFF
--- a/packages/ember-simple-auth/tests/unit/authenticators/devise-test.js
+++ b/packages/ember-simple-auth/tests/unit/authenticators/devise-test.js
@@ -32,7 +32,7 @@ describe('DeviseAuthenticator', () => {
 
     describe('when the data contains a custom token and email attribute', function() {
       beforeEach(function() {
-        authenticator = Devise.extend({ tokenAttributeName: 'employee.token', identificationAttributeName: 'employee.email' }).create();
+        authenticator = Devise.extend({ resourceName: 'employee', tokenAttributeName: 'token', identificationAttributeName: 'email' }).create();
       });
 
       it('resolves with the correct data', async function() {


### PR DESCRIPTION
## Issue
I have fixed a unit test which was failing quietly

## Explanation
"get" function was used for getting tokenAttribute and identificationAttribute. So there could be used path to property like "employee.token"

```
const tokenAttribute = get(data, tokenAttributeName);
const identificationAttribute = get(data, identificationAttributeName);
```

it was changed 5 years ago with PR https://github.com/simplabs/ember-simple-auth/pull/957

```
_data[tokenAttributeName]
_data[identificationAttributeName]
```
After that change, only the property name could be used in tokenAttributeName. There was tokenAttributeName: 'employee.token' used in one test. So that test was failing. It was failing quietly because there was "throw undefined" which mocha does not catch.
I have fixed that test by using resourceName:'employee' and tokenAttributeName:'token' as required by code change.

```
authenticator = Devise.extend({ tokenAttributeName: 'employee.token', identificationAttributeName: 'employee.email' }).create();
```
```
authenticator = Devise.extend({ resourceName: 'employee', tokenAttributeName: 'token', identificationAttributeName: 'email' }).create();
```