### PR TITLE
Remove use of `keys` and `merge` utils coming from `@ember/polyfills`

### DIFF
--- a/packages/ember-simple-auth/addon/authenticators/devise.js
+++ b/packages/ember-simple-auth/addon/authenticators/devise.js
@@ -1,11 +1,9 @@
 import { Promise } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { run } from '@ember/runloop';
-import { merge, assign as emberAssign } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
-
-const assign = emberAssign || merge;
 
 const JSON_CONTENT_TYPE = 'application/json';
 

--- a/packages/ember-simple-auth/addon/authenticators/devise.js
+++ b/packages/ember-simple-auth/addon/authenticators/devise.js
@@ -1,7 +1,7 @@
 import { Promise } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { run } from '@ember/runloop';
-import { assign } from '@ember/polyfills';
+import assign from 'ember-simple-auth/utils/assign';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
 

--- a/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
@@ -4,7 +4,7 @@ import { run, later, cancel } from '@ember/runloop';
 import { A, makeArray } from '@ember/array';
 import { warn } from '@ember/debug';
 import { getOwner } from '@ember/application';
-import { assign } from '@ember/polyfills';
+import assign from 'ember-simple-auth/utils/assign';
 import Ember from 'ember';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';

--- a/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
@@ -5,7 +5,6 @@ import { A, makeArray } from '@ember/array';
 import { warn } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import {
-  keys as emberKeys,
   merge,
   assign as emberAssign
 } from '@ember/polyfills';
@@ -15,7 +14,6 @@ import fetch from 'fetch';
 import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
 
 const assign = emberAssign || merge;
-const keys = Object.keys || emberKeys; // Ember.keys deprecated in 1.13
 
 /**
   Authenticator that conforms to OAuth 2
@@ -299,7 +297,7 @@ export default BaseAuthenticator.extend({
       data['client_id'] = this.get('clientId');
     }
 
-    const body = keys(data).map((key) => {
+    const body = Object.keys(data).map((key) => {
       return `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`;
     }).join('&');
 

--- a/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
@@ -4,16 +4,11 @@ import { run, later, cancel } from '@ember/runloop';
 import { A, makeArray } from '@ember/array';
 import { warn } from '@ember/debug';
 import { getOwner } from '@ember/application';
-import {
-  merge,
-  assign as emberAssign
-} from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import Ember from 'ember';
 import BaseAuthenticator from './base';
 import fetch from 'fetch';
 import isFastBoot from 'ember-simple-auth/utils/is-fastboot';
-
-const assign = emberAssign || merge;
 
 /**
   Authenticator that conforms to OAuth 2

--- a/packages/ember-simple-auth/addon/authenticators/torii.js
+++ b/packages/ember-simple-auth/addon/authenticators/torii.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import { assert, deprecate } from '@ember/debug';
 import { isPresent, isEmpty } from '@ember/utils';
-import { assign as emberAssign } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import BaseAuthenticator from './base';
 
 deprecate('Ember Simple Auth: The Torii authenticator is deprecated.', false, {
@@ -73,7 +73,7 @@ export default BaseAuthenticator.extend({
       return this.get('torii').fetch(data.provider, data).then(
         (fetchedData) => {
           this._authenticateWithProvider(provider, fetchedData);
-          return emberAssign(data, fetchedData);
+          return assign(data, fetchedData);
         },
         (err) => {
           delete this._provider;

--- a/packages/ember-simple-auth/addon/authenticators/torii.js
+++ b/packages/ember-simple-auth/addon/authenticators/torii.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import { assert, deprecate } from '@ember/debug';
 import { isPresent, isEmpty } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import assign from 'ember-simple-auth/utils/assign';
 import BaseAuthenticator from './base';
 
 deprecate('Ember Simple Auth: The Torii authenticator is deprecated.', false, {

--- a/packages/ember-simple-auth/addon/internal-session.js
+++ b/packages/ember-simple-auth/addon/internal-session.js
@@ -3,11 +3,10 @@ import RSVP from 'rsvp';
 import { isEmpty, isNone } from '@ember/utils';
 import ObjectProxy from '@ember/object/proxy';
 import Evented from '@ember/object/evented';
-import { merge, assign as emberAssign } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
 import { getOwner, setOwner } from '@ember/application';
-const assign = emberAssign || merge;
 
 export default ObjectProxy.extend(Evented, {
   authenticator:       null,

--- a/packages/ember-simple-auth/addon/internal-session.js
+++ b/packages/ember-simple-auth/addon/internal-session.js
@@ -3,7 +3,7 @@ import RSVP from 'rsvp';
 import { isEmpty, isNone } from '@ember/utils';
 import ObjectProxy from '@ember/object/proxy';
 import Evented from '@ember/object/evented';
-import { assign } from '@ember/polyfills';
+import assign from 'ember-simple-auth/utils/assign';
 import { set } from '@ember/object';
 import { debug, assert } from '@ember/debug';
 import { getOwner, setOwner } from '@ember/application';

--- a/packages/ember-simple-auth/addon/session-stores/cookie.js
+++ b/packages/ember-simple-auth/addon/session-stores/cookie.js
@@ -9,6 +9,7 @@ import { warn } from '@ember/debug';
 import Ember from 'ember';
 import BaseStore from './base';
 import objectsAreEqual from '../utils/objects-are-equal';
+import assign from 'ember-simple-auth/utils/assign';
 
 const persistingProperty = function(beforeSet = function() {}) {
   return computed({
@@ -180,7 +181,7 @@ export default BaseStore.extend({
   },
 
   _initialize(options) {
-    const clonedOptions = Object.assign({}, options);
+    const clonedOptions = assign({}, options);
     if (clonedOptions.cookieName) {
       this.set('_cookieName', clonedOptions.cookieName);
     }

--- a/packages/ember-simple-auth/addon/utils/assign.js
+++ b/packages/ember-simple-auth/addon/utils/assign.js
@@ -1,0 +1,3 @@
+import { assign } from '@ember/polyfills';
+
+export default Object.assign || assign;

--- a/packages/ember-simple-auth/tests/helpers/create-adaptive-store.js
+++ b/packages/ember-simple-auth/tests/helpers/create-adaptive-store.js
@@ -1,11 +1,12 @@
 import Adaptive from 'ember-simple-auth/session-stores/adaptive';
+import assign from 'ember-simple-auth/utils/assign';
 
 export default function createAdaptiveStore(
   cookiesService,
   options = {},
   owner
 ) {
-  owner.register('session-store:adaptive', Adaptive.extend(Object.assign({
+  owner.register('session-store:adaptive', Adaptive.extend(assign({
     _isLocalStorageAvailable: false,
   }, options)));
 

--- a/packages/ember-simple-auth/tests/helpers/start-app.js
+++ b/packages/ember-simple-auth/tests/helpers/start-app.js
@@ -1,12 +1,11 @@
 import Application from '../../app';
 import config from '../../config/environment';
-import { merge } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = merge({}, config.APP);
+  let attributes = Object.assign({}, config.APP);
   attributes.autoboot = true;
-  attributes = merge(attributes, attrs); // use defaults, but you can override;
+  attributes = Object.assign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);

--- a/packages/ember-simple-auth/tests/helpers/start-app.js
+++ b/packages/ember-simple-auth/tests/helpers/start-app.js
@@ -1,11 +1,12 @@
 import Application from '../../app';
 import config from '../../config/environment';
 import { run } from '@ember/runloop';
+import assign from 'ember-simple-auth/utils/assign';
 
 export default function startApp(attrs) {
-  let attributes = Object.assign({}, config.APP);
+  let attributes = assign({}, config.APP);
   attributes.autoboot = true;
-  attributes = Object.assign(attributes, attrs); // use defaults, but you can override;
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);

--- a/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/adaptive-test.js
@@ -6,6 +6,7 @@ import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import createAdaptiveStore from '../../helpers/create-adaptive-store';
+import assign from 'ember-simple-auth/utils/assign';
 
 module('AdaptiveStore', function(hooks) {
   setupTest(hooks);
@@ -56,7 +57,7 @@ module('AdaptiveStore', function(hooks) {
           let cookieService = owner.lookup('service:cookies');
           sinon.spy(cookieService, 'read');
           sinon.spy(cookieService, 'write');
-          let store = createAdaptiveStore(cookieService, Object.assign({
+          let store = createAdaptiveStore(cookieService, assign({
             _isLocalStorageAvailable: false,
             _cookieName: 'test:session',
           }, storeOptions), owner);

--- a/packages/ember-simple-auth/tests/unit/session-stores/cookie-test.js
+++ b/packages/ember-simple-auth/tests/unit/session-stores/cookie-test.js
@@ -4,6 +4,7 @@ import itBehavesLikeAStore from './shared/store-behavior';
 import itBehavesLikeACookieStore from './shared/cookie-store-behavior';
 import FakeCookieService from '../../helpers/fake-cookie-service';
 import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import assign from 'ember-simple-auth/utils/assign';
 
 module('CookieStore', function(hooks) {
   setupTest(hooks);
@@ -38,7 +39,7 @@ module('CookieStore', function(hooks) {
         let cookieService = owner.lookup('service:cookies');
         sinon.spy(cookieService, 'read');
         sinon.spy(cookieService, 'write');
-        owner.register('session-store:cookie', CookieStore.extend(Object.assign({
+        owner.register('session-store:cookie', CookieStore.extend(assign({
           _cookieName: 'test:session',
         }, storeOptions)));
         let store = owner.lookup('session-store:cookie');

--- a/packages/ember-simple-auth/tests/unit/utils/assign-test.js
+++ b/packages/ember-simple-auth/tests/unit/utils/assign-test.js
@@ -1,0 +1,10 @@
+import { module, test } from 'qunit';
+import assign from 'ember-simple-auth/utils/assign';
+
+module('Unit | Utility | assign', function() {
+  test('it works', function(assert) {
+    let result = assign({ foo: 'foo' }, { bar: 'bar' });
+
+    assert.deepEqual(result, { foo: 'foo', bar: 'bar' });
+  });
+});


### PR DESCRIPTION
- `keys` does not exist anymore
- `merge` was deprecated in v3 and removed in v4