### PR TITLE
Remove `@embroider/macros` from `dependencies`

### DIFF
--- a/packages/ember-simple-auth/package.json
+++ b/packages/ember-simple-auth/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@ember/test-waiters": "^3 || ^4",
     "@embroider/addon-shim": "^1.0.0",
-    "@embroider/macros": "^1.0.0",
     "ember-cookies": "^1.4.1"
   },
   "devDependencies": {
@@ -41,6 +40,7 @@
     "@babel/plugin-proposal-decorators": "7.28.6",
     "@babel/runtime": "7.28.6",
     "@embroider/addon-dev": "7.1.6",
+    "@embroider/macros": "^1.0.0",
     "@glint/core": "1.5.2",
     "@glint/environment-ember-loose": "1.5.2",
     "@glint/environment-ember-template-imports": "1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.0.0
         version: 1.10.2
-      '@embroider/macros':
-        specifier: ^1.0.0
-        version: 1.19.6(@glint/template@1.7.7)
       ember-cookies:
         specifier: ^1.4.1
         version: 1.4.1(ember-source@6.8.1(@glimmer/component@2.0.0)(rsvp@4.8.5))
@@ -114,6 +111,9 @@ importers:
       '@embroider/addon-dev':
         specifier: 7.1.6
         version: 7.1.6(@glint/template@1.7.7)(rollup@4.53.3)
+      '@embroider/macros':
+        specifier: ^1.0.0
+        version: 1.19.6(@glint/template@1.7.7)
       '@glint/core':
         specifier: 1.5.2
         version: 1.5.2(typescript@5.9.3)


### PR DESCRIPTION
macros is an external as it is a build time behavior controlled by the consumer

also we don't want macros to show up in optimized deps