### PR TITLE
Fix FastBoot check in LocalStorageStore always returning false

### DIFF
--- a/packages/ember-simple-auth/src/session-stores/local-storage.ts
+++ b/packages/ember-simple-auth/src/session-stores/local-storage.ts
@@ -40,9 +40,7 @@ export default class LocalStorageStore extends BaseStore {
   constructor(owner: any) {
     super(owner);
 
-    this._isFastBoot = this.hasOwnProperty('_isFastBoot')
-      ? this._isFastBoot
-      : isFastBoot(getOwner(this));
+    this._isFastBoot = isFastBoot(getOwner(this));
     if (!this.get('_isFastBoot')) {
       window.addEventListener('storage', this._handleStorageEvent);
     }


### PR DESCRIPTION
Currently the FastBoot check in LocalStorageStore always returns `false` because `_isFastBoot` is initialised to false and then this value is always used because `hasOwnProperty()` returns true, so the `isFastBoot()` check is never executed.

This is a bug from conversion to class syntax and typescript.