### PR TITLE
Fixed quietly failing unit test because server returned nothing

### DIFF
--- a/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -381,6 +381,8 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
           'grant_type': 'refresh_token',
           'refresh_token': 'refresh token!'
         });
+
+        return [200, { 'Content-Type': 'application/json' }, '{}'];
       });
 
       await authenticator._refreshAccessToken(12345, 'refresh token!');


### PR DESCRIPTION
## Issue
I have fixed quietly failing unit test.

## Explanation
In that unit test is a fake server with no response. It caused the test to "throw undefined", which is not caught by mocha. I have fixed the test by returning success.

```
return [200, { 'Content-Type': 'application/json' }, '{}'];
```