### PR TITLE
Relax sessionData Record type from string to any

### DIFF
--- a/packages/ember-simple-auth/src/test-support/index.ts
+++ b/packages/ember-simple-auth/src/test-support/index.ts
@@ -20,7 +20,7 @@ function ensureAuthenticator(owner: any) {
  * @return {Promise}
  * @public
  */
-export async function authenticateSession(sessionData: Record<string, string>) {
+export async function authenticateSession(sessionData: Record<string, any>) {
   const { owner } = getContext() as { owner: any };
   const session = owner.lookup(SESSION_SERVICE_KEY);
   ensureAuthenticator(owner);


### PR DESCRIPTION
Hey folks, appreciate the ongoing maintenance work you've been doing. I'm helping migrate an older Ember app up to the latest version of things and just recently bumped from v6 -> v8 here. As part of that, we're trashing internally maintained types in favor of yours and hit some type issues here. Looking at the underlying code, the type used seems more restrictive than expected, thoughts?

Fwiw, passing an object as described in the doc block above the method here **does** work as all our tests are passing. So **think** this should be ok to relax?