### PR TITLE
session.setup must be guarded to avoid double calling

### DIFF
--- a/packages/ember-simple-auth/src/services/session.ts
+++ b/packages/ember-simple-auth/src/services/session.ts
@@ -334,11 +334,13 @@ export default class SessionService<Data = DefaultDataShape> extends Service {
     @public
   */
   setup() {
-    this._setupIsCalled = true;
-    this._setupHandlers();
-
-    return this.session.restore().catch(() => {
-      // If it raises an error then it means that restore didn't find any restorable state.
-    });
+    if(!this._setupIsCalled) {
+      this._setupIsCalled = true;
+      this._setupHandlers();
+  
+      return this.session.restore().catch(() => {
+        // If it raises an error then it means that restore didn't find any restorable state.
+      });
+    }
   }
 }


### PR DESCRIPTION
If you call setup twice, multiple event listeners are added: `authenticationSucceeded` `invalidationSucceeded`

This could happen easily if you place the setup call on any beforeModel, say application route beforeModel, without manual guarding. Any transition that happens in between while executing the beforeModel aborts the transition and triggers a new one, which causes the beforeModel to be triggered again, thus calling setup again. This prob should be guarded from within the lib.

As a work around we extended the service with:

```ts
async safeSetup() {
    if (!this._setupIsCalled) {
      return this.setup();
    }
  }
```