### PR TITLE
Prevent UnhandledPromiseError when restoring the session

### DIFF
--- a/packages/ember-simple-auth/addon/services/session.js
+++ b/packages/ember-simple-auth/addon/services/session.js
@@ -391,13 +391,12 @@ export default Service.extend(Evented, {
     @method setup
     @public
   */
-  async setup() {
+  setup() {
     this._setupIsCalled = true;
-    try {
-      this._setupHandlers();
-      await this.session.restore();
-    } catch (error) {
+    this._setupHandlers();
+
+    return this.session.restore().catch(() => {
       // If it raises an error then it means that restore didn't find any restorable state.
-    }
+    });
   },
 });

--- a/packages/ember-simple-auth/tests/unit/services/session-test.js
+++ b/packages/ember-simple-auth/tests/unit/services/session-test.js
@@ -8,6 +8,7 @@ import { registerDeprecationHandler } from '@ember/debug';
 import sinonjs from 'sinon';
 import * as LocationUtil from 'ember-simple-auth/utils/location';
 import Configuration from 'ember-simple-auth/configuration';
+import RSVP from 'rsvp';
 
 module('SessionService', function(hooks) {
   setupTest(hooks);
@@ -558,7 +559,7 @@ module('SessionService', function(hooks) {
     test("doesn't raise an error when restore rejects", async function(assert) {
       assert.expect(1);
       sinon.stub(sessionService, '_setupHandlers');
-      sinon.stub(session, 'restore').throws(new Error());
+      sinon.stub(session, 'restore').returns(RSVP.reject());
 
       try {
         await sessionService.setup();


### PR DESCRIPTION
It's possible for an `UnhandledPromiseError` to raise in the background when restoring the session. This doesn't raise to the caller of the library but does occur as a caught exception in the browser, which in turn can be picked up by error tracking code such as sentry.

This fixes #2358 which has more specific detail around the issue and how to reproduce it.