### PR TITLE
docs: add information about v4 release for embroider and typescript users

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ authorization mechanisms__.
 
 * [Managing a current User](guides/managing-current-user.md)
 * [GitHub authorization with torii](guides/auth-torii-with-github.md)
+* [Upgrading to v4](guides/upgrade-to-v4.md)
+* [Upgrading to v3](guides/upgrade-to-v3.md)
 
 **Other Resources**
 
@@ -106,9 +108,17 @@ ember install ember-simple-auth
 ```
 
 ### Upgrading from a pre-3.0 release?
+
 The 3.0 release of ember-simple-auth removes previously deprecated code,
 introducing some breaking changes, but thankfully there is an
-[upgrade guide](guides/upgrade-to-v3.md).
+[v3 upgrade guide](guides/upgrade-to-v3.md).
+
+### Upgrading to 4.0 release?
+
+The 4.1 release introduced a `session#setup` that fixes build issues for `typescript` and `embroider` users,
+due to ESA using initializers. Consult with the guide in order to fix them
+as well as prepare yourself for v5 release which will make it **required**.
+[v4 upgrade guide](guides/upgrade-to-v4.md).
 
 ## Walkthrough
 
@@ -686,6 +696,8 @@ If you're an `ember-mocha` user, we can recommend to check out this
 ## Other guides
 
 * [Managing current User](guides/managing-current-user.md)
+* [Upgrading to v4](guides/upgrade-to-v4.md)
+* [Upgrading to v3](guides/upgrade-to-v3.md)
 
 ## License
 


### PR DESCRIPTION
- adds links to v3, v4 guides.
- adds info about possible typescript and embroider issues due to ESA using initializers and shipping the application.js route.
- attempts to make the guides more discoverable for people looking for help with `typescript` or `embroider` issues e.g #2433 #2279 