### PR TITLE
Use Volta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,18 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          cache: yarn
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install
@@ -88,7 +99,18 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          cache: yarn
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install
@@ -113,7 +135,18 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          cache: yarn
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install --no-lockfile
@@ -131,7 +164,18 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          cache: yarn
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
+      - uses: volta-cli/action@v1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -96,9 +94,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
+      - uses: volta-cli/action@v1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -132,9 +128,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
+      - uses: volta-cli/action@v1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -161,9 +155,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
+      - uses: volta-cli/action@v1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "release-it-lerna-changelog": "^4.0.0",
     "release-it-yarn-workspaces": "^2.0.0"
   },
-  "version": "4.2.2"
+  "version": "4.2.2",
+  "volta": {
+    "node": "14.19.3",
+    "yarn": "1.22.18"
+  }
 }


### PR DESCRIPTION
This pins the Node and Yarn versions we use using [Volta](http://volta.sh).

Since The Volta GitHub action doesn't support the `cache: yarn` argument that the setup-node action supports we need to revert to using the cache action manually on CI. Overall I think this is still beneficial though.