### PR TITLE
Always assert the looked up authenticator

### DIFF
--- a/packages/ember-simple-auth/addon/internal-session.js
+++ b/packages/ember-simple-auth/addon/internal-session.js
@@ -32,7 +32,6 @@ export default ObjectProxy.extend(Evented, {
     this._busy = true;
     assert(`Session#authenticate requires the authenticator to be specified, was "${authenticatorFactory}"!`, !isEmpty(authenticatorFactory));
     const authenticator = this._lookupAuthenticator(authenticatorFactory);
-    assert(`No authenticator for factory "${authenticatorFactory}" could be found!`, !isNone(authenticator));
 
     return authenticator.authenticate(...args).then((content) => {
       this._busy = false;
@@ -203,6 +202,7 @@ export default ObjectProxy.extend(Evented, {
   _lookupAuthenticator(authenticatorName) {
     let owner = getOwner(this);
     let authenticator = owner.lookup(authenticatorName);
+    assert(`No authenticator for factory "${authenticatorName}" could be found!`, !isNone(authenticator));
     setOwner(authenticator, owner);
     return authenticator;
   }

--- a/packages/ember-simple-auth/tests/unit/internal-session-test.js
+++ b/packages/ember-simple-auth/tests/unit/internal-session-test.js
@@ -267,6 +267,12 @@ module('InternalSession', function(hooks) {
         sinon.stub(authenticator, 'authenticate').returns(RSVP.resolve({ some: 'property' }));
       });
 
+      test('it throws when the provided authenticator could not be found', function(assert) {
+        assert.throws(() => {
+          session.authenticate('authenticator:foo');
+        }, /No authenticator for factory "authenticator:foo" could be found!/);
+      });
+
       test('is authenticated', async function(assert) {
         await session.authenticate('authenticator:test');
 


### PR DESCRIPTION
Redo of #2336.

Instead of:

```
TypeError: Cannot set properties of undefined (setting '__OWNER__ember16431396598451637272055234__')
```

This will throw:

```
Error: Assertion Failed: No authenticator for factory "authenticator:foo" could be found!
```

Which should be clearer to the user what went wrong. This will be the case everywhere were `_lookupAuthenticator` is called.