### PR TITLE
chore: remove responseText, responseJSON deprecation

### DIFF
--- a/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.ts
+++ b/packages/ember-simple-auth/src/authenticators/oauth2-password-grant.ts
@@ -45,13 +45,7 @@ export type MakeRequestData =
   | OAuthRefreshRequestData;
 
 export interface OAuth2Response extends Response {
-  /**
-   * @deprecated 'responseText' is deprecated. This is a legacy AJAX API.
-   */
   responseText: string;
-  /**
-   * @deprecated 'responseJSON' is deprecated. This is a legacy AJAX API.
-   */
   responseJSON: string;
 }
 


### PR DESCRIPTION
Deprecating `responseText` and `responseJSON` was a misjudgement on my part at the time.
The API stands out still but is ultimately not a real problem.

There's not great way to create a gradual transition path for users and there's no reason to cause a disturbance and drop these properties.

closes  #2922, #2923