### PR TITLE
Fixed failing unit test - invalidate call revoke endpoint twice. Unit test did not validate it correctly.

### DIFF
--- a/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
+++ b/packages/ember-simple-auth/tests/unit/authenticators/oauth2-password-grant-test.js
@@ -333,17 +333,23 @@ describe('OAuth2PasswordGrantAuthenticator', () => {
 
       describe('when a refresh token is set', function() {
         it('sends an AJAX request to invalidate the refresh token', async function() {
+          let refreshTokenValidated = false;
           server.post('/revoke', (request) => {
             let { requestBody } = request;
             let body = parsePostData(requestBody);
 
-            expect(body).to.eql({
-              'token_type_hint': 'refresh_token',
-              'token': 'refresh token!'
-            });
+            if (body.token_type_hint === 'refresh_token') {
+              expect(body).to.eql({
+                'token_type_hint': 'refresh_token',
+                'token': 'refresh token!'
+              });
+              refreshTokenValidated = true;
+            }
           });
 
           await authenticator.invalidate({ 'access_token': 'access token!', 'refresh_token': 'refresh token!' });
+
+          expect(refreshTokenValidated).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
## Issue
The unit test was testing the authenticator.invalidate method. It is calling revoke endpoint twice. One time revoke refresh_token and the second time revoke access_token. Unit test expected only one request for refresh_token. Call for revoke access_token was not expected and was failing quietly.

## Fix
When the fake revoke endpoint is called, only the refresh token is validated.