### PR TITLE
Update the oauth2 password grant to support client_secret

### DIFF
--- a/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
+++ b/packages/ember-simple-auth/addon/authenticators/oauth2-password-grant.js
@@ -46,6 +46,19 @@ export default BaseAuthenticator.extend({
     @public
   */
   clientId: null,
+  
+    /**
+    The client_secret to be sent to the authentication server (see
+    https://tools.ietf.org/html/rfc6749#appendix-A.2). __This should only be
+    used for statistics or logging etc. as it cannot actually be trusted since
+    it could have been manipulated on the client!__
+
+    @property clientSecret
+    @type String
+    @default null
+    @public
+  */
+  clientSecret: null,
 
   /**
     The endpoint on the server that authentication and token refresh requests
@@ -290,6 +303,11 @@ export default BaseAuthenticator.extend({
     const clientId = this.get('clientId');
     if (!isEmpty(clientId)) {
       data['client_id'] = this.get('clientId');
+    }
+    
+    const clientSecret = this.get('clientSecret');
+    if (!isEmpty(clientSecret)) {
+      data['client_secret'] = this.get('clientSecret');
     }
 
     const body = Object.keys(data).map((key) => {


### PR DESCRIPTION
Earlier version of ESA supported passing the `client_id` and the `client_secret` values [in the header](https://github.com/simplabs/ember-simple-auth/blob/1815e03a6ed3c5f05f27153a2f1c927014db1ffc/addon/authenticators/oauth2-password-grant.js#L130). More recently this feature was changed to pass `client_id` in the request body, but in the process support for passing in a `client_secret` was removed entirely.

The OAuth server I use does not support generating a `client_id` without a `client_secret`, so this breaks my login flow unless I implement a custom client parser.

[The spec](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) suggests that the recommended way to accomplish this would be to pass both in the `Authorization` header as it was done before, but in the absence of the header it would be great to have the ability to pass in a `client_secret` value directly. 

Alternatively, the spec dictates that the server must accept the `HTTP Basic authentication scheme`, so it may be easier to simply add a `clientHeader` value instead. 