### PR TITLE
feat: redirectTarget, use cookie store configuration to set the cookie.

### DIFF
--- a/packages/ember-simple-auth/src/session-stores/cookie.ts
+++ b/packages/ember-simple-auth/src/session-stores/cookie.ts
@@ -370,10 +370,14 @@ export default class CookieStore extends BaseStore {
   }
 
   setRedirectTarget(url: string) {
-    this.get('_cookies').write(`${this.cookieName}-redirectTarget`, url, {
-      path: '/',
+    let cookieOptions = {
+      domain: this.get('cookieDomain'),
+      path: this.get('cookiePath'),
       secure: this._secureCookies(),
-    });
+      sameSite: this.get('sameSite'),
+      partitioned: this.get('partitioned'),
+    } as WriteOptions;
+    this.get('_cookies').write(`${this.cookieName}-redirectTarget`, url, cookieOptions);
   }
 
   getRedirectTarget() {

--- a/packages/test-esa/tests/unit/services/session-test.js
+++ b/packages/test-esa/tests/unit/services/session-test.js
@@ -244,7 +244,10 @@ module('SessionService', function (hooks) {
 
           assert.ok(
             writeCookieStub.calledWith(cookieName, transition.intent.url, {
+              domain: null,
+              partitioned: null,
               path: '/',
+              sameSite: null,
               secure: true,
             })
           );
@@ -256,7 +259,10 @@ module('SessionService', function (hooks) {
 
           assert.ok(
             writeCookieStub.calledWith(cookieName, redirectTarget, {
+              domain: null,
+              partitioned: null,
               path: '/',
+              sameSite: null,
               secure: true,
             })
           );


### PR DESCRIPTION
- Configures the `redirectTarget` cookie write to use settings from the store.