### PR TITLE
fix(renovate.json): use proper path for .json5 preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>simplabs/renovate-config"]
+  "extends": ["github>simplabs/renovate-config:default.json5"]
 }


### PR DESCRIPTION
# Description
Use proper path for Renovate preset with `.json5` extension.

## Context
https://github.com/renovatebot/renovate/pull/15377/files#diff-3d9467eb14d298becd6f4618c5e6003b34060fedcc24d26441bbc3ba5db79c7f

Fixes #2432 